### PR TITLE
Strip array level from both per-vertex TCS output and TES input

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1640,7 +1640,7 @@ static bool validate_interface_between_stages(layer_data *my_data, shader_module
             if (a_it->second.is_patch != b_it->second.is_patch) {
                 if (log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, /*dev*/ 0,
                             __LINE__, SHADER_CHECKER_INTERFACE_TYPE_MISMATCH, "SC",
-                            "Decoration mismatch on location %u.%u: is per-%s in %s stage but"
+                            "Decoration mismatch on location %u.%u: is per-%s in %s stage but "
                             "per-%s in %s stage", a_first.first, a_first.second,
                             a_it->second.is_patch ? "patch" : "vertex", producer_stage->name,
                             b_it->second.is_patch ? "patch" : "vertex", consumer_stage->name)) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1626,16 +1626,24 @@ static bool validate_interface_between_stages(layer_data *my_data, shader_module
             }
             b_it++;
         } else {
-            if (types_match(producer, consumer, a_it->second.type_id, b_it->second.type_id,
+            if (!types_match(producer, consumer, a_it->second.type_id, b_it->second.type_id,
                              producer_stage->arrayed_output && !a_it->second.is_patch,
                              consumer_stage->arrayed_input && !b_it->second.is_patch)) {
-                /* OK! */
-            } else {
                 if (log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VkDebugReportObjectTypeEXT(0), 0,
                             __LINE__, SHADER_CHECKER_INTERFACE_TYPE_MISMATCH, "SC", "Type mismatch on location %u.%u: '%s' vs '%s'",
                             a_first.first, a_first.second,
                             describe_type(producer, a_it->second.type_id).c_str(),
                             describe_type(consumer, b_it->second.type_id).c_str())) {
+                    pass = false;
+                }
+            }
+            if (a_it->second.is_patch != b_it->second.is_patch) {
+                if (log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, /*dev*/ 0,
+                            __LINE__, SHADER_CHECKER_INTERFACE_TYPE_MISMATCH, "SC",
+                            "Decoration mismatch on location %u.%u: is per-%s in %s stage but"
+                            "per-%s in %s stage", a_first.first, a_first.second,
+                            a_it->second.is_patch ? "patch" : "vertex", producer_stage->name,
+                            b_it->second.is_patch ? "patch" : "vertex", consumer_stage->name)) {
                     pass = false;
                 }
             }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5918,6 +5918,11 @@ TEST_F(VkLayerTest, CreatePipelineTessPerVertex)
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
+    if (!m_device->phy().features().tessellationShader) {
+        printf("Device does not support tessellation shaders; skipped.\n");
+        return;
+    }
+
     char const *vsSource =
         "#version 450\n"
         "void main(){}\n";
@@ -5994,6 +5999,11 @@ TEST_F(VkLayerTest, CreatePipelineTessPatchDecorationMismatch)
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    if (!m_device->phy().features().tessellationShader) {
+        printf("Device does not support tessellation shaders; skipped.\n");
+        return;
+    }
 
     char const *vsSource =
         "#version 450\n"

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5867,6 +5867,118 @@ m_errorMonitor->GetFailureMsg();
     }
 }
 
