### PR TITLE
Fix regression with dEQP-VK.api.object_management.alloc_callback_fail.device.

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3559,7 +3559,9 @@ VkResult loader_create_device_chain(const struct loader_physical_device_tramp *p
         loader_create_info.pNext = &create_info_disp;
         res = fpCreateDevice(pd->phys_dev, &loader_create_info, pAllocator,
                              &created_device);
-        dev->device = created_device;
+        if (res == VK_SUCCESS) {
+            dev->device = created_device;
+        }
     } else {
         // Couldn't find CreateDevice function!
         return VK_ERROR_INITIALIZATION_FAILED;

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3559,9 +3559,10 @@ VkResult loader_create_device_chain(const struct loader_physical_device_tramp *p
         loader_create_info.pNext = &create_info_disp;
         res = fpCreateDevice(pd->phys_dev, &loader_create_info, pAllocator,
                              &created_device);
-        if (res == VK_SUCCESS) {
-            dev->device = created_device;
+        if (res != VK_SUCCESS) {
+            return res;
         }
+        dev->device = created_device;
     } else {
         // Couldn't find CreateDevice function!
         return VK_ERROR_INITIALIZATION_FAILED;


### PR DESCRIPTION
When the loader vkCreateDevice trampoline code calls down to
vkCreateDevice and it fails don't update the dev->device field with a bogus device
handle.