### PR TITLE
layers: Fix 24 char truncation warnings on VS2015.

### DIFF
--- a/layers/vk_layer_utils.cpp
+++ b/layers/vk_layer_utils.cpp
@@ -568,14 +568,14 @@ VkDeviceSize vk_safe_modulo(VkDeviceSize dividend, VkDeviceSize divisor) {
     return result;
 }
 
-static const char UTF8_ONE_BYTE_CODE = 0xC0;
-static const char UTF8_ONE_BYTE_MASK = 0xE0;
-static const char UTF8_TWO_BYTE_CODE = 0xE0;
-static const char UTF8_TWO_BYTE_MASK = 0xF0;
-static const char UTF8_THREE_BYTE_CODE = 0xF0;
-static const char UTF8_THREE_BYTE_MASK = 0xF8;
-static const char UTF8_DATA_BYTE_CODE = 0x80;
-static const char UTF8_DATA_BYTE_MASK = 0xC0;
+static const char UTF8_ONE_BYTE_CODE = (char)0xC0;
+static const char UTF8_ONE_BYTE_MASK = (char)0xE0;
+static const char UTF8_TWO_BYTE_CODE = (char)0xE0;
+static const char UTF8_TWO_BYTE_MASK = (char)0xF0;
+static const char UTF8_THREE_BYTE_CODE = (char)0xF0;
+static const char UTF8_THREE_BYTE_MASK = (char)0xF8;
+static const char UTF8_DATA_BYTE_CODE = (char)0x80;
+static const char UTF8_DATA_BYTE_MASK = (char)0xC0;
 
 VkStringErrorFlags vk_string_validate(const int max_length, const char *utf8) {
     VkStringErrorFlags result = VK_STRING_ERROR_NONE;


### PR DESCRIPTION
Casts the values to signed char to silence 24 warning C4309 on
VS2015. The warning happens because the values are larger than
what can be represented in a signed char, but the expected
overflow works just fine with VS2015.