### PR TITLE
layers: GH117: swapchain layer warns if app uses neither semaphore no…

### DIFF
--- a/layers/swapchain.cpp
+++ b/layers/swapchain.cpp
@@ -1744,9 +1744,9 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(VkDevice de
                               VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     }
     if ((semaphore == VK_NULL_HANDLE) && (fence == VK_NULL_HANDLE)) {
-        skipCall |= LOG_WARNING(VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, device, "VkDevice", SWAPCHAIN_NO_SYNC_FOR_ACQUIRE,
-                                "%s() called with both the semaphore and fence parameters set to "
-                                "VK_NULL_HANDLE (at least one should be used).", __FUNCTION__);
+        skipCall |= LOG_ERROR(VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, device, "VkDevice", SWAPCHAIN_NO_SYNC_FOR_ACQUIRE,
+                              "%s() called with both the semaphore and fence parameters set to "
+                              "VK_NULL_HANDLE (at least one should be used).", __FUNCTION__);
     }
     SwpSwapchain *pSwapchain = &my_data->swapchainMap[swapchain];
     if (pSwapchain) {

--- a/layers/swapchain.cpp
+++ b/layers/swapchain.cpp
@@ -1743,6 +1743,11 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(VkDevice de
                               "%s() called even though the %s extension was not enabled for this VkDevice.", __FUNCTION__,
                               VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     }
+    if ((semaphore == VK_NULL_HANDLE) && (fence == VK_NULL_HANDLE)) {
+        skipCall |= LOG_WARNING(VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, device, "VkDevice", SWAPCHAIN_NO_SYNC_FOR_ACQUIRE,
+                                "%s() called with both the semaphore and fence parameters set to "
+                                "VK_NULL_HANDLE (at least one should be used).", __FUNCTION__);
+    }
     SwpSwapchain *pSwapchain = &my_data->swapchainMap[swapchain];
     if (pSwapchain) {
         // Look to see if the application is trying to own too many images at

--- a/layers/swapchain.h
+++ b/layers/swapchain.h
@@ -79,6 +79,7 @@ typedef enum _SWAPCHAIN_ERROR {
                                                 // vkGetPhysicalDeviceQueueFamilyProperties()
     SWAPCHAIN_SURFACE_NOT_SUPPORTED_WITH_QUEUE, // A surface is not supported by a given queueFamilyIndex, as seen by
                                                 // vkGetPhysicalDeviceSurfaceSupportKHR()
+    SWAPCHAIN_NO_SYNC_FOR_ACQUIRE,      // vkAcquireNextImageKHR should be called with a valid semaphore and/or fence
 } SWAPCHAIN_ERROR;
 
 // The following is for logging error messages:
@@ -123,6 +124,10 @@ typedef enum _SWAPCHAIN_ERROR {
 #define LOG_PERF_WARNING(objType, type, obj, enm, fmt, ...)                                                                        \
     (my_data) ? log_msg(my_data->report_data, VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, (objType), (uint64_t)(obj), __LINE__,   \
                         (enm), LAYER_NAME, (fmt), __VA_ARGS__)                                                                     \
+              : VK_FALSE
+#define LOG_WARNING(objType, type, obj, enm, fmt, ...)                                                                             \
+    (my_data) ? log_msg(my_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, (objType), (uint64_t)(obj), __LINE__, (enm),        \
+                        LAYER_NAME, (fmt), __VA_ARGS__)                                                                            \
               : VK_FALSE
 #define LOG_INFO_WRONG_NEXT(objType, type, obj)                                                                                    \
     (my_data) ? log_msg(my_data->report_data, VK_DEBUG_REPORT_INFORMATION_BIT_EXT, (objType), (uint64_t)(obj), 0,                  \

--- a/layers/vk_validation_layer_details.md
+++ b/layers/vk_validation_layer_details.md
@@ -385,6 +385,7 @@ This layer is a work in progress. VK_LAYER_LUNARG_swapchain layer is intended to
 | Valid use of queueFamilyIndex | Validates that a queueFamilyIndex not used before vkGetPhysicalDeviceQueueFamilyProperties() was called | DID_NOT_QUERY_QUEUE_FAMILIES | vkGetPhysicalDeviceSurfaceSupportKHR | NA | None |
 | Valid queueFamilyIndex value | Validates that a queueFamilyIndex value is less-than pQueueFamilyPropertyCount returned by vkGetPhysicalDeviceQueueFamilyProperties | QUEUE_FAMILY_INDEX_TOO_LARGE | vkGetPhysicalDeviceSurfaceSupportKHR | NA | None |
 | Supported combination of queue and surface | Validates that the surface associated with a swapchain was seen to support the queueFamilyIndex of a given queue | SURFACE_NOT_SUPPORTED_WITH_QUEUE | vkQueuePresentKHR | NA | None |
+| Proper synchronization of acquired images | vkAcquireNextImageKHR should be called with a valid semaphore and/or fence | NO_SYNC_FOR_ACQUIRE | vkAcquireNextImageKHR | NA | None |
 
 Note: The following platform-specific functions are not mentioned above, because they are protected by ifdefs, which cause test failures:
 


### PR DESCRIPTION
This addresses github issue #117 (for the Vulkan-Doc repository).  Applications should call
vkAcquireNextImageKHR with either a valid semaphore and/or fence.  Issue a
warning if both are set to VK_NULL_HANDLE.