### PR TITLE
Fix vulkaninfo on win32 to use existing console

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -87,11 +87,7 @@ if(WIN32)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
 endif()
 
-if(UNIX)
-    add_executable(vulkaninfo vulkaninfo.c)
-else()
-    add_executable(vulkaninfo WIN32 vulkaninfo.c)
-endif()
+add_executable(vulkaninfo vulkaninfo.c)
 target_link_libraries(vulkaninfo ${LIBRARIES})
 
 if(UNIX)


### PR DESCRIPTION
The vulkaninfo utility is compiled as /SUBSYSTEM:APPLICATION but
attempts to allocate its own console and print to it. Not only
does this appear to be unreliable (sometimes no output is printed),
it is unnecessary if the utility is compiled as /SUBSYSTEM:CONSOLE.

This removes unnecessary console manipulation code. By using
/SUBSYSTEM:CONSOLE, the ordinary main() entrypoint function can be
used.

The console is still enlarged if it was opened exclusively for the
process by detecting whether it was so opened. Likewise, the process
still sleeps forever if the console is exclusive to the process.
The process behaves like a normal command line process when executed
from the command line.

IMPORTANT: I don't know how you generate the .vcxproj files included
in the SDK, as I can't find them here, but you need to change them
from /SUBSYSTEM:APPLICATION to /SUBSYSTEM:CONSOLE in line with this
change.

Fixes lunarg issue 350.