### PR TITLE
Integrate SPIRV-Tools validator

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -37,8 +37,9 @@ LOCAL_C_INCLUDES += $(SRC_DIR)/include \
                     $(SRC_DIR)/layers \
                     $(LAYER_DIR)/include \
                     $(SRC_DIR)/loader \
-                    $(SRC_DIR)/../glslang
-LOCAL_STATIC_LIBRARIES += layer_utils
+                    $(SRC_DIR)/../glslang \
+		    $(SRC_DIR)/../spirv-tools/include
+LOCAL_STATIC_LIBRARIES += layer_utils SPIRV-Tools-prebuilt
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR
 LOCAL_LDLIBS    := -llog
 include $(BUILD_SHARED_LIBRARY)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -83,7 +83,6 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../loader
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/vulkan
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${GLSLANG_SPIRV_INCLUDE_DIR}
 )
 
 if (WIN32)
@@ -154,3 +153,8 @@ add_vk_layer(object_tracker object_tracker.cpp vk_layer_table.cpp)
 add_vk_layer(threading threading.cpp thread_check.h vk_layer_table.cpp)
 add_vk_layer(unique_objects unique_objects.cpp vk_layer_table.cpp vk_safe_struct.cpp)
 add_vk_layer(parameter_validation parameter_validation.cpp parameter_validation.h vk_layer_table.cpp)
+
+# Core validation has additional dependencies
+target_include_directories(VkLayer_core_validation PRIVATE ${GLSLANG_SPIRV_INCLUDE_DIR})
+target_include_directories(VkLayer_core_validation PRIVATE ${SPIRV_TOOLS_INCLUDE_DIR})
+target_link_libraries(VkLayer_core_validation ${SPIRV_TOOLS_LIB})

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -60,6 +60,7 @@
 #include "vk_layer_data.h"
 #include "vk_layer_extension_utils.h"
 #include "vk_layer_utils.h"
+#include "spirv-tools/libspirv.h"
 
 #if defined __ANDROID__
 #include <android/log.h>
@@ -913,14 +914,6 @@ static spirv_inst_iter find_entrypoint(shader_module *src, char const *name, VkS
     }
 
     return src->end();
-}
-
-bool shader_is_spirv(VkShaderModuleCreateInfo const *pCreateInfo) {
-    uint32_t *words = (uint32_t *)pCreateInfo->pCode;
-    size_t sizeInWords = pCreateInfo->codeSize / sizeof(uint32_t);
-
-    /* Just validate that the header makes sense. */
-    return sizeInWords >= 5 && words[0] == spv::MagicNumber && words[1] == spv::Version;
 }
 
 static char const *storage_class_name(unsigned sc) {
@@ -8905,10 +8898,23 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateShaderModule(VkDevice dev
                                                                     VkShaderModule *pShaderModule) {
     layer_data *my_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
     bool skip_call = false;
-    if (!shader_is_spirv(pCreateInfo)) {
-        skip_call |= log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT,
-                             /* dev */ 0, __LINE__, SHADER_CHECKER_NON_SPIRV_SHADER, "SC", "Shader is not SPIR-V");
+
+    /* Use SPIRV-Tools validator to try and catch any issues with the module itself */
+    spv_context ctx = spvContextCreate(SPV_ENV_VULKAN_1_0);
+    spv_const_binary_t binary { pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t) };
+    spv_diagnostic diag = nullptr;
+
+    auto result = spvValidate(ctx, &binary, &diag);
+    if (result != SPV_SUCCESS) {
+        skip_call |= log_msg(my_data->report_data,
+                             result == SPV_WARNING ? VK_DEBUG_REPORT_WARNING_BIT_EXT : VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                             VkDebugReportObjectTypeEXT(0), 0,
+                             __LINE__, SHADER_CHECKER_INCONSISTENT_SPIRV, "SC", "SPIR-V module not valid: %s",
+                             diag && diag->error ? diag->error : "(no error text)");
     }
+
+    spvDiagnosticDestroy(diag);
+    spvContextDestroy(ctx);
 
     if (skip_call)
         return VK_ERROR_VALIDATION_FAILED_EXT;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -5795,7 +5795,7 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
 #if SHADER_CHECKER_TESTS
 TEST_F(VkLayerTest, InvalidSPIRVCodeSize) {
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Shader is not SPIR-V");
+                                         "Invalid SPIR-V header");
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -5820,7 +5820,7 @@ TEST_F(VkLayerTest, InvalidSPIRVCodeSize) {
 
 TEST_F(VkLayerTest, InvalidSPIRVMagic) {
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Shader is not SPIR-V");
+                                         "Invalid SPIR-V magic number");
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -5843,9 +5843,11 @@ TEST_F(VkLayerTest, InvalidSPIRVMagic) {
     m_errorMonitor->VerifyFound();
 }
 
+#if 0
+// Not currently covered by SPIRV-Tools validator
 TEST_F(VkLayerTest, InvalidSPIRVVersion) {
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         "Shader is not SPIR-V");
+                                         "Invalid SPIR-V header");
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -5868,6 +5870,7 @@ TEST_F(VkLayerTest, InvalidSPIRVVersion) {
 
     m_errorMonitor->VerifyFound();
 }
+#endif
 
 TEST_F(VkLayerTest, CreatePipelineVertexOutputNotConsumed) {
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,


### PR DESCRIPTION
This integrates the validator from SPIRV-Tools. It replaces the existing `shader_is_spirv` function, and adds many more checks.

DON'T MERGE until #342 is merged.

Disabled one test (SPIR-V header version #, currently not covered by SPIRV-Tools). Will investigate adding support for this in that project.