+TEST_F(VkLayerTest, CreatePipelineSimplePositive)
+{
+    m_errorMonitor->SetDesiredFailureMsg(~0u, "");
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    char const *vsSource =
+        "#version 450\n"
+        "out gl_PerVertex {\n"
+        "    vec4 gl_Position;\n"
+        "};\n"
+        "void main(){\n"
+        "   gl_Position = vec4(0);\n"
+        "}\n";
+    char const *fsSource =
+        "#version 450\n"
+        "\n"
+        "layout(location=0) out vec4 color;\n"
+        "void main(){\n"
+        "   color = vec4(1);\n"
+        "}\n";
+
+    VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+    VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+    VkPipelineObj pipe(m_device);
+    pipe.AddColorAttachment();
+    pipe.AddShader(&vs);
+    pipe.AddShader(&fs);
+
+    VkDescriptorSetObj descriptorSet(m_device);
+    descriptorSet.AppendDummy();
+    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+    if (m_errorMonitor->DesiredMsgFound()) {
+        FAIL() << "Expected to succeed but: " <<
+m_errorMonitor->GetFailureMsg();
+        m_errorMonitor->DumpFailureMsgs();
+    }
+}
+
+TEST_F(VkLayerTest, CreatePipelineTessPerVertex)
+{
+    m_errorMonitor->SetDesiredFailureMsg(~0u, "");
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    char const *vsSource =
+        "#version 450\n"
+        "void main(){}\n";
+    char const *tcsSource =
+        "#version 450\n"
+        "layout(location=0) out int x[];\n"
+        "layout(vertices=3) out;\n"
+        "void main(){\n"
+        "   gl_TessLevelOuter[0] = gl_TessLevelOuter[1] = gl_TessLevelOuter[2] = 1;\n"
+        "   gl_TessLevelInner[0] = 1;\n"
+        "   x[gl_InvocationID] = gl_InvocationID;\n"
+        "}\n";
+    char const *tesSource =
+        "#version 450\n"
+        "layout(triangles, equal_spacing, cw) in;\n"
+        "layout(location=0) in int x[];\n"
+        "out gl_PerVertex { vec4 gl_Position; };\n"
+        "void main(){\n"
+        "   gl_Position.xyz = gl_TessCoord;\n"
+        "   gl_Position.w = x[0] + x[1] + x[2];\n"
+        "}\n";
+    char const *fsSource =
+        "#version 450\n"
+        "layout(location=0) out vec4 color;\n"
+        "void main(){\n"
+        "   color = vec4(1);\n"
+        "}\n";
+
+    VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+    VkShaderObj tcs(m_device, tcsSource, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, this);
+    VkShaderObj tes(m_device, tesSource, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, this);
+    VkShaderObj fs(m_device, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, this);
+
+    VkPipelineInputAssemblyStateCreateInfo iasci{
+        VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+        nullptr,
+        0,
+        VK_PRIMITIVE_TOPOLOGY_PATCH_LIST,
+        VK_FALSE};
+
+    VkPipelineObj pipe(m_device);
+    pipe.SetInputAssembly(&iasci);
+    pipe.AddColorAttachment();
+    pipe.AddShader(&vs);
+    pipe.AddShader(&tcs);
+    pipe.AddShader(&tes);
+    pipe.AddShader(&fs);
+
+    VkDescriptorSetObj descriptorSet(m_device);
+    descriptorSet.AppendDummy();
+    descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
+
+    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+
+    if (m_errorMonitor->DesiredMsgFound()) {
+        m_errorMonitor->DumpFailureMsgs();
+        FAIL() << "Expected to succeed but: " <<
+m_errorMonitor->GetFailureMsg();
+    }
+}
+
 TEST_F(VkLayerTest, CreatePipelineAttribBindingConflict) {
     m_errorMonitor->SetDesiredFailureMsg(
         VK_DEBUG_REPORT_ERROR_BIT_EXT,

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5958,8 +5958,15 @@ TEST_F(VkLayerTest, CreatePipelineTessPerVertex)
         VK_PRIMITIVE_TOPOLOGY_PATCH_LIST,
         VK_FALSE};
 
+    VkPipelineTessellationStateCreateInfo tsci{
+        VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO,
+        nullptr,
+        0,
+        3};
+
     VkPipelineObj pipe(m_device);
     pipe.SetInputAssembly(&iasci);
+    pipe.SetTessellation(&tsci);
     pipe.AddColorAttachment();
     pipe.AddShader(&vs);
     pipe.AddShader(&tcs);

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5164,9 +5164,7 @@ TEST_F(VkLayerTest, CreatePipelineVertexOutputNotConsumed) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out float x;\n"
         "out gl_PerVertex {\n"
@@ -5177,9 +5175,7 @@ TEST_F(VkLayerTest, CreatePipelineVertexOutputNotConsumed) {
         "   x = 0;\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 color;\n"
         "void main(){\n"
@@ -5214,9 +5210,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvided) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "out gl_PerVertex {\n"
         "    vec4 gl_Position;\n"
@@ -5225,9 +5219,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvided) {
         "   gl_Position = vec4(1);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) in float x;\n"
         "layout(location=0) out vec4 color;\n"
@@ -5263,9 +5255,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvidedInBlock) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "out gl_PerVertex {\n"
         "    vec4 gl_Position;\n"
