### PR TITLE
Cross platform fixes

### DIFF
--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -49,14 +49,14 @@ cd ..\..
 xcopy /s gradle-templates\*   generated\gradle-build\
 for %%G in (core_validation device_limits image parameter_validation swapchain threading) Do (
     copy ..\layers\%%G.cpp   generated\layer-src\%%G
-    echo apply from: "../win.template.gradle"  > generated\gradle-build\%%G\build.gradle
+    echo apply from: "../common.gradle"  > generated\gradle-build\%%G\build.gradle
 )
 copy generated\include\object_tracker.cpp   generated\layer-src\object_tracker
-echo apply from: "../win.template.gradle"  > generated\gradle-build\object_tracker\build.gradle
+echo apply from: "../common.gradle"  > generated\gradle-build\object_tracker\build.gradle
 copy generated\include\unique_objects.cpp   generated\layer-src\unique_objects
 copy generated\include\vk_safe_struct.cpp generated\layer-src\core_validation\vk_safe_struct.cpp
 move generated\include\vk_safe_struct.cpp generated\layer-src\unique_objects\vk_safe_struct.cpp
-echo apply from: "../win.template.gradle"  > generated\gradle-build\unique_objects\build.gradle
+echo apply from: "../common.gradle"  > generated\gradle-build\unique_objects\build.gradle
 
 del  /f /q generated\include\object_tracker.cpp
 del  /f /q generated\include\unique_objects.cpp

--- a/build-android/gradle-templates/common.gradle
+++ b/build-android/gradle-templates/common.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'com.android.model.native'
 
