### PR TITLE
Validation of push constants

### DIFF
--- a/layers/draw_state.cpp
+++ b/layers/draw_state.cpp
@@ -812,7 +812,7 @@ collect_interface_by_location(layer_data *my_data, VkDevice dev,
 
 static void
 collect_interface_by_descriptor_slot(layer_data *my_data, VkDevice dev,
-                              shader_module const *src, spv::StorageClass sinterface,
+                              shader_module const *src,
                               std::unordered_set<uint32_t> const &accessible_ids,
                               std::map<descriptor_slot_t, interface_var> &out)
 {
@@ -851,7 +851,7 @@ collect_interface_by_descriptor_slot(layer_data *my_data, VkDevice dev,
                 log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, /*dev*/0, __LINE__,
                         SHADER_CHECKER_INCONSISTENT_SPIRV, "SC",
                         "var %d (type %d) in %s interface in descriptor slot (%u,%u) conflicts with existing definition",
-                        insn.word(2), insn.word(1), storage_class_name(sinterface),
+                        insn.word(2), insn.word(1), storage_class_name(insn.word(3)),
                         existing_it->first.first, existing_it->first.second);
             }
 
@@ -1595,7 +1595,7 @@ validate_pipeline_shaders(layer_data *my_data, VkDevice dev, PIPELINE_NODE* pPip
 
                 /* validate descriptor set layout against what the entrypoint actually uses */
                 std::map<descriptor_slot_t, interface_var> descriptor_uses;
-                collect_interface_by_descriptor_slot(my_data, dev, module, spv::StorageClassUniform,
+                collect_interface_by_descriptor_slot(my_data, dev, module,
                         accessible_ids,
                         descriptor_uses);
 

--- a/layers/draw_state.cpp
+++ b/layers/draw_state.cpp
@@ -449,6 +449,7 @@ storage_class_name(unsigned sc)
     case spv::StorageClassGeneric: return "generic";
     case spv::StorageClassAtomicCounter: return "atomic counter";
     case spv::StorageClassImage: return "image";
+    case spv::StorageClassPushConstant: return "push constant";
     default: return "unknown";
     }
 }

--- a/layers/draw_state.cpp
+++ b/layers/draw_state.cpp
@@ -1003,6 +1003,14 @@ get_fundamental_type(shader_module const *src, unsigned type)
     }
 }
 
