### PR TITLE
Issue 99, 100, LX459: layers: LX459,GH#99,#100, Fix semaphore reference count

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5342,9 +5342,9 @@ vkQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
         vector<VkSemaphore> semaphoreList;
         for (uint32_t i = 0; i < submit->waitSemaphoreCount; ++i) {
             const VkSemaphore &semaphore = submit->pWaitSemaphores[i];
-            semaphoreList.push_back(semaphore);
             if (dev_data->semaphoreMap[semaphore].signaled) {
                 dev_data->semaphoreMap[semaphore].signaled = 0;
+                dev_data->semaphoreMap[semaphore].in_use.fetch_sub(1);
             } else {
                 skipCall |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                     VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, 0, __LINE__, DRAWSTATE_QUEUE_FORWARD_PROGRESS,
@@ -10645,6 +10645,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkAcquireNextImageKHR(VkDevice device, VkSwapchai
                                "vkAcquireNextImageKHR: Semaphore must not be currently signaled or in a wait state");
         }
         dev_data->semaphoreMap[semaphore].state = MEMTRACK_SEMAPHORE_STATE_SIGNALLED;
+        dev_data->semaphoreMap[semaphore].in_use.fetch_add(1);
     }
     auto fence_data = dev_data->fenceMap.find(fence);
     if (fence_data != dev_data->fenceMap.end()) {


### PR DESCRIPTION
QueueSubmit waitSemaphore refcounts were getting incremented instead of
decremented, resulting in invalid 'semaphore still in use' errors.

Change-Id: I8ac224115b8ee43637b8de4b377750b277cfd22b