@@ -5275,8 +5265,6 @@ TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvidedInBlock) {
         "}\n";
     char const *fsSource =
         "#version 450\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
         "\n"
         "in block { layout(location=0) float x; } ins;\n"
         "layout(location=0) out vec4 color;\n"
@@ -5314,9 +5302,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out float x[2];\n"
         "out gl_PerVertex {\n"
@@ -5327,9 +5313,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
         "   gl_Position = vec4(1);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) in float x[3];\n"
         "layout(location=0) out vec4 color;\n"
@@ -5367,9 +5351,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatch) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out int x;\n"
         "out gl_PerVertex {\n"
@@ -5380,9 +5362,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatch) {
         "   gl_Position = vec4(1);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) in float x;\n" /* VS writes int */
         "layout(location=0) out vec4 color;\n"
@@ -5419,8 +5399,6 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatchInBlock) {
 
     char const *vsSource =
         "#version 450\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
         "\n"
         "out block { layout(location=0) int x; } outs;\n"
         "out gl_PerVertex {\n"
@@ -5432,8 +5410,6 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatchInBlock) {
         "}\n";
     char const *fsSource =
         "#version 450\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
         "\n"
         "in block { layout(location=0) float x; } ins;\n" /* VS writes int */
         "layout(location=0) out vec4 color;\n"
@@ -5470,8 +5446,6 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByLocation) {
 
     char const *vsSource =
         "#version 450\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
         "\n"
         "out block { layout(location=1) float x; } outs;\n"
         "out gl_PerVertex {\n"
@@ -5483,8 +5457,6 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByLocation) {
         "}\n";
     char const *fsSource =
         "#version 450\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
         "\n"
         "in block { layout(location=0) float x; } ins;\n"
         "layout(location=0) out vec4 color;\n"
@@ -5521,8 +5493,6 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByComponent) {
 
     char const *vsSource =
         "#version 450\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
         "\n"
         "out block { layout(location=0, component=0) float x; } outs;\n"
         "out gl_PerVertex {\n"
@@ -5534,8 +5504,6 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByComponent) {
         "}\n";
     char const *fsSource =
         "#version 450\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
         "\n"
         "in block { layout(location=0, component=1) float x; } ins;\n"
         "layout(location=0) out vec4 color;\n"
@@ -5578,9 +5546,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribNotConsumed) {
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "out gl_PerVertex {\n"
         "    vec4 gl_Position;\n"
@@ -5589,9 +5555,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribNotConsumed) {
         "   gl_Position = vec4(1);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 color;\n"
         "void main(){\n"
@@ -5636,9 +5600,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribLocationMismatch) {
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=1) in float x;\n"
         "out gl_PerVertex {\n"
@@ -5648,9 +5610,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribLocationMismatch) {
         "   gl_Position = vec4(x);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 color;\n"
         "void main(){\n"
@@ -5689,9 +5649,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribNotProvided) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) in vec4 x;\n" /* not provided */
         "out gl_PerVertex {\n"
@@ -5701,9 +5659,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribNotProvided) {
         "   gl_Position = x;\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 color;\n"
         "void main(){\n"
@@ -5747,9 +5703,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribTypeMismatch) {
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) in int x;\n" /* attrib provided float */
         "out gl_PerVertex {\n"
@@ -5759,9 +5713,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribTypeMismatch) {
         "   gl_Position = vec4(x);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 color;\n"
         "void main(){\n"
@@ -5810,9 +5762,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribMatrixType) {
     }
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) in mat2x4 x;\n"
         "out gl_PerVertex {\n"
@@ -5822,9 +5772,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribMatrixType) {
         "   gl_Position = x[0] + x[1];\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 color;\n"
         "void main(){\n"
@@ -5875,9 +5823,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribArrayType)
     }
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) in vec4 x[2];\n"
         "out gl_PerVertex {\n"
@@ -5887,9 +5833,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribArrayType)
         "   gl_Position = x[0] + x[1];\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 color;\n"
         "void main(){\n"
@@ -5937,9 +5881,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribBindingConflict) {
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) in float x;\n" /* attrib provided float */
         "out gl_PerVertex {\n"
@@ -5949,9 +5891,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribBindingConflict) {
         "   gl_Position = vec4(x);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 color;\n"
         "void main(){\n"
@@ -5989,9 +5929,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputNotWritten) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "out gl_PerVertex {\n"
         "    vec4 gl_Position;\n"