+
+static uint32_t get_shader_stage_id(VkShaderStageFlagBits stage)
+{
+    uint32_t bit_pos = u_ffs(stage);
+    return bit_pos-1;
+}
+
+
 static bool
 validate_vi_consistency(layer_data *my_data, VkDevice dev, VkPipelineVertexInputStateCreateInfo const *vi)
 {
@@ -1300,12 +1308,6 @@ has_descriptor_binding(layer_data* my_data,
                    ->bindingToIndexMap;
 
     return (bindingMap.find(slot.second) != bindingMap.end());
-}
-
-static uint32_t get_shader_stage_id(VkShaderStageFlagBits stage)
-{
-    uint32_t bit_pos = u_ffs(stage);
-    return bit_pos-1;
 }
 
 // Block of code at start here for managing/tracking Pipeline state that this layer cares about

--- a/layers/draw_state.h
+++ b/layers/draw_state.h
@@ -178,9 +178,9 @@ typedef enum _DRAW_STATE_ERROR {
                                            // type is being updated with an
                                            // invalid or bad BufferView
     DRAWSTATE_BUFFERINFO_DESCRIPTOR_ERROR, // A Descriptor of
-                                           // *_[UNIFORM|STORAGE]_BUFFER_[DYNAMIC]
-                                           // type is being updated with an
-                                           // invalid or bad BufferView
+    // *_[UNIFORM|STORAGE]_BUFFER_[DYNAMIC]
+    // type is being updated with an
+    // invalid or bad BufferView
     DRAWSTATE_DYNAMIC_OFFSET_OVERFLOW, // At draw time the dynamic offset
                                        // combined with buffer offset and range
                                        // oversteps size of buffer
@@ -200,6 +200,7 @@ typedef enum _DRAW_STATE_ERROR {
                                  // must be a valid VkLogicOp value
     DRAWSTATE_INVALID_QUEUE_INDEX,           // Specified queue index exceeds number
                                              // of queried queue families
+    DRAWSTATE_PUSH_CONSTANTS_ERROR, // Push constants exceed maxPushConstantSize
 } DRAW_STATE_ERROR;
 
 typedef enum _SHADER_CHECKER_ERROR {
@@ -482,8 +483,7 @@ typedef struct _DESCRIPTOR_POOL_NODE {
 } DESCRIPTOR_POOL_NODE;
 
 // Cmd Buffer Tracking
-typedef enum _CMD_TYPE
-{
+typedef enum _CMD_TYPE {
     CMD_BINDPIPELINE,
     CMD_BINDPIPELINEDELTA,
     CMD_SETVIEWPORTSTATE,
@@ -525,6 +525,7 @@ typedef enum _CMD_TYPE
     CMD_RESETQUERYPOOL,
     CMD_COPYQUERYPOOLRESULTS,
     CMD_WRITETIMESTAMP,
+    CMD_PUSHCONSTANTS,
     CMD_INITATOMICCOUNTERS,
     CMD_LOADATOMICCOUNTERS,
     CMD_SAVEATOMICCOUNTERS,

--- a/layers/draw_state.h
+++ b/layers/draw_state.h
@@ -205,7 +205,7 @@ typedef enum _DRAW_STATE_ERROR {
 
 typedef enum _SHADER_CHECKER_ERROR {
     SHADER_CHECKER_NONE,
-    SHADER_CHECKER_FS_MIXED_BROADCAST,      /* FS writes broadcast output AND custom outputs */
+    SHADER_CHECKER_FS_MIXED_BROADCAST,      /* FS writes broadcast output AND custom outputs -- DEFUNCT */
     SHADER_CHECKER_INTERFACE_TYPE_MISMATCH, /* Type mismatch between shader stages or shader and pipeline */
     SHADER_CHECKER_OUTPUT_NOT_CONSUMED,     /* Entry appears in output interface, but missing in input */
     SHADER_CHECKER_INPUT_NOT_PRODUCED,      /* Entry appears in input interface, but missing in output */
@@ -216,6 +216,8 @@ typedef enum _SHADER_CHECKER_ERROR {
     SHADER_CHECKER_MISSING_DESCRIPTOR,      /* Shader attempts to use a descriptor binding not declared in the layout */
     SHADER_CHECKER_BAD_SPECIALIZATION,      /* Specialization map entry points outside specialization data block */
     SHADER_CHECKER_MISSING_ENTRYPOINT,      /* Shader module does not contain the requested entrypoint */
+    SHADER_CHECKER_PUSH_CONSTANT_OUT_OF_RANGE,  /* Push constant variable is not in a push constant range */
+    SHADER_CHECKER_PUSH_CONSTANT_NOT_ACCESSIBLE_FROM_STAGE, /* Push constant range exists, but not accessible from stage */
 } SHADER_CHECKER_ERROR;
 
 typedef enum _DRAW_TYPE

--- a/layers/vk_validation_layer_details.md
+++ b/layers/vk_validation_layer_details.md
@@ -140,6 +140,12 @@ depends on the pair of pipeline stages involved.
 | Shader Specialization | Error if specialization entry data is not fully contained within the specialization data block. | BAD_SPECIALIZATION | vkCreateGraphicsPipelines vkCreateComputePipelines | TBD | NA |
 | Missing Descriptor | Flags error if shader attempts to use a descriptor binding not declared in the layout | MISSING_DESCRIPTOR | vkCreateGraphicsPipelines | CreatePipelineUniformBlockNotProvided | NA |
 | Missing Entrypoint | Flags error if specified entrypoint is not present in the shader module | MISSING_ENTRYPOINT | vkCreateGraphicsPipelines | TBD | NA |
+| Push constant out of range | Flags error if a member of a push constant block
+is not contained within a push constant range specified in the pipeline layout | PUSH_CONSTANT_OUT_OF_RANGE | vkCreateGraphicsPipelines | CreatePipelinePushContantsNotInLayout | NA |
+| Push constant not accessible from stage | Flags error if the push constant
+range containing a push constant block member is not accessible from the current
+shader stage. | PUSH_CONSTANT_NOT_ACCESSIBLE_FROM_STAGE |
+vkCreateGraphicsPipelines | TBD | NA |
 | NA | Enum used for informational messages | NONE | | NA | None |
 
 ### VK_LAYER_LUNARG_ShaderChecker Pending Work

--- a/layers/vk_validation_layer_details.md
+++ b/layers/vk_validation_layer_details.md
@@ -87,6 +87,7 @@ The VK_LAYER_LUNARG_draw_state layer tracks state leading into Draw cmds. This i
 | Enabled Logic Operations  | If logic operations is not enabled, logicOpEnable must be VK_FALSE | DISABLED_LOGIC_OP | vkCreateGraphicsPipelines | TODO | Create test |
 | Valid Logic Operations  | If logicOpEnable is VK_TRUE, logicOp must be a valid VkLogicOp value | INVALID_LOGIC_OP | vkCreateGraphicsPipelines | TODO | Create test |
 | QueueFamilyIndex is Valid | Validates that QueueFamilyIndices are less an the number of QueueFamilies | INVALID_QUEUE_INDEX | vkCmdWaitEvents vkCmdPipelineBarrier vkCreateBuffer vkCreateImage | TODO | Create test |
+| Push Constants | Validate that the size of push constant ranges and updates does not exceed maxPushConstantSize | PUSH_CONSTANTS_ERROR | vkCreatePipelineLayout vkCmdPushConstants | TODO | Create test |
 | NA | Enum used for informational messages | NONE | | NA | None |
 | NA | Enum used for errors in the layer itself. This does not indicate an app issue, but instead a bug in the layer. | INTERNAL_ERROR | | NA | None |
 | NA | Enum used when VK_LAYER_LUNARG_draw_state attempts to allocate memory for its own internal use and is unable to. | OUT_OF_MEMORY | | NA | None |

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5798,10 +5798,6 @@ TEST_F(VkLayerTest, CreatePipelineAttribMatrixType) {
     }
 }
 
-/*
- * Would work, but not supported by glslang! This is similar to the matrix case
-above.
- *
 TEST_F(VkLayerTest, CreatePipelineAttribArrayType)
 {
     m_errorMonitor->SetDesiredFailureMsg(~0u, "");
@@ -5865,7 +5861,6 @@ m_errorMonitor->GetFailureMsg();
         m_errorMonitor->DumpFailureMsgs();
     }
 }
-*/
 
 TEST_F(VkLayerTest, CreatePipelineAttribBindingConflict) {
     m_errorMonitor->SetDesiredFailureMsg(


### PR DESCRIPTION
Series adds Tobin's DrawState validation checks for push constants, and additional ShaderChecker checks for consistency between the shader's push constant usage and the pipeline layout.