### PR TITLE
layers: Fix MSVS noexcept warning in core_validation.

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -34,9 +34,12 @@
 #define HAS_NOEXCEPT
 #endif
 #else
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ * 10 + __GNUC_MINOR__ >= 46 || \
-    defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ * 10 + __GNUC_MINOR__ >= 46
 #define HAS_NOEXCEPT
+#else
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026 && defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS
+#define HAS_NOEXCEPT
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
warning 4577: 'noexcept' used with no exception handling mode specified

In ANGLE we use the _HAS_EXCEPTIONS=0 macro in many places since we build without exceptions. This fixes a warning that occurs in conjunction with this define.