@@ -6000,9 +5938,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputNotWritten) {
         "   gl_Position = vec4(1);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "void main(){\n"
         "}\n";
@@ -6039,9 +5975,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputNotConsumed) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "out gl_PerVertex {\n"
         "    vec4 gl_Position;\n"
@@ -6050,9 +5984,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputNotConsumed) {
         "   gl_Position = vec4(1);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 x;\n"
         "layout(location=1) out vec4 y;\n" /* no matching attachment for this */
@@ -6093,9 +6025,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputTypeMismatch) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "out gl_PerVertex {\n"
         "    vec4 gl_Position;\n"
@@ -6104,9 +6034,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputTypeMismatch) {
         "   gl_Position = vec4(1);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out ivec4 x;\n" /* not UNORM */
         "void main(){\n"
@@ -6143,9 +6071,7 @@ TEST_F(VkLayerTest, CreatePipelineUniformBlockNotProvided) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     char const *vsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "out gl_PerVertex {\n"
         "    vec4 gl_Position;\n"
@@ -6154,9 +6080,7 @@ TEST_F(VkLayerTest, CreatePipelineUniformBlockNotProvided) {
         "   gl_Position = vec4(1);\n"
         "}\n";
     char const *fsSource =
-        "#version 400\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
+        "#version 450\n"
         "\n"
         "layout(location=0) out vec4 x;\n"
         "layout(set=0) layout(binding=0) uniform foo { int x; int y; } bar;\n"
@@ -6197,8 +6121,6 @@ TEST_F(VkLayerTest, CreatePipelinePushConstantsNotInLayout) {
 
     char const *vsSource =
         "#version 450\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
         "\n"
         "layout(push_constant, std430) uniform foo { float x; } consts;\n"
         "out gl_PerVertex {\n"
@@ -6209,8 +6131,6 @@ TEST_F(VkLayerTest, CreatePipelinePushConstantsNotInLayout) {
         "}\n";
     char const *fsSource =
         "#version 450\n"
-        "#extension GL_ARB_separate_shader_objects: require\n"
-        "#extension GL_ARB_shading_language_420pack: require\n"
         "\n"
         "layout(location=0) out vec4 x;\n"
         "void main(){\n"

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -154,6 +154,9 @@ class ErrorMonitor {
         string errorString(msgString);
         if (msgFlags & m_msgFlags) {
             if (errorString.find(m_desiredMsg) != string::npos) {
+                if (m_msgFound) { /* if multiple matches, don't lose all but the last! */
+                    m_otherMsgs.push_back(m_failureMsg);
+                }
                 m_failureMsg = errorString;
                 m_msgFound = VK_TRUE;
                 result = VK_TRUE;
@@ -2844,7 +2847,7 @@ VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
 
     if (!m_errorMonitor->DesiredMsgFound()) {
         FAIL() << "Did not receive Error 'Invalid Pipeline CreateInfo State:
-VK_PRIMITIVE_TOPOLOGY_PATCH primitive...'";
+VK_PRIMITIVE_TOPOLOGY_PATCHLIST primitive...'";
         m_errorMonitor->DumpFailureMsgs();
     }
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1252,20 +1252,24 @@ void VkPipelineObj::MakeDynamic(VkDynamicState state) {
 
 void VkPipelineObj::SetMSAA(
     const VkPipelineMultisampleStateCreateInfo *ms_state) {
-    memcpy(&m_ms_state, ms_state, sizeof(VkPipelineMultisampleStateCreateInfo));
+    m_ms_state = *ms_state;
 }
 
 void VkPipelineObj::SetInputAssembly(
     const VkPipelineInputAssemblyStateCreateInfo *ia_state) {
-    memcpy(&m_ia_state, ia_state,
-           sizeof(VkPipelineInputAssemblyStateCreateInfo));
+    m_ia_state = *ia_state;
 }
 
 void VkPipelineObj::SetRasterization(
     const VkPipelineRasterizationStateCreateInfo *rs_state) {
-    memcpy(&m_rs_state, rs_state,
-           sizeof(VkPipelineRasterizationStateCreateInfo));
+    m_rs_state = *rs_state;
 }
+
+void VkPipelineObj::SetTessellation(
+    const VkPipelineTessellationStateCreateInfo *te_state) {
+    m_te_state = *te_state;
+}
+
 
 VkResult VkPipelineObj::CreateVKPipeline(VkPipelineLayout layout,
                                          VkRenderPass render_pass) {
@@ -1314,13 +1318,20 @@ VkResult VkPipelineObj::CreateVKPipeline(VkPipelineLayout layout,
 
     info.renderPass = render_pass;
     info.subpass = 0;
-    info.pTessellationState = NULL;
     info.pInputAssemblyState = &m_ia_state;
     info.pViewportState = &m_vp_state;
     info.pRasterizationState = &m_rs_state;
     info.pMultisampleState = &m_ms_state;
     info.pDepthStencilState = &m_ds_state;
     info.pColorBlendState = &m_cb_state;
+
+    if (m_ia_state.topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST) {
+        m_te_state.sType = VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO;
+        info.pTessellationState = &m_te_state;
+    }
+    else {
+        info.pTessellationState = nullptr;
+    }
 
     return init_try(*m_device, info);
 }

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1280,14 +1280,8 @@ VkResult VkPipelineObj::CreateVKPipeline(VkPipelineLayout layout,
             m_shaderObjs[i]->GetStageCreateInfo();
     }
 
-    if (m_vi_state.vertexAttributeDescriptionCount &&
-        m_vi_state.vertexBindingDescriptionCount) {
-        m_vi_state.sType =
-            VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-        info.pVertexInputState = &m_vi_state;
-    } else {
-        info.pVertexInputState = NULL;
-    }
+    m_vi_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    info.pVertexInputState = &m_vi_state;
 
     info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
     info.pNext = NULL;

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -429,10 +429,9 @@ class VkPipelineObj : public vk_testing::Pipeline {
 
     void SetDepthStencil(const VkPipelineDepthStencilStateCreateInfo *);
     void SetMSAA(const VkPipelineMultisampleStateCreateInfo *ms_state);
-    void
-    SetInputAssembly(const VkPipelineInputAssemblyStateCreateInfo *ia_state);
-    void
-    SetRasterization(const VkPipelineRasterizationStateCreateInfo *rs_state);
+    void SetInputAssembly(const VkPipelineInputAssemblyStateCreateInfo *ia_state);
+    void SetRasterization(const VkPipelineRasterizationStateCreateInfo *rs_state);
+    void SetTessellation(const VkPipelineTessellationStateCreateInfo *te_state);
     void SetViewport(const vector<VkViewport> viewports);
     void SetScissor(const vector<VkRect2D> scissors);
     VkResult CreateVKPipeline(VkPipelineLayout layout,
@@ -446,6 +445,7 @@ class VkPipelineObj : public vk_testing::Pipeline {
     VkPipelineDepthStencilStateCreateInfo m_ds_state;
     VkPipelineViewportStateCreateInfo m_vp_state;
     VkPipelineMultisampleStateCreateInfo m_ms_state;
+    VkPipelineTessellationStateCreateInfo m_te_state;
     vector<VkDynamicState> m_dynamic_state_enables;
     vector<VkViewport> m_viewports;
     vector<VkRect2D> m_scissors;

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -121,6 +121,12 @@ VkPhysicalDeviceMemoryProperties PhysicalDevice::memory_properties() const {
     return info;
 }
 
+VkPhysicalDeviceFeatures PhysicalDevice::features() const {
+    VkPhysicalDeviceFeatures features;
+    vkGetPhysicalDeviceFeatures(handle(), &features);
+    return features;
+}
+
 /*
  * Return list of Global layers available
  */
@@ -307,6 +313,10 @@ void Device::init(std::vector<const char *> &layers,
     dev_info.ppEnabledLayerNames = layers.data();
     dev_info.enabledExtensionCount = extensions.size();
     dev_info.ppEnabledExtensionNames = extensions.data();
+
+    // request all supportable features enabled
+    auto features = phy().features();
+    dev_info.pEnabledFeatures = &features;
 
     init(dev_info);
 }

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -124,6 +124,7 @@ class PhysicalDevice : public internal::Handle<VkPhysicalDevice> {
     VkPhysicalDeviceProperties properties() const;
     VkPhysicalDeviceMemoryProperties memory_properties() const;
     std::vector<VkQueueFamilyProperties> queue_properties() const;
+    VkPhysicalDeviceFeatures features() const;
 
     bool set_memory_type(const uint32_t type_bits, VkMemoryAllocateInfo *info,
                          const VkMemoryPropertyFlags properties,


### PR DESCRIPTION
The array sizes declared needn't match -- and often don't. Also, track whether the `patch` decoration has been applied to the decoration, and require it to match across this interface.

Fixes #120.