### PR TITLE
Fix wayland support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
     set(DisplayServer Android)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     #   TODO: Basic support is present for Xlib but is untested.
-    #         Wayland/Mir support is stubbed in but unimplemented and untested.
+    #         Mir support is stubbed in but unimplemented and untested.
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" OFF)
     option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,21 +19,30 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Android")
     add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
     set(DisplayServer Android)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
+    #   TODO: Basic support is present for Xlib but is untested.
+    #         Wayland/Mir support is stubbed in but unimplemented and untested.
+    option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
+    option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" OFF)
+    option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" OFF)
+    option(BUILD_WSI_MIR_SUPPORT "Build Mir WSI support" OFF)
+
     set(DisplayServer Xcb)
 
-#   TODO: Basic support is present for Xlib but is untested.
-#         Wayland/Mir support is stubbed in but unimplemented and untested.
+    if (BUILD_WSI_XCB_SUPPORT)
+        add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
+    endif()
 
-#   add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
-#   set(DisplayServer Xlib)
+    if (BUILD_WSI_XLIB_SUPPORT)
+        add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
+    endif()
 
-#   add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
-#   set(DisplayServer Mir)
+    if (BUILD_WSI_WAYLAND_SUPPORT)
+        add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
+    endif()
 
-#   add_definitions(-DVK_USEPLATFORM_WAYLAND_KHR)
-#   set(DisplayServer Wayland)
-
+    if (BUILD_WSI_MIR_SUPPORT)
+        add_definitions(-DVK_USE_PLATFORM_MIR_KHR)
+    endif()
 else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()

--- a/layers/swapchain.cpp
+++ b/layers/swapchain.cpp
@@ -222,6 +222,7 @@ createInstanceRegisterExtensions(const VkInstanceCreateInfo *pCreateInfo,
 
             my_data->instanceMap[instance].androidSurfaceExtensionEnabled =
                 true;
+        }
 #endif // VK_USE_PLATFORM_ANDROID_KHR
 #ifdef VK_USE_PLATFORM_MIR_KHR
             if (strcmp(pCreateInfo->ppEnabledExtensionNames[i],
@@ -229,6 +230,7 @@ createInstanceRegisterExtensions(const VkInstanceCreateInfo *pCreateInfo,
 
                 my_data->instanceMap[instance].mirSurfaceExtensionEnabled =
                     true;
+            }
 #endif // VK_USE_PLATFORM_MIR_KHR
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
                 if (strcmp(pCreateInfo->ppEnabledExtensionNames[i],
@@ -236,6 +238,7 @@ createInstanceRegisterExtensions(const VkInstanceCreateInfo *pCreateInfo,
 
                     my_data->instanceMap[instance]
                         .waylandSurfaceExtensionEnabled = true;
+                }
 #endif // VK_USE_PLATFORM_WAYLAND_KHR
 #ifdef VK_USE_PLATFORM_WIN32_KHR
                     if (strcmp(pCreateInfo->ppEnabledExtensionNames[i],
@@ -243,6 +246,7 @@ createInstanceRegisterExtensions(const VkInstanceCreateInfo *pCreateInfo,
 
                         my_data->instanceMap[instance]
                             .win32SurfaceExtensionEnabled = true;
+                    }
 #endif // VK_USE_PLATFORM_WIN32_KHR
 #ifdef VK_USE_PLATFORM_XCB_KHR
                         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i],
@@ -250,6 +254,7 @@ createInstanceRegisterExtensions(const VkInstanceCreateInfo *pCreateInfo,
 
                             my_data->instanceMap[instance]
                                 .xcbSurfaceExtensionEnabled = true;
+                        }
 #endif // VK_USE_PLATFORM_XCB_KHR
 #ifdef VK_USE_PLATFORM_XLIB_KHR
                             if (strcmp(pCreateInfo->ppEnabledExtensionNames[i],
@@ -258,8 +263,8 @@ createInstanceRegisterExtensions(const VkInstanceCreateInfo *pCreateInfo,
 
                                 my_data->instanceMap[instance]
                                     .xlibSurfaceExtensionEnabled = true;
-#endif // VK_USE_PLATFORM_XLIB_KHR
                             }
+#endif // VK_USE_PLATFORM_XLIB_KHR
                         }
                     }
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1386,6 +1386,9 @@ static bool loader_icd_init_entrys(struct loader_icd *icd, VkInstance inst,
 #ifdef VK_USE_PLATFORM_XCB_KHR
     LOOKUP_GIPA(GetPhysicalDeviceXcbPresentationSupportKHR, false);
 #endif
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    LOOKUP_GIPA(GetPhysicalDeviceWaylandPresentationSupportKHR, false);
+#endif
 
 #undef LOOKUP_GIPA
 

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -623,7 +623,7 @@ loader_GetPhysicalDeviceMirPresentationSupportKHR(
  */
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
 vkCreateWaylandSurfaceKHR(VkInstance instance,
-                          const VkMirSurfaceCreateInfoKHR *pCreateInfo,
+                          const VkWaylandSurfaceCreateInfoKHR *pCreateInfo,
                           const VkAllocationCallbacks *pAllocator,
                           VkSurfaceKHR *pSurface) {
     const VkLayerInstanceDispatchTable *disp;
@@ -641,7 +641,7 @@ vkCreateWaylandSurfaceKHR(VkInstance instance,
  */
 VKAPI_ATTR VkResult VKAPI_CALL
 loader_CreateWaylandSurfaceKHR(VkInstance instance,
-                               const VkMirSurfaceCreateInfoKHR *pCreateInfo,
+                               const VkWaylandSurfaceCreateInfoKHR *pCreateInfo,
                                const VkAllocationCallbacks *pAllocator,
                                VkSurfaceKHR *pSurface) {
     struct loader_instance *ptr_instance = loader_get_instance(instance);
@@ -1021,6 +1021,7 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *ptr_instance,
                     ? (void *)vkGetPhysicalDeviceMirPresentationSupportKHR
                     : NULL;
         return true;
+    }
 #endif // VK_USE_PLATFORM_MIR_KHR
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
         /*
@@ -1038,6 +1039,7 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *ptr_instance,
                     ? (void *)vkGetPhysicalDeviceWaylandPresentationSupportKHR
                     : NULL;
             return true;
+        }
 #endif // VK_USE_PLATFORM_WAYLAND_KHR
 #ifdef VK_USE_PLATFORM_XCB_KHR
             /*


### PR DESCRIPTION
This little series gets Wayland support working with the loader.  The first commit makes all of the different WSI platforms configurable.  We should, perhaps, consider autodetection on Linux via pkg-config, but that can come later.