+// To detect host operating system
+import org.apache.tools.ant.taskdefs.condition.Os
+
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 def ndkDir = properties.getProperty('ndk.dir')
@@ -19,10 +22,19 @@ model {
 
     android.ndk {
         moduleName = "VkLayer_${project.name}"
-        toolchain = "clang"
+
+        // This is a workaround for clang problems on Windows
+        // http://llvm.org/bugs/show_bug.cgi?id=27396
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            toolchain = "gcc"
+        } else {
+            toolchain = "clang"
+            cppFlags.addAll(["-Werror"])
+        }
+
         stl = "gnustl_static"
         ldLibs.addAll(["log", "android"])
-        cppFlags.addAll(["-std=c++11", "-DVK_PROTOTYPES", "-Wall", "-Werror",
+        cppFlags.addAll(["-std=c++11", "-DVK_PROTOTYPES", "-Wall",
                          "-Wno-unused-function", "-Wno-unused-const-variable",
                          "-DVK_USE_PLATFORM_ANDROID_KHR"])
         cppFlags.addAll(["-I${file("../../../../layers")}".toString(),

--- a/vk_helper.py
+++ b/vk_helper.py
@@ -393,6 +393,36 @@ def get_struct_name_from_struct_type(struct_type):
 
     return struct_name
 
+# Emit an ifdef if incoming func matches a platform identifier
+def add_platform_wrapper_entry(list, func):
+    if (re.match(r'.*Xlib.*', func)):
+        list.append("#ifdef VK_USE_PLATFORM_XLIB_KHR")
+    if (re.match(r'.*Xcb.*', func)):
+        list.append("#ifdef VK_USE_PLATFORM_XCB_KHR")
+    if (re.match(r'.*Wayland.*', func)):
+        list.append("#ifdef VK_USE_PLATFORM_WAYLAND_KHR")
+    if (re.match(r'.*Mir.*', func)):
+        list.append("#ifdef VK_USE_PLATFORM_MIR_KHR")
+    if (re.match(r'.*Android.*', func)):
+        list.append("#ifdef VK_USE_PLATFORM_ANDROID_KHR")
+    if (re.match(r'.*Win32.*', func)):
+        list.append("#ifdef VK_USE_PLATFORM_WIN32_KHR")
+
+# Emit an endif if incoming func matches a platform identifier
+def add_platform_wrapper_exit(list, func):
+    if (re.match(r'.*Xlib.*', func)):
+        list.append("#endif //VK_USE_PLATFORM_XLIB_KHR")
+    if (re.match(r'.*Xcb.*', func)):
+        list.append("#endif //VK_USE_PLATFORM_XCB_KHR")
+    if (re.match(r'.*Wayland.*', func)):
+        list.append("#endif //VK_USE_PLATFORM_WAYLAND_KHR")
+    if (re.match(r'.*Mir.*', func)):
+        list.append("#endif //VK_USE_PLATFORM_MIR_KHR")
+    if (re.match(r'.*Android.*', func)):
+        list.append("#endif //VK_USE_PLATFORM_ANDROID_KHR")
+    if (re.match(r'.*Win32.*', func)):
+        list.append("#endif //VK_USE_PLATFORM_WIN32_KHR")
+
 # class for writing common file elements
 # Here's how this class lays out a file:
 #  COPYRIGHT
@@ -851,25 +881,12 @@ class StructWrapperGen:
         # XXX - REMOVE this comment
         lineinfo = sourcelineinfo()
         sh_funcs.append('%s' % lineinfo.get())
-        exclude_struct_list = ['VkAndroidSurfaceCreateInfoKHR',
-                               'VkMirSurfaceCreateInfoKHR',
-                               'VkWaylandSurfaceCreateInfoKHR',
-                               'VkXlibSurfaceCreateInfoKHR']
-        if sys.platform == 'win32':
-            exclude_struct_list.append('VkXcbSurfaceCreateInfoKHR')
-        else:
-            exclude_struct_list.append('VkWin32SurfaceCreateInfoKHR')
         for s in sorted(self.struct_dict):
-            if (typedef_fwd_dict[s] not in exclude_struct_list):
-                if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#ifdef VK_USE_PLATFORM_XCB_KHR")
-                if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#ifdef VK_USE_PLATFORM_WIN32_KHR")
-                sh_funcs.append('string %s(const %s* pStruct, const string prefix);' % (self._get_sh_func_name(s), typedef_fwd_dict[s]))
-                if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#endif //VK_USE_PLATFORM_WIN32_KHR")
-                if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#endif //VK_USE_PLATFORM_XCB_KHR")
+            # Wrap this in platform check since it may contain undefined structs or functions
+            add_platform_wrapper_entry(sh_funcs, typedef_fwd_dict[s])
+            sh_funcs.append('string %s(const %s* pStruct, const string prefix);' % (self._get_sh_func_name(s), typedef_fwd_dict[s]))
+            add_platform_wrapper_exit(sh_funcs, typedef_fwd_dict[s])
+
         sh_funcs.append('\n')
         sh_funcs.append('%s' % lineinfo.get())
         for s in sorted(self.struct_dict):
@@ -881,13 +898,11 @@ class StructWrapperGen:
                     # TODO: This is a tmp workaround
                     if 'ppActiveLayerNames' not in self.struct_dict[s][m]['name']:
                         stp_list.append(self.struct_dict[s][m])
-            if (typedef_fwd_dict[s] in exclude_struct_list):
-                continue
             sh_funcs.append('%s' % lineinfo.get())
-            if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                sh_funcs.append("#ifdef VK_USE_PLATFORM_XCB_KHR")
-            if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                sh_funcs.append("#ifdef VK_USE_PLATFORM_WIN32_KHR")
+
+            # Wrap this in platform check since it may contain undefined structs or functions
+            add_platform_wrapper_entry(sh_funcs, typedef_fwd_dict[s])
+
             sh_funcs.append('string %s(const %s* pStruct, const string prefix)\n{' % (self._get_sh_func_name(s), typedef_fwd_dict[s]))
             sh_funcs.append('%s' % lineinfo.get())
             indent = '    '
@@ -1085,10 +1100,10 @@ class StructWrapperGen:
             sh_funcs.append('%s' % lineinfo.get())
             sh_funcs.append('    final_str = %s;' % final_str)
             sh_funcs.append('    return final_str;\n}')
-            if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                sh_funcs.append("#endif //VK_USE_PLATFORM_WIN32_KHR")
-            if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                sh_funcs.append("#endif //VK_USE_PLATFORM_XCB_KHR")
+
+            # End of platform wrapped section
+            add_platform_wrapper_exit(sh_funcs, typedef_fwd_dict[s])
+
         # Add function to return a string value for input void*
         sh_funcs.append('%s' % lineinfo.get())
         sh_funcs.append("string string_convert_helper(const void* toString, const string prefix)\n{")
@@ -1282,33 +1297,19 @@ class StructWrapperGen:
     def _generateValidateHelperFunctions(self):
         sh_funcs = []
         # We do two passes, first pass just generates prototypes for all the functsions
-        exclude_struct_list = ['VkAndroidSurfaceCreateInfoKHR',
-                               'VkMirSurfaceCreateInfoKHR',
-                               'VkWaylandSurfaceCreateInfoKHR',
-                               'VkXlibSurfaceCreateInfoKHR']
-        if sys.platform == 'win32':
-            exclude_struct_list.append('VkXcbSurfaceCreateInfoKHR')
-        else:
-            exclude_struct_list.append('VkWin32SurfaceCreateInfoKHR')
         for s in sorted(self.struct_dict):
-            if (typedef_fwd_dict[s] not in exclude_struct_list):
-                if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#ifdef VK_USE_PLATFORM_XCB_KHR")
-                if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#ifdef VK_USE_PLATFORM_WIN32_KHR")
-                sh_funcs.append('uint32_t %s(const %s* pStruct);' % (self._get_vh_func_name(s), typedef_fwd_dict[s]))
-                if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#endif //VK_USE_PLATFORM_WIN32_KHR")
-                if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#endif //VK_USE_PLATFORM_XCB_KHR")
+
+            # Wrap this in platform check since it may contain undefined structs or functions
+            add_platform_wrapper_entry(sh_funcs, typedef_fwd_dict[s])
+            sh_funcs.append('uint32_t %s(const %s* pStruct);' % (self._get_vh_func_name(s), typedef_fwd_dict[s]))
+            add_platform_wrapper_exit(sh_funcs, typedef_fwd_dict[s])
+
         sh_funcs.append('\n')
         for s in sorted(self.struct_dict):
-            if (typedef_fwd_dict[s] in exclude_struct_list):
-                continue
-            if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                sh_funcs.append("#ifdef VK_USE_PLATFORM_XCB_KHR")
-            if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                sh_funcs.append("#ifdef VK_USE_PLATFORM_WIN32_KHR")
+
+            # Wrap this in platform check since it may contain undefined structs or functions
+            add_platform_wrapper_entry(sh_funcs, typedef_fwd_dict[s])
+
             sh_funcs.append('uint32_t %s(const %s* pStruct)\n{' % (self._get_vh_func_name(s), typedef_fwd_dict[s]))
             for m in sorted(self.struct_dict[s]):
                 # TODO : Need to handle arrays of enums like in VkRenderPassCreateInfo struct
@@ -1321,10 +1322,9 @@ class StructWrapperGen:
                     else:
                         sh_funcs.append('    if (!%s((const %s*)&pStruct->%s))\n        return 0;' % (self._get_vh_func_name(self.struct_dict[s][m]['type']), self.struct_dict[s][m]['type'], self.struct_dict[s][m]['name']))
             sh_funcs.append("    return 1;\n}")
-            if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                sh_funcs.append("#endif //VK_USE_PLATFORM_WIN32_KHR")
-            if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                sh_funcs.append("#endif //VK_USE_PLATFORM_XCB_KHR")
+
+            # End of platform wrapped section
+            add_platform_wrapper_exit(sh_funcs, typedef_fwd_dict[s])
 
         return "\n".join(sh_funcs)
 
@@ -1341,42 +1341,24 @@ class StructWrapperGen:
     def _generateSizeHelperFunctions(self):
         sh_funcs = []
         # just generates prototypes for all the functions
-        exclude_struct_list = ['VkAndroidSurfaceCreateInfoKHR',
-                               'VkMirSurfaceCreateInfoKHR',
-                               'VkWaylandSurfaceCreateInfoKHR',
-                               'VkXlibSurfaceCreateInfoKHR']
-        if sys.platform == 'win32':
-            exclude_struct_list.append('VkXcbSurfaceCreateInfoKHR')
-        else:
-            exclude_struct_list.append('VkWin32SurfaceCreateInfoKHR')
         for s in sorted(self.struct_dict):
-            if (typedef_fwd_dict[s] not in exclude_struct_list):
-                if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#ifdef VK_USE_PLATFORM_XCB_KHR")
-                if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#ifdef VK_USE_PLATFORM_WIN32_KHR")
-                sh_funcs.append('size_t %s(const %s* pStruct);' % (self._get_size_helper_func_name(s), typedef_fwd_dict[s]))
-                if (re.match(r'.*Win32.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#endif //VK_USE_PLATFORM_WIN32_KHR")
-                if (re.match(r'.*Xcb.*', typedef_fwd_dict[s])):
-                    sh_funcs.append("#endif //VK_USE_PLATFORM_XCB_KHR")
+
+            # Wrap this in platform check since it may contain undefined structs or functions
+            add_platform_wrapper_entry(sh_funcs, typedef_fwd_dict[s])
+            sh_funcs.append('size_t %s(const %s* pStruct);' % (self._get_size_helper_func_name(s), typedef_fwd_dict[s]))
+            add_platform_wrapper_exit(sh_funcs, typedef_fwd_dict[s])
+
         return "\n".join(sh_funcs)
 
 
     def _generateSizeHelperFunctionsC(self):
         sh_funcs = []
         # generate function definitions
-        exclude_struct_list = ['VkAndroidSurfaceCreateInfoKHR',
-                               'VkMirSurfaceCreateInfoKHR',
-                               'VkWaylandSurfaceCreateInfoKHR',
-                               'VkXlibSurfaceCreateInfoKHR']
-        if sys.platform == 'win32':
-            exclude_struct_list.append('VkXcbSurfaceCreateInfoKHR')
-        else:
-            exclude_struct_list.append('VkWin32SurfaceCreateInfoKHR')
         for s in sorted(self.struct_dict):
-            if (typedef_fwd_dict[s] in exclude_struct_list):
-                continue
+
+            # Wrap this in platform check since it may contain undefined structs or functions
+            add_platform_wrapper_entry(sh_funcs, typedef_fwd_dict[s])
+
             skip_list = [] # Used when struct elements need to be skipped because size already accounted for
             sh_funcs.append('size_t %s(const %s* pStruct)\n{' % (self._get_size_helper_func_name(s), typedef_fwd_dict[s]))
             indent = '    '
@@ -1434,6 +1416,10 @@ class StructWrapperGen:
             indent = '    '
             sh_funcs.append('%s}' % (indent))
             sh_funcs.append("%sreturn structSize;\n}" % (indent))
+
+            # End of platform wrapped section
+            add_platform_wrapper_exit(sh_funcs, typedef_fwd_dict[s])
+
         # Now generate generic functions to loop over entire struct chain (or just handle single generic structs)
         if '_debug_' not in self.header_filename:
             for follow_chain in [True, False]:


### PR DESCRIPTION
These changes allow us to run android-generate on one platform, use the result on another.  For instance, run android-generate.sh on Linux, copy the result over to Windows, and it works.

Builds on OSX, Linux, Windows.
Tested on Android and Linux.
I need help testing on Windows.