### PR TITLE
layers: Initialize IMAGE_CMD_BUF_LAYOUT_NODE.initialLayout

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -458,7 +458,7 @@ typedef struct _IMAGE_LAYOUT_NODE {
 
 class IMAGE_CMD_BUF_LAYOUT_NODE {
   public:
-    IMAGE_CMD_BUF_LAYOUT_NODE() {}
+    IMAGE_CMD_BUF_LAYOUT_NODE() : initialLayout(VK_IMAGE_LAYOUT_UNDEFINED) {}
     IMAGE_CMD_BUF_LAYOUT_NODE(VkImageLayout initialLayoutInput, VkImageLayout layoutInput)
         : initialLayout(initialLayoutInput), layout(layoutInput) {}
 


### PR DESCRIPTION
Uninitialized initalLayout in core_validation caused scads of bad layout-
transition errors in DOTA2.

Change-Id: I3d8b913222e8562ef02333a4f804d78c28269949