### PR TITLE
[For Review] GL207, validate queue family index

### DIFF
--- a/layers/draw_state.cpp
+++ b/layers/draw_state.cpp
@@ -4570,10 +4570,34 @@ VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyRenderPass(VkDevice device, 
     // TODO : Clean up any internal data structures using this obj.
 }
 
+VkBool32 validate_queue_family_indices(layer_data* dev_data, const char *function_name, const uint32_t count, const uint32_t* indices) {
+    VkBool32 skipCall = VK_FALSE;
+    for (auto i = 0; i < count; i++) {
+        if (indices[i] >= dev_data->physDevProperties.queue_family_properties.size()) {
+            skipCall |=
+                log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                    (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
+                    DRAWSTATE_INVALID_QUEUE_INDEX, "DS",
+                    "%s has QueueFamilyIndex greater than the number of QueueFamilies ("
+                    PRINTF_SIZE_T_SPECIFIER ") for this device.",
+                    function_name,
+                    dev_data->physDevProperties.queue_family_properties.size());
+        }
+    }
+    return skipCall;
+}
+
+
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer)
 {
+    VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
     layer_data* dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
-    VkResult result = dev_data->device_dispatch_table->CreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
+    bool skipCall = validate_queue_family_indices(dev_data, "vkCreateBuffer",
+        pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices);
+    if (!skipCall) {
+        result = dev_data->device_dispatch_table->CreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
+    }
+
     if (VK_SUCCESS == result) {
         loader_platform_thread_lock_mutex(&globalLock);
         // TODO : This doesn't create deep copy of pQueueFamilyIndices so need to fix that if/when we want that data to be valid
@@ -4598,8 +4622,14 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateBufferView(VkDevice devic
 
 VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkImage* pImage)
 {
+    VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
     layer_data* dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
-    VkResult result = dev_data->device_dispatch_table->CreateImage(device, pCreateInfo, pAllocator, pImage);
+    bool skipCall = validate_queue_family_indices(dev_data, "vkCreateImage",
+        pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices);
+    if (!skipCall) {
+        result = dev_data->device_dispatch_table->CreateImage(device, pCreateInfo, pAllocator, pImage);
+    }
+
     if (VK_SUCCESS == result) {
         IMAGE_NODE image_node;
         image_node.layout = pCreateInfo->initialLayout;
@@ -4607,7 +4637,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateImage(VkDevice device, co
         loader_platform_thread_lock_mutex(&globalLock);
         dev_data->imageMap[*pImage] = unique_ptr<VkImageCreateInfo>(new VkImageCreateInfo(*pCreateInfo));
         ImageSubresourcePair subpair = {*pImage, false, VkImageSubresource()};
-        dev_data->imageSubresourceMap[*pImage].push_back(subpair); 
+        dev_data->imageSubresourceMap[*pImage].push_back(subpair);
         dev_data->imageLayoutMap[subpair] = image_node;
         loader_platform_thread_unlock_mutex(&globalLock);
     }
@@ -6305,6 +6335,23 @@ VkBool32 ValidateBarriers(VkCommandBuffer cmdBuffer, uint32_t memBarrierCount,
     }
     for (uint32_t i = 0; i < imageMemBarrierCount; ++i) {
         auto mem_barrier = &pImageMemBarriers[i];
+
+        // Validate image barrier queue family indices
+        if ((mem_barrier->srcQueueFamilyIndex >=
+             dev_data->physDevProperties.queue_family_properties.size()) ||
+            (mem_barrier->dstQueueFamilyIndex >=
+             dev_data->physDevProperties.queue_family_properties.size())) {
+            skip_call |=
+                log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                    (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
+                    DRAWSTATE_INVALID_QUEUE_INDEX, "DS",
+                    "Image Barrier 0x%" PRIx64 " has QueueFamilyIndex greater "
+                    "than the number of QueueFamilies (" PRINTF_SIZE_T_SPECIFIER
+                    ") for this device.",
+                    reinterpret_cast<const uint64_t &>(mem_barrier->image),
+                    dev_data->physDevProperties.queue_family_properties.size());
+        }
+
         if (pCB->activeRenderPass) {
             skip_call |=
                 log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
@@ -6328,6 +6375,23 @@ VkBool32 ValidateBarriers(VkCommandBuffer cmdBuffer, uint32_t memBarrierCount,
         }
         if (!mem_barrier)
             continue;
+
+        // Validate buffer barrier queue family indices
+        if ((mem_barrier->srcQueueFamilyIndex >=
+             dev_data->physDevProperties.queue_family_properties.size()) ||
+            (mem_barrier->dstQueueFamilyIndex >=
+             dev_data->physDevProperties.queue_family_properties.size())) {
+            skip_call |=
+                log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                    (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
+                    DRAWSTATE_INVALID_QUEUE_INDEX, "DS",
+                    "Buffer Barrier 0x%" PRIx64 " has QueueFamilyIndex greater "
+                    "than the number of QueueFamilies (" PRINTF_SIZE_T_SPECIFIER
+                    ") for this device.",
+                    reinterpret_cast<const uint64_t &>(mem_barrier->buffer),
+                    dev_data->physDevProperties.queue_family_properties.size());
+        }
+
         auto buffer_data = dev_data->bufferMap.find(mem_barrier->buffer);
         uint64_t buffer_size = buffer_data->second.create_info
                                    ? reinterpret_cast<uint64_t &>(

--- a/layers/draw_state.h
+++ b/layers/draw_state.h
@@ -193,6 +193,8 @@ typedef enum _DRAW_STATE_ERROR {
                                              // violate device limit
     DRAWSTATE_INVALID_STORAGE_BUFFER_OFFSET, // Dynamic Storage Buffer Offsets
                                              // violate device limit
+    DRAWSTATE_INVALID_QUEUE_INDEX,           // Specified queue index exceeds number
+                                             // of queried queue families
 } DRAW_STATE_ERROR;
 
 typedef enum _SHADER_CHECKER_ERROR {

--- a/layers/swapchain.cpp
+++ b/layers/swapchain.cpp
@@ -1559,6 +1559,21 @@ static VkBool32 validateCreateSwapchainKHR(
     // Keep around a useful pointer to pPhysicalDevice:
     SwpPhysicalDevice *pPhysicalDevice = pDevice->pPhysicalDevice;
 
+    // Validate pCreateInfo values with result of
+    // vkGetPhysicalDeviceQueueFamilyProperties
+    if (pPhysicalDevice && pPhysicalDevice->gotQueueFamilyPropertyCount) {
+        for (auto i = 0; i < pCreateInfo->queueFamilyIndexCount; i++) {
+            if (pCreateInfo->pQueueFamilyIndices[i] >=
+                pPhysicalDevice->numOfQueueFamilies) {
+                skipCall |= LOG_ERROR_QUEUE_FAMILY_INDEX_TOO_LARGE(
+                    VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
+                    pPhysicalDevice, "VkPhysicalDevice",
+                    pCreateInfo->pQueueFamilyIndices[i],
+                    pPhysicalDevice->numOfQueueFamilies);
+            }
+        }
+    }
+
     // Validate pCreateInfo values with the results of
     // vkGetPhysicalDeviceSurfaceCapabilitiesKHR():
     if (!pPhysicalDevice || !pPhysicalDevice->gotSurfaceCapabilities) {

--- a/layers/vk_validation_layer_details.md
+++ b/layers/vk_validation_layer_details.md
@@ -78,6 +78,7 @@ The VK_LAYER_LUNARG_draw_state layer tracks state leading into Draw cmds. This i
 | Live Semaphore  | When waiting on a semaphore, need to make sure that the semaphore is live and therefore can be signalled, otherwise queue is stalled and cannot make forward progress. | QUEUE_FORWARD_PROGRESS | vkQueueSubmit vkQueueBindSparse vkQueuePresentKHR vkAcquireNextImageKHR | TODO | Create test |
 | Storage Buffer Alignment  | Storage Buffer offsets in BindDescriptorSets must agree with offset alignment device limit | INVALID_STORAGE_BUFFER_OFFSET | vkCmdBindDescriptorSets | TODO | Create test |
 | Uniform Buffer Alignment  | Uniform Buffer offsets in BindDescriptorSets must agree with offset alignment device limit | INVALID_UNIFORM_BUFFER_OFFSET | vkCmdBindDescriptorSets | TODO | Create test |
+| QueueFamilyIndex is Valid | Validates that QueueFamilyIndices are less an the number of QueueFamilies | INVALID_QUEUE_INDEX | vkCmdWaitEvents vkCmdPipelineBarrier vkCreateBuffer vkCreateImage | TODO | Create test |
 | NA | Enum used for informational messages | NONE | | NA | None |
 | NA | Enum used for errors in the layer itself. This does not indicate an app issue, but instead a bug in the layer. | INTERNAL_ERROR | | NA | None |
 | NA | Enum used when VK_LAYER_LUNARG_draw_state attempts to allocate memory for its own internal use and is unable to. | OUT_OF_MEMORY | | NA | None |

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -3720,6 +3720,33 @@ TEST_F(VkLayerTest, IdxBufferAlignmentError) {
     vkDestroyBuffer(m_device->device(), ib, NULL);
 }
 
+TEST_F(VkLayerTest, InvalidQueueFamilyIndex) {
+    // Create an out-of-range queueFamilyIndex
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "vkCreateBuffer has QueueFamilyIndex greater than");
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    VkBufferCreateInfo buffCI = {};
+    buffCI.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    buffCI.size = 1024;
+    buffCI.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+    buffCI.queueFamilyIndexCount = 1;
+    // Introduce failure by specifying invalid queue_family_index
+    uint32_t qfi = 777;
+    buffCI.pQueueFamilyIndices = &qfi;
+
+    VkBuffer ib;
+    vkCreateBuffer(m_device->device(), &buffCI, NULL, &ib);
+
+    if (!m_errorMonitor->DesiredMsgFound()) {
+        FAIL() << "Did not receive Error 'vkCreateBuffer() has "
+        "QueueFamilyIndex greater than...'";
+        m_errorMonitor->DumpFailureMsgs();
+    }
+}
+
 TEST_F(VkLayerTest, ExecuteCommandsPrimaryCB) {
     // Attempt vkCmdExecuteCommands w/ a primary cmd buffer (should only be
     // secondary)


### PR DESCRIPTION
This is for Gitlab issue 207.  Note the some uses of QueueFamilyIndex were already validated:

DeviceQueueCreateInfo -- draw_state
GetDeviceQueue -- device_limits
GetPhysicalDeviceSurfaceSupport -- swapchain
GetPhysicalDevice[Mir|Wayland|Xcb|Xlib|Win32]PresentationSupport -- swapchain

This commit adds validation for CreateComandPool, CmdWaitEvents, CmdPipelineBarrier, CreateBuffer, CreateImage, and CreateSwapchain.

I already see that I need to add CreateCommandPool to the layers doc, and need to update the first commit message with the issue number (!).