### PR TITLE
Lxml removal and consistent source code generation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -88,14 +88,6 @@ Windows 7+ with additional required software packages:
   - Ensure the pip module is installed (it should be by default)
   - Need python3.3 or later to get the Windows py.exe launcher that is used to get python3 rather than python2 if both are installed on Windows
   - 32 bit python works
-- Python lxml package must be installed
-  - Download the lxml package from
-        http://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml
-        32-bit latest for Python 3.5 is: lxml-3.5.0-cp35-none-win32.whl
-        64-bit latest for Python 3.5 is: lxml-3.5.0-cp35-none-win_amd64.whl
-  - The package can be installed with pip as follows:
-        pip install lxml-3.5.0-cp35-none-win32.whl
-        If pip is not in your path, you can find it at $PYTHON_HOME\Scripts\pip.exe, where PYTHON_HOME is the folder where you installed Python.
 - Git (from http://git-scm.com/download/win).
   - Note: If you use Cygwin, you can normally use Cygwin's "git.exe".  However, in order to use the "update_external_sources.bat" script, you must have this version.
   - Tell the installer to allow it to be used for "Developer Prompt" as well as "Git Bash".
@@ -175,10 +167,6 @@ export PATH=$HOME/homebrew/bin:$PATH
 brew install cmake
 brew install python
 brew install python3
-pip install --upgrade pip
-pip install lxml
-pip3.5 install --upgrade pip
-pip3.5 install lxm
 ```
 ### Build steps for Android
 Use the following to ensure the Android build works.

--- a/generator.py
+++ b/generator.py
@@ -23,7 +23,7 @@
 
 import os,re,sys
 from collections import namedtuple
-from lxml import etree
+import xml.etree.ElementTree as etree
 
 def write( *args, **kwargs ):
     file = kwargs.pop('file',sys.stdout)
@@ -32,7 +32,7 @@ def write( *args, **kwargs ):
     file.write( end )
 
 # noneStr - returns string argument, or "" if argument is None.
-# Used in converting lxml Elements into text.
+# Used in converting etree Elements into text.
 #   str - string to convert
 def noneStr(str):
     if (str):
@@ -679,7 +679,7 @@ class OutputGenerator:
         # For typedefs, add (APIENTRY *<name>) around the name and
         #   use the PFN_cmdnameproc naming convention.
         # Done by walking the tree for <proto> element by element.
-        # lxml.etree has elem.text followed by (elem[i], elem[i].tail)
+        # etree has elem.text followed by (elem[i], elem[i].tail)
         #   for each child element and any following text
         # Leading text
         pdecl += noneStr(proto.text)
@@ -3013,7 +3013,15 @@ class ParamCheckerOutputGenerator(OutputGenerator):
                     #if value not in self.stypes:
                     #    print('WARNING: {} is not part of the VkStructureType enumeration [{}]'.format(value, typeName))
                 else:
-                    value = '<ERROR>'
+                    value = typeName
+                    # Remove EXT
+                    value = re.sub('EXT', '', value)
+                    # Add underscore between lowercase then uppercase
+                    value = re.sub('([a-z0-9])([A-Z])', r'\1_\2', value)
+                    # Change to uppercase
+                    value = value.upper()
+                    # Add STRUCTURE_TYPE_
+                    value = re.sub('VK_', 'VK_STRUCTURE_TYPE_', value)
                 # Store the required type value
                 self.structTypes[typeName] = self.StructType(name=name, value=value)
             #

--- a/reg.py
+++ b/reg.py
@@ -22,7 +22,7 @@
 # MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
 import io,os,re,string,sys
-from lxml import etree
+import xml.etree.ElementTree as etree
 
 # matchAPIProfile - returns whether an API and profile
 #   being generated matches an element's profile
@@ -77,7 +77,7 @@ def matchAPIProfile(api, profile, elem):
 #   required - should this feature be defined during header generation
 #     (has it been removed by a profile or version)?
 #   declared - has this feature been defined already?
-#   elem - lxml.etree Element for this feature
+#   elem - etree Element for this feature
 #   resetState() - reset required/declared to initial values. Used
 #     prior to generating a new API interface.
 class BaseInfo:

--- a/vk-layer-generate.py
+++ b/vk-layer-generate.py
@@ -754,7 +754,7 @@ class ObjectTrackerSubcommand(Subcommand):
     # for each member of struct_type
     #     add objs in obj_list to obj_set
     #     call self for structs
-        for m in vk_helper.struct_dict[struct_type]:
+        for m in sorted(vk_helper.struct_dict[struct_type]):
             if vk_helper.struct_dict[struct_type][m]['type'] in obj_list:
                 obj_set.add(vk_helper.struct_dict[struct_type][m]['type'])
             elif vk_helper.is_type(vk_helper.struct_dict[struct_type][m]['type'], 'struct'):
@@ -913,8 +913,8 @@ class ObjectTrackerSubcommand(Subcommand):
         #  dispatchable object type, we have a corresponding validate_* function
         #  for that object and all non-dispatchable objects that are used in API
         #  calls with that dispatchable object.
-        procs_txt.append('//%s' % str(obj_use_dict))
-        for do in obj_use_dict:
+        procs_txt.append('//%s' % str(sorted(obj_use_dict)))
+        for do in sorted(obj_use_dict):
             name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', do)
             name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()[3:]
             # First create validate_* func for disp obj
@@ -930,7 +930,7 @@ class ObjectTrackerSubcommand(Subcommand):
             procs_txt.append('    return VK_FALSE;')
             procs_txt.append('}')
             procs_txt.append('')
-            for o in obj_use_dict[do]:
+            for o in sorted(obj_use_dict[do]):
                 if o == do: # We already generated this case above so skip here
                     continue
                 name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', o)
@@ -1135,7 +1135,7 @@ class ObjectTrackerSubcommand(Subcommand):
                 full_name = '%s%s' % (prefix, name)
                 null_obj_ok = 'false'
                 # If a valid null param is defined for this func and we have a match, allow NULL
-                if func_name in valid_null_dict and True in [name in pn for pn in valid_null_dict[func_name]]:
+                if func_name in valid_null_dict and True in [name in pn for pn in sorted(valid_null_dict[func_name])]:
                     null_obj_ok = 'true'
                 if (array_index > 0) or '' != array:
                     tmp_pre = self._dereference_conditionally(indent, prefix, type_name, full_name)
@@ -1316,7 +1316,7 @@ class ObjectTrackerSubcommand(Subcommand):
                 if not mutex_unlock:
                     using_line += '%sloader_platform_thread_lock_mutex(&objLock);\n' % (indent)
                     mutex_unlock = True
-                using_line += '// objects to validate: %s\n' % str(struct_uses)
+                using_line += '// objects to validate: %s\n' % str(sorted(struct_uses))
                 using_line += self._gen_obj_validate_code(struct_uses, obj_type_mapping, proto.name, valid_null_object_names, param0_name, '    ', '', 0)
             if mutex_unlock:
                 using_line += '%sloader_platform_thread_unlock_mutex(&objLock);\n' % (indent)
@@ -1564,15 +1564,15 @@ class UniqueObjectsSubcommand(Subcommand):
         (struct_uses, local_decls) = get_object_uses(vulkan.object_non_dispatch_list, proto.params[1:last_param_index])
 
         if len(struct_uses) > 0:
-            pre_call_txt += '// STRUCT USES:%s\n' % struct_uses
+            pre_call_txt += '// STRUCT USES:%s\n' % sorted(struct_uses)
             if len(local_decls) > 0:
-                pre_call_txt += '//LOCAL DECLS:%s\n' % local_decls
+                pre_call_txt += '//LOCAL DECLS:%s\n' % sorted(local_decls)
             if destroy_func: # only one object
-                for del_obj in struct_uses:
+                for del_obj in sorted(struct_uses):
                     pre_call_txt += '%s%s local_%s = %s;\n' % (indent, struct_uses[del_obj], del_obj, del_obj)
             (pre_decl, pre_code, post_code) = self._gen_obj_code(struct_uses, local_decls, '    ', '', 0, set(), True)
             # This is a bit hacky but works for now. Need to decl local versions of top-level structs
-            for ld in local_decls:
+            for ld in sorted(local_decls):
                 init_null_txt = 'NULL';
                 if '*' not in local_decls[ld]:
                     init_null_txt = '{}';

--- a/vk-layer-generate.py
+++ b/vk-layer-generate.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 #
 # VK
 #


### PR DESCRIPTION
These patches change from using lxml to python's xml.etree.
That removes a dependency on lxml.
There is also a patch that changes the generated code to have a consistent order.
Before that patch the generated code would vary between builds.
Finally, there is a removal of a unicode header that crept into vk-layer-generate.py.