### PR TITLE
layers: Add component awareness to SC interface matching

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5146,7 +5146,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvidedInBlock) {
 
 TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Type mismatch on location 0: 'ptr to "
+                                         "Type mismatch on location 0.0: 'ptr to "
                                          "output arr[2] of float32' vs 'ptr to "
                                          "input arr[3] of float32'");
 
@@ -5193,7 +5193,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
 
     if (!m_errorMonitor->DesiredMsgFound()) {
         m_errorMonitor->DumpFailureMsgs();
-        FAIL() << "Did not receive Error 'Type mismatch on location 0: 'ptr to "
+        FAIL() << "Did not receive Error 'Type mismatch on location 0.0: 'ptr to "
                   "output arr[2] of float32' vs 'ptr to input arr[3] of "
                   "float32''";
     }
@@ -5296,8 +5296,110 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatchInBlock) {
     pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
 
     if (!m_errorMonitor->DesiredMsgFound()) {
-        FAIL() << "Did not receive Error 'Type mismatch on location 0'";
         m_errorMonitor->DumpFailureMsgs();
+        FAIL() << "Did not receive Error 'Type mismatch on location 0'";
+    }
+}
+
+TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByLocation) {
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                         "location 0.0 which is not written by vertex shader");
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    char const *vsSource =
+        "#version 450\n"
+        "#extension GL_ARB_separate_shader_objects: require\n"
+        "#extension GL_ARB_shading_language_420pack: require\n"
+        "\n"
+        "out block { layout(location=1) float x; } outs;\n"
+        "out gl_PerVertex {\n"
+        "    vec4 gl_Position;\n"
+        "};\n"
+        "void main(){\n"
+        "   outs.x = 0;\n"
+        "   gl_Position = vec4(1);\n"
+        "}\n";
+    char const *fsSource =
+        "#version 450\n"
+        "#extension GL_ARB_separate_shader_objects: require\n"
+        "#extension GL_ARB_shading_language_420pack: require\n"
+        "\n"
+        "in block { layout(location=0) float x; } ins;\n"
+        "layout(location=0) out vec4 color;\n"
+        "void main(){\n"
+        "   color = vec4(ins.x);\n"
+        "}\n";
+
+    VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+    VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+    VkPipelineObj pipe(m_device);
+    pipe.AddColorAttachment();
+    pipe.AddShader(&vs);
+    pipe.AddShader(&fs);
+
+    VkDescriptorSetObj descriptorSet(m_device);
+    descriptorSet.AppendDummy();
+    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+    if (!m_errorMonitor->DesiredMsgFound()) {
+        m_errorMonitor->DumpFailureMsgs();
+        FAIL() << "Did not receive Error 'location 0.0 which is not written by vertex shader'";
+    }
+}
+
+TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByComponent) {
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                                         "location 0.1 which is not written by vertex shader");
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    char const *vsSource =
+        "#version 450\n"
+        "#extension GL_ARB_separate_shader_objects: require\n"
+        "#extension GL_ARB_shading_language_420pack: require\n"
+        "\n"
+        "out block { layout(location=0, component=0) float x; } outs;\n"
+        "out gl_PerVertex {\n"
+        "    vec4 gl_Position;\n"
+        "};\n"
+        "void main(){\n"
+        "   outs.x = 0;\n"
+        "   gl_Position = vec4(1);\n"
+        "}\n";
+    char const *fsSource =
+        "#version 450\n"
+        "#extension GL_ARB_separate_shader_objects: require\n"
+        "#extension GL_ARB_shading_language_420pack: require\n"
+        "\n"
+        "in block { layout(location=0, component=1) float x; } ins;\n"
+        "layout(location=0) out vec4 color;\n"
+        "void main(){\n"
+        "   color = vec4(ins.x);\n"
+        "}\n";
+
+    VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+    VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+    VkPipelineObj pipe(m_device);
+    pipe.AddColorAttachment();
+    pipe.AddShader(&vs);
+    pipe.AddShader(&fs);
+
+    VkDescriptorSetObj descriptorSet(m_device);
+    descriptorSet.AppendDummy();
+    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+    if (!m_errorMonitor->DesiredMsgFound()) {
+        m_errorMonitor->DumpFailureMsgs();
+        FAIL() << "Did not receive Error 'location 0.1 which is not written by vertex shader'";
     }
 }
 


### PR DESCRIPTION
- Adds more tests for mismatch by component and by location
- Removes dead handling of builtins (we only care about collecting builtin /decorations/ to aid in the interface block handling;
    we don't really care about producing the set of builtins used overall.)

Some SC error messages change slightly, as interstage locations now include the component index.

Fixes internal bug 26609754

V2: Remove dead code

(This patch is already on the android-* branch, but the issue it addresses is present on master too)