### PR TITLE
layers: Add fix for lx172 to catch invalid line widths.

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -1555,6 +1555,7 @@ static void demo_prepare_pipeline(struct demo *demo) {
     rs.depthClampEnable = VK_FALSE;
     rs.rasterizerDiscardEnable = VK_FALSE;
     rs.depthBiasEnable = VK_FALSE;
+    rs.lineWidth = 1.0f;
 
     memset(&cb, 0, sizeof(cb));
     cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;

--- a/demos/tri.c
+++ b/demos/tri.c
@@ -1316,6 +1316,7 @@ static void demo_prepare_pipeline(struct demo *demo) {
     rs.depthClampEnable = VK_FALSE;
     rs.rasterizerDiscardEnable = VK_FALSE;
     rs.depthBiasEnable = VK_FALSE;
+    rs.lineWidth = 1.0f;
 
     memset(&cb, 0, sizeof(cb));
     cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;


### PR DESCRIPTION
Validate line width in both vkCreateGraphicsPipelines and in
vkCmdSetLineWidth.  Also, add a warning in vkCmdSetLineWidth
if the user calls it but doesn't enable dynamic line width.

Change-Id: I62118da9cb5282fcc22b1506e9be2db82b5f4a40