### PR TITLE
Fix loader_unwrap_physical_device() to cast to correct type

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -376,8 +376,8 @@ static inline struct loader_instance *loader_instance(VkInstance instance) {
 
 static inline VkPhysicalDevice
 loader_unwrap_physical_device(VkPhysicalDevice physicalDevice) {
-    struct loader_physical_device *phys_dev =
-        (struct loader_physical_device *)physicalDevice;
+    struct loader_physical_device_tramp *phys_dev =
+        (struct loader_physical_device_tramp *)physicalDevice;
     return phys_dev->phys_dev;
 }
 


### PR DESCRIPTION
The trampoline loader_unwrap_physical_device() utility function was
casting the VkPhysicalDevice parameter to (loader_physical_device*)
instead of (loader_physical_device_tramp*). It worked previously because
it just so happened that the phys_dev member was in the same location in
both structs.