### PR TITLE
Fix for GH issues 99 and 100.

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5420,7 +5420,19 @@ static inline void removeInFlightCmdBuffer(layer_data *dev_data, VkCommandBuffer
             if ((q != queue) &&
                 (dev_data->queueMap[q].inFlightCmdBuffers.find(cmd_buffer) != dev_data->queueMap[q].inFlightCmdBuffers.end())) {
                 dev_data->globalInFlightCmdBuffers.insert(cmd_buffer);
-                break;
+                return;
+            }
+        }
+    }
+    // If cmdbuffer was removed from inFlight set, remove linked command buffers also
+    GLOBAL_CB_NODE *pCb = dev_data->commandBufferMap[cmd_buffer];
+    if (pCb) {
+        for (auto semaphore : pCb->semaphores) {
+            auto semaphoreNode = dev_data->semaphoreMap.find(semaphore);
+            if (semaphoreNode != dev_data->semaphoreMap.end()) {
+                for (auto cb : semaphoreNode->second.linkedCmdBuffers) {
+                    dev_data->globalInFlightCmdBuffers.erase(cb);
+                }
             }
         }
     }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -601,6 +601,9 @@ class FENCE_NODE : public BASE_NODE {
     FENCE_NODE() : queue(NULL), needsSignaled(VK_FALSE){};
 };
 
+// Forward reference
+struct GLOBAL_CB_NODE;
+
 class SEMAPHORE_NODE : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
@@ -608,7 +611,7 @@ class SEMAPHORE_NODE : public BASE_NODE {
     SemaphoreState state;
     VkQueue queue;
     // Track command buffers linked by semaphores
-    vector<VkCommandBuffer> linkedCmdBuffers;
+    std::vector<GLOBAL_CB_NODE *> linkedCmdBuffers;
 };
 
 class EVENT_NODE : public BASE_NODE {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -607,6 +607,8 @@ class SEMAPHORE_NODE : public BASE_NODE {
     uint32_t signaled;
     SemaphoreState state;
     VkQueue queue;
+    // Track command buffers linked by semaphores
+    vector<VkCommandBuffer> linkedCmdBuffers;
 };
 
 class EVENT_NODE : public BASE_NODE {


### PR DESCRIPTION
This corner case occurs because command buffers and semaphores are cleaned up through fence references, but QueueSubmit calls does not require fences so the refs were left hanging.  Dominik, can you take a look?  It passes your app here, but I'm interested in more complicated QueueSubmit patterns you may have access to.  