### PR TITLE
Temporary debug_report callback in VkDestroyInstance + Cube enables it

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -2286,6 +2286,25 @@ static void demo_init_vk(struct demo *demo) {
         .enabledExtensionCount = enabled_extension_count,
         .ppEnabledExtensionNames = (const char *const *)extension_names,
     };
+    VkDebugReportCallbackCreateInfoEXT dbgCreateInfo;
+    PFN_vkDebugReportCallbackEXT callback;
+    if (demo->validate) {
+        if (!demo->use_break) {
+            callback = dbgFunc;
+        } else {
+            callback = dbgFunc;
+            // TODO add a break callback defined locally since there is no
+            // longer
+            // one included in the loader
+        }
+        dbgCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
+        dbgCreateInfo.pNext = NULL;
+        dbgCreateInfo.pfnCallback = callback;
+        dbgCreateInfo.pUserData = NULL;
+        dbgCreateInfo.flags =
+            VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
+        inst_info.pNext = &dbgCreateInfo;
+    }
 
     uint32_t gpu_count;
 

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -293,6 +293,7 @@ struct loader_instance {
 
     bool debug_report_enabled;
     VkLayerDbgFunctionNode *DbgFunctionHead;
+    VkDebugReportCallbackCreateInfoEXT *pDebugReportCreateInfo;
 
     VkAllocationCallbacks alloc_callbacks;
 

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -293,7 +293,7 @@ struct loader_instance {
 
     bool debug_report_enabled;
     VkLayerDbgFunctionNode *DbgFunctionHead;
-    VkDebugReportCallbackCreateInfoEXT *pDebugReportCreateInfo;
+    VkDebugReportCallbackCreateInfoEXT debugReportCreateInfo;
 
     VkAllocationCallbacks alloc_callbacks;
 

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -282,9 +282,8 @@ vkCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
             // Use this pNext so that vkCreateInstance has a callback that can
             // be used to log messages.  Make a copy for use by
             // vkDestroyInstance as well.
-            ptr_instance->pDebugReportCreateInfo =
-                ((VkDebugReportCallbackCreateInfoEXT *)
-                 malloc(sizeof(VkDebugReportCallbackCreateInfoEXT)));
+            memcpy(&ptr_instance->debugReportCreateInfo, pNext,
+                   sizeof(VkDebugReportCallbackCreateInfoEXT));
             instance_callback = (VkDebugReportCallbackEXT)ptr_instance;
             if (util_CreateDebugReportCallback(ptr_instance, pNext, NULL,
                                                instance_callback)) {
@@ -457,11 +456,12 @@ vkDestroyInstance(VkInstance instance,
 
     ptr_instance = loader_get_instance(instance);
 
-    if (ptr_instance->pDebugReportCreateInfo) {
+    if (ptr_instance->debugReportCreateInfo.sType ==
+        VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT) {
         // Setup a temporary callback here to catch cleanup issues:
         instance_callback = (VkDebugReportCallbackEXT)ptr_instance;
         if (!util_CreateDebugReportCallback(ptr_instance,
-                                            ptr_instance->pDebugReportCreateInfo,
+                                            &ptr_instance->debugReportCreateInfo,
                                             NULL, instance_callback)) {
             callback_setup = true;
         }


### PR DESCRIPTION
Courtney added the ability for a temporary callback to be created during vkCreateInstance, so that validation messages could be seen before the debug_report extension had been properly setup.  This pull request saves and reuses that for vkDestroyInstance, so that validation messages can be seen after debug_report is no longer setup.

This pull request also modifies the cube demo to call vkCreateInstance in such a manner that the temporary callback is setup in both vkCreateInstance and vkDestroyInstance.