### PR TITLE
Trampoline vkEnumeratePhysicalDevices should use layer-returned physical device count

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -511,7 +511,8 @@ vkEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,
     }
     if (inst->phys_devs)
         loader_heap_free(inst, inst->phys_devs);
-    count = inst->total_gpu_count;
+    count = min(inst->total_gpu_count, *pPhysicalDeviceCount);
+    *pPhysicalDevices = count;
     inst->phys_devs = (struct loader_physical_device_tramp *)loader_heap_alloc(
         inst, count * sizeof(struct loader_physical_device_tramp),
         VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE);


### PR DESCRIPTION
Modify the trampoline vkEnumeratePhysicalDevices() implementation to
enumerate the number of physical devices based on what the top-most
layer reports and not what the terminator_EnumeratePhysicalDevices
counted. This allows intermediate layers to modify the physical device
count.