### PR TITLE
WIP: Mem ref cleanup

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -579,9 +579,8 @@ static void clear_cmd_buf_and_mem_references(layer_data *dev_data, const VkComma
 
     if (pCBNode) {
         if (pCBNode->pMemObjList.size() > 0) {
-            list<VkDeviceMemory> mem_obj_list = pCBNode->pMemObjList;
-            for (list<VkDeviceMemory>::iterator it = mem_obj_list.begin(); it != mem_obj_list.end(); ++it) {
-                DEVICE_MEM_INFO *pInfo = get_mem_obj_info(dev_data, *it);
+            for (auto mem : pCBNode->pMemObjList) {
+                DEVICE_MEM_INFO *pInfo = get_mem_obj_info(dev_data, mem);
                 if (pInfo) {
                     pInfo->commandBufferBindings.erase(cb);
                 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -771,7 +771,7 @@ static VkBool32 set_mem_binding(layer_data *dev_data, void *dispatch_object, VkD
         if (!pObjBindInfo) {
             skipCall |=
                 log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, type, handle, __LINE__, MEMTRACK_MISSING_MEM_BINDINGS,
-                        "MEM", "In %s, attempting to update Binding of %s Obj(%#" PRIxLEAST64 ") that's not in global list()",
+                        "MEM", "In %s, attempting to update Binding of %s Obj(%#" PRIxLEAST64 ") that's not in global list",
                         object_type_to_string(type), apiName, handle);
         } else {
             // non-null case so should have real mem obj

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -891,7 +891,7 @@ struct GLOBAL_CB_NODE {
     std::unordered_set<VkCommandBuffer> secondaryCommandBuffers;
     // MTMTODO : Scrub these data fields and merge active sets w/ lastBound as appropriate
     vector<std::function<VkBool32()>> validate_functions;
-    list<VkDeviceMemory> pMemObjList; // List container of Mem objs referenced by this CB
+    std::unordered_set<VkDeviceMemory> memObjs;
     vector<std::function<bool(VkQueue)>> eventUpdates;
 };
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -123,7 +123,6 @@ struct MEMORY_RANGE {
 // Data struct for tracking memory object
 struct DEVICE_MEM_INFO {
     void *object;      // Dispatchable object used to create this memory (device of swapchain)
-    uint32_t refCount; // Count of references (obj bindings or CB use)
     bool valid;        // Stores if the memory has valid data or not
     VkDeviceMemory mem;
     VkMemoryAllocateInfo allocInfo;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -143,7 +143,7 @@ struct DEVICE_MEM_INFO {
     VkDeviceMemory mem;
     VkMemoryAllocateInfo allocInfo;
     unordered_set<MT_OBJ_HANDLE_TYPE> objBindings; // objects bound to this memory
-    list<VkCommandBuffer> pCommandBufferBindings; // list container of cmd buffers that reference this mem object
+    unordered_set<VkCommandBuffer> commandBufferBindings; // cmd buffers referencing this memory
     vector<MEMORY_RANGE> bufferRanges;
     vector<MEMORY_RANGE> imageRanges;
     VkImage image; // If memory is bound to image, this will have VkImage handle, else VK_NULL_HANDLE

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -36,10 +36,12 @@
 #include <atomic>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include <memory>
 #include <functional>
 
 using std::vector;
+using std::unordered_set;
 
 #if MTMERGE
 // Mem Tracker ERROR codes
@@ -113,6 +115,20 @@ struct MT_OBJ_HANDLE_TYPE {
     VkDebugReportObjectTypeEXT type;
 };
 
+bool operator==(MT_OBJ_HANDLE_TYPE a, MT_OBJ_HANDLE_TYPE b) noexcept {
+    return a.handle == b.handle && a.type == b.type;
+}
+
+namespace std {
+    template<>
+    struct hash<MT_OBJ_HANDLE_TYPE> {
+        size_t operator()(MT_OBJ_HANDLE_TYPE obj) const noexcept {
+            return hash<uint64_t>()(obj.handle) ^
+                   hash<uint32_t>()(obj.type);
+        }
+    };
+}
+
 struct MEMORY_RANGE {
     uint64_t handle;
     VkDeviceMemory memory;
@@ -126,7 +142,7 @@ struct DEVICE_MEM_INFO {
     bool valid;        // Stores if the memory has valid data or not
     VkDeviceMemory mem;
     VkMemoryAllocateInfo allocInfo;
-    list<MT_OBJ_HANDLE_TYPE> pObjBindings;        // list container of objects bound to this memory
+    unordered_set<MT_OBJ_HANDLE_TYPE> objBindings; // objects bound to this memory
     list<VkCommandBuffer> pCommandBufferBindings; // list container of cmd buffers that reference this mem object
     vector<MEMORY_RANGE> bufferRanges;
     vector<MEMORY_RANGE> imageRanges;


### PR DESCRIPTION
Gets rid of some crazy std::list usage in the GLOBAL_CB_NODE & DEVICE_MEM_INFO structs.

Ignore the first 4 commits -- they are in another PR and just provided a good starting point for this work.