### PR TITLE
Remove the ICD and Layers search path for Windows

### DIFF
--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -254,10 +254,10 @@ using namespace std;
 #define DEFAULT_VK_REGISTRY_HIVE HKEY_LOCAL_MACHINE
 #define DEFAULT_VK_DRIVERS_INFO "SOFTWARE\\Khronos\\Vulkan\\Drivers"
 // TODO: Are these the correct paths
-#define DEFAULT_VK_DRIVERS_PATH "C:\\Windows\\System32;C:\\Windows\\SysWow64"
+#define DEFAULT_VK_DRIVERS_PATH ""
 #define DEFAULT_VK_ELAYERS_INFO "SOFTWARE\\Khronos\\Vulkan\\ExplicitLayers"
 #define DEFAULT_VK_ILAYERS_INFO "SOFTWARE\\Khronos\\Vulkan\\ImplicitLayers"
-#define DEFAULT_VK_LAYERS_PATH "C:\\Windows\\System32;C:\\Windows\\SysWow64"
+#define DEFAULT_VK_LAYERS_PATH ""
 #define LAYERS_PATH_ENV "VK_LAYER_PATH"
 #define HOME_VK_DRIVERS_INFO ""
 #define HOME_VK_ELAYERS_INFO ""


### PR DESCRIPTION
This makes it more like Linux which leaves it up to the system
LoadLibrary() call to find the .dll as specified in the .json files.
Hard-coding "C:" or any other search path creates the possibility of
picking up the wrong .dll. The LoadLibrary() implementation does the
right thing without having to search in its behalf and give it a full path. If the .json wanted to use a full path it would have specified that in the first place. No need for the loader to do any searching.

This fixes a bug with the loader where a system may have more than 1 OS installation and the in use installation is installed on say E:, but there is also an install in C: too, which we're not booted into. By hard-coding "C:\" in the search path the loader picks up the other OS installation's Vulkan ICD, which is not what the .json of the current OS expected.
