### PR TITLE
layers: GH241 vkSetEvent should affect queue stageMasks

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -10234,6 +10234,13 @@ VKAPI_ATTR VkResult VKAPI_CALL vkSetEvent(VkDevice device, VkEvent event) {
     dev_data->eventMap[event].needsSignaled = false;
     dev_data->eventMap[event].stageMask = VK_PIPELINE_STAGE_HOST_BIT;
     loader_platform_thread_unlock_mutex(&globalLock);
+    // Host setting event is visible to all queues immediately so update stageMask for any queue that's seen this event
+    for (auto queue_data : dev_data->queueMap) {
+        auto event_entry = queue_data.second.eventToStageMap.find(event);
+        if (event_entry != queue_data.second.eventToStageMap.end()) {
+            event_entry->second |= VK_PIPELINE_STAGE_HOST_BIT;
+        }
+    }
     VkResult result = dev_data->device_dispatch_table->SetEvent(device, event);
     return result;
 }


### PR DESCRIPTION
vkSetEvent may occur asynchronously from cmd buffer execution
and the results of vkSetEvent should be immediately visible
across all queues of a device.

This fix will update any event that a queue has seen so that
its VK_PIPELINE_STAGE_HOST_BIT is set at vkSetEvent() time.