### PR TITLE
layers: Break out VkDescriptorSetLayout code into its own class

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -46,41 +46,22 @@
 #define MTMERGE 1
 
 #pragma once
+#include "core_validation_error_enums.h"
+#include "descriptor_sets.h"
+#include "vk_layer_logging.h"
 #include "vk_safe_struct.h"
 #include "vulkan/vk_layer.h"
 #include <atomic>
-#include <vector>
+#include <functional>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
-#include <memory>
-#include <functional>
+#include <vector>
 
 using std::vector;
 using std::unordered_set;
 
 #if MTMERGE
-// Mem Tracker ERROR codes
-typedef enum _MEM_TRACK_ERROR {
-    MEMTRACK_NONE,                         // Used for INFO & other non-error messages
-    MEMTRACK_INVALID_CB,                   // Cmd Buffer invalid
-    MEMTRACK_INVALID_MEM_OBJ,              // Invalid Memory Object
-    MEMTRACK_INVALID_ALIASING,             // Invalid Memory Aliasing
-    MEMTRACK_INVALID_LAYOUT,               // Invalid Layout
-    MEMTRACK_INTERNAL_ERROR,               // Bug in Mem Track Layer internal data structures
-    MEMTRACK_FREED_MEM_REF,                // MEM Obj freed while it still has obj and/or CB refs
-    MEMTRACK_MEM_OBJ_CLEAR_EMPTY_BINDINGS, // Clearing bindings on mem obj that doesn't have any bindings
-    MEMTRACK_MISSING_MEM_BINDINGS,         // Trying to retrieve mem bindings, but none found (may be internal error)
-    MEMTRACK_INVALID_OBJECT,               // Attempting to reference generic VK Object that is invalid
-    MEMTRACK_MEMORY_BINDING_ERROR,         // Error during one of many calls that bind memory to object or CB
-    MEMTRACK_MEMORY_LEAK,                  // Failure to call vkFreeMemory on Mem Obj prior to DestroyDevice
-    MEMTRACK_INVALID_STATE,                // Memory not in the correct state
-    MEMTRACK_RESET_CB_WHILE_IN_FLIGHT,     // vkResetCommandBuffer() called on a CB that hasn't completed
-    MEMTRACK_INVALID_FENCE_STATE,          // Invalid Fence State signaled or used
-    MEMTRACK_REBIND_OBJECT,                // Non-sparse object bindings are immutable
-    MEMTRACK_INVALID_USAGE_FLAG,           // Usage flags specified at image/buffer create conflict w/ use of object
-    MEMTRACK_INVALID_MAP,                  // Size flag specified at alloc is too small for mapping range
-} MEM_TRACK_ERROR;
-
 struct MemRange {
     VkDeviceSize offset;
     VkDeviceSize size;
@@ -182,201 +163,6 @@ struct MT_SWAP_CHAIN_INFO {
 };
 
 #endif
-// Draw State ERROR codes
-typedef enum _DRAW_STATE_ERROR {
-    // TODO: Remove the comments here or expand them. There isn't any additional information in the
-    // comments than in the name in almost all cases.
-    DRAWSTATE_NONE,                          // Used for INFO & other non-error messages
-    DRAWSTATE_INTERNAL_ERROR,                // Error with DrawState internal data structures
-    DRAWSTATE_NO_PIPELINE_BOUND,             // Unable to identify a bound pipeline
-    DRAWSTATE_INVALID_POOL,                  // Invalid DS pool
-    DRAWSTATE_INVALID_SET,                   // Invalid DS
-    DRAWSTATE_INVALID_RENDER_AREA,           // Invalid renderArea
-    DRAWSTATE_INVALID_LAYOUT,                // Invalid DS layout
-    DRAWSTATE_INVALID_IMAGE_LAYOUT,          // Invalid Image layout
-    DRAWSTATE_INVALID_PIPELINE,              // Invalid Pipeline handle referenced
-    DRAWSTATE_INVALID_PIPELINE_LAYOUT,       // Invalid PipelineLayout
-    DRAWSTATE_INVALID_PIPELINE_CREATE_STATE, // Attempt to create a pipeline
-                                             // with invalid state
-    DRAWSTATE_INVALID_COMMAND_BUFFER,        // Invalid CommandBuffer referenced
-    DRAWSTATE_INVALID_BARRIER,               // Invalid Barrier
-    DRAWSTATE_INVALID_BUFFER,                // Invalid Buffer
-    DRAWSTATE_INVALID_QUERY,                 // Invalid Query
-    DRAWSTATE_INVALID_FENCE,                 // Invalid Fence
-    DRAWSTATE_INVALID_SEMAPHORE,             // Invalid Semaphore
-    DRAWSTATE_INVALID_EVENT,                 // Invalid Event
-    DRAWSTATE_VTX_INDEX_OUT_OF_BOUNDS,       // binding in vkCmdBindVertexData() too
-                                             // large for PSO's
-                                             // pVertexBindingDescriptions array
-    DRAWSTATE_VTX_INDEX_ALIGNMENT_ERROR,     // binding offset in
-                                             // vkCmdBindIndexBuffer() out of
-                                             // alignment based on indexType
-    // DRAWSTATE_MISSING_DOT_PROGRAM,              // No "dot" program in order
-    // to generate png image
-    DRAWSTATE_OUT_OF_MEMORY,                          // malloc failed
-    DRAWSTATE_INVALID_DESCRIPTOR_SET,                 // Descriptor Set handle is unknown
-    DRAWSTATE_DESCRIPTOR_TYPE_MISMATCH,               // Type in layout vs. update are not the
-                                                      // same
-    DRAWSTATE_DESCRIPTOR_STAGEFLAGS_MISMATCH,         // StageFlags in layout are not
-                                                      // the same throughout a single
-                                                      // VkWriteDescriptorSet update
-    DRAWSTATE_DESCRIPTOR_UPDATE_OUT_OF_BOUNDS,        // Descriptors set for update out
-                                                      // of bounds for corresponding
-                                                      // layout section
-    DRAWSTATE_DESCRIPTOR_POOL_EMPTY,                  // Attempt to allocate descriptor from a
-                                                      // pool with no more descriptors of that
-                                                      // type available
-    DRAWSTATE_CANT_FREE_FROM_NON_FREE_POOL,           // Invalid to call
-                                                      // vkFreeDescriptorSets on Sets
-                                                      // allocated from a NON_FREE Pool
-    DRAWSTATE_INVALID_UPDATE_INDEX,                   // Index of requested update is invalid for
-                                                      // specified descriptors set
-    DRAWSTATE_INVALID_UPDATE_STRUCT,                  // Struct in DS Update tree is of invalid
-                                                      // type
-    DRAWSTATE_NUM_SAMPLES_MISMATCH,                   // Number of samples in bound PSO does not
-                                                      // match number in FB of current RenderPass
-    DRAWSTATE_NO_END_COMMAND_BUFFER,                  // Must call vkEndCommandBuffer() before
-                                                      // QueueSubmit on that commandBuffer
-    DRAWSTATE_NO_BEGIN_COMMAND_BUFFER,                // Binding cmds or calling End on CB that
-                                                      // never had vkBeginCommandBuffer()
-                                                      // called on it
-    DRAWSTATE_COMMAND_BUFFER_SINGLE_SUBMIT_VIOLATION, // Cmd Buffer created with
-    // VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
-    // flag is submitted
-    // multiple times
-    DRAWSTATE_INVALID_SECONDARY_COMMAND_BUFFER, // vkCmdExecuteCommands() called
-                                                // with a primary commandBuffer
-                                                // in pCommandBuffers array
-    DRAWSTATE_VIEWPORT_NOT_BOUND,               // Draw submitted with no viewport state bound
-    DRAWSTATE_SCISSOR_NOT_BOUND,                // Draw submitted with no scissor state bound
-    DRAWSTATE_LINE_WIDTH_NOT_BOUND,             // Draw submitted with no line width state
-                                                // bound
-    DRAWSTATE_DEPTH_BIAS_NOT_BOUND,             // Draw submitted with no depth bias state
-                                                // bound
-    DRAWSTATE_BLEND_NOT_BOUND,                  // Draw submitted with no blend state bound when
-                                                // color write enabled
-    DRAWSTATE_DEPTH_BOUNDS_NOT_BOUND,           // Draw submitted with no depth bounds
-                                                // state bound when depth enabled
-    DRAWSTATE_STENCIL_NOT_BOUND,                // Draw submitted with no stencil state bound
-                                                // when stencil enabled
-    DRAWSTATE_INDEX_BUFFER_NOT_BOUND,           // Draw submitted with no depth-stencil
-                                                // state bound when depth write enabled
-    DRAWSTATE_PIPELINE_LAYOUTS_INCOMPATIBLE,    // Draw submitted PSO Pipeline
-                                                // layout that's not compatible
-                                                // with layout from
-                                                // BindDescriptorSets
-    DRAWSTATE_RENDERPASS_INCOMPATIBLE,          // Incompatible renderpasses between
-                                                // secondary cmdBuffer and primary
-                                                // cmdBuffer or framebuffer
-    DRAWSTATE_FRAMEBUFFER_INCOMPATIBLE,         // Incompatible framebuffer between
-                                                // secondary cmdBuffer and active
-                                                // renderPass
-    DRAWSTATE_INVALID_RENDERPASS,               // Use of a NULL or otherwise invalid
-                                                // RenderPass object
-    DRAWSTATE_INVALID_RENDERPASS_CMD,           // Invalid cmd submitted while a
-                                                // RenderPass is active
-    DRAWSTATE_NO_ACTIVE_RENDERPASS,             // Rendering cmd submitted without an active
-                                                // RenderPass
-    DRAWSTATE_DESCRIPTOR_SET_NOT_UPDATED,       // DescriptorSet bound but it was
-                                                // never updated. This is a warning
-                                                // code.
-    DRAWSTATE_DESCRIPTOR_SET_NOT_BOUND,         // DescriptorSet used by pipeline at
-                                                // draw time is not bound, or has been
-                                                // disturbed (which would have flagged
-                                                // previous warning)
-    DRAWSTATE_INVALID_DYNAMIC_OFFSET_COUNT,     // DescriptorSets bound with
-                                                // different number of dynamic
-                                                // descriptors that were included in
-                                                // dynamicOffsetCount
-    DRAWSTATE_CLEAR_CMD_BEFORE_DRAW,            // Clear cmd issued before any Draw in
-                                                // CommandBuffer, should use RenderPass Ops
-                                                // instead
-    DRAWSTATE_BEGIN_CB_INVALID_STATE,           // CB state at Begin call is bad. Can be
-                                                // Primary/Secondary CB created with
-                                                // mismatched FB/RP information or CB in
-                                                // RECORDING state
-    DRAWSTATE_INVALID_CB_SIMULTANEOUS_USE,      // CmdBuffer is being used in
-                                                // violation of
-    // VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT
-    // rules (i.e. simultaneous use w/o
-    // that bit set)
-    DRAWSTATE_INVALID_COMMAND_BUFFER_RESET, // Attempting to call Reset (or
-                                            // Begin on recorded cmdBuffer) that
-                                            // was allocated from Pool w/o
-    // VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
-    // bit set
-    DRAWSTATE_VIEWPORT_SCISSOR_MISMATCH,             // Count for viewports and scissors
-                                                     // mismatch and/or state doesn't match
-                                                     // count
-    DRAWSTATE_INVALID_IMAGE_ASPECT,                  // Image aspect is invalid for the current
-                                                     // operation
-    DRAWSTATE_MISSING_ATTACHMENT_REFERENCE,          // Attachment reference must be
-                                                     // present in active subpass
-    DRAWSTATE_SAMPLER_DESCRIPTOR_ERROR,              // A Descriptor of *_SAMPLER type is
-                                                     // being updated with an invalid or bad
-                                                     // Sampler
-    DRAWSTATE_INCONSISTENT_IMMUTABLE_SAMPLER_UPDATE, // Descriptors of
-                                                     // *COMBINED_IMAGE_SAMPLER
-                                                     // type are being updated
-                                                     // where some, but not all,
-                                                     // of the updates use
-                                                     // immutable samplers
-    DRAWSTATE_IMAGEVIEW_DESCRIPTOR_ERROR,            // A Descriptor of *_IMAGE or
-                                                     // *_ATTACHMENT type is being updated
-                                                     // with an invalid or bad ImageView
-    DRAWSTATE_BUFFERVIEW_DESCRIPTOR_ERROR,           // A Descriptor of *_TEXEL_BUFFER
-                                                     // type is being updated with an
-                                                     // invalid or bad BufferView
-    DRAWSTATE_BUFFERINFO_DESCRIPTOR_ERROR,           // A Descriptor of
-    // *_[UNIFORM|STORAGE]_BUFFER_[DYNAMIC]
-    // type is being updated with an
-    // invalid or bad BufferView
-    DRAWSTATE_DYNAMIC_OFFSET_OVERFLOW,       // At draw time the dynamic offset
-                                             // combined with buffer offset and range
-                                             // oversteps size of buffer
-    DRAWSTATE_DOUBLE_DESTROY,                // Destroying an object twice
-    DRAWSTATE_OBJECT_INUSE,                  // Destroying or modifying an object in use by a
-                                             // command buffer
-    DRAWSTATE_QUEUE_FORWARD_PROGRESS,        // Queue cannot guarantee forward progress
-    DRAWSTATE_INVALID_BUFFER_MEMORY_OFFSET,  // Dynamic Buffer Offset
-                                             // violates memory requirements limit
-    DRAWSTATE_INVALID_TEXEL_BUFFER_OFFSET,   // Dynamic Texel Buffer Offsets
-                                             // violate device limit
-    DRAWSTATE_INVALID_UNIFORM_BUFFER_OFFSET, // Dynamic Uniform Buffer Offsets
-                                             // violate device limit
-    DRAWSTATE_INVALID_STORAGE_BUFFER_OFFSET, // Dynamic Storage Buffer Offsets
-                                             // violate device limit
-    DRAWSTATE_INDEPENDENT_BLEND,             // If independent blending is not enabled, all
-                                             // elements of pAttachmentsMustBeIdentical
-    DRAWSTATE_DISABLED_LOGIC_OP,             // If logic operations is not enabled, logicOpEnable
-                                             // must be VK_FALSE
-    DRAWSTATE_INVALID_LOGIC_OP,              // If logicOpEnable is VK_TRUE, logicOp must
-                                             // must be a valid VkLogicOp value
-    DRAWSTATE_INVALID_QUEUE_INDEX,           // Specified queue index exceeds number
-                                             // of queried queue families
-    DRAWSTATE_PUSH_CONSTANTS_ERROR,          // Push constants exceed maxPushConstantSize
-} DRAW_STATE_ERROR;
-
-typedef enum _SHADER_CHECKER_ERROR {
-    SHADER_CHECKER_NONE,
-    SHADER_CHECKER_INTERFACE_TYPE_MISMATCH,    // Type mismatch between shader stages or shader and pipeline
-    SHADER_CHECKER_OUTPUT_NOT_CONSUMED,        // Entry appears in output interface, but missing in input
-    SHADER_CHECKER_INPUT_NOT_PRODUCED,         // Entry appears in input interface, but missing in output
-    SHADER_CHECKER_NON_SPIRV_SHADER,           // Shader image is not SPIR-V
-    SHADER_CHECKER_INCONSISTENT_SPIRV,         // General inconsistency within a SPIR-V module
-    SHADER_CHECKER_UNKNOWN_STAGE,              // Stage is not supported by analysis
-    SHADER_CHECKER_INCONSISTENT_VI,            // VI state contains conflicting binding or attrib descriptions
-    SHADER_CHECKER_MISSING_DESCRIPTOR,         // Shader attempts to use a descriptor binding not declared in the layout
-    SHADER_CHECKER_BAD_SPECIALIZATION,         // Specialization map entry points outside specialization data block
-    SHADER_CHECKER_MISSING_ENTRYPOINT,         // Shader module does not contain the requested entrypoint
-    SHADER_CHECKER_PUSH_CONSTANT_OUT_OF_RANGE, // Push constant variable is not in a push constant range
-    SHADER_CHECKER_PUSH_CONSTANT_NOT_ACCESSIBLE_FROM_STAGE, // Push constant range exists, but not accessible from stage
-    SHADER_CHECKER_DESCRIPTOR_TYPE_MISMATCH,                // Descriptor type does not match shader resource type
-    SHADER_CHECKER_DESCRIPTOR_NOT_ACCESSIBLE_FROM_STAGE,    // Descriptor used by shader, but not accessible from stage
-    SHADER_CHECKER_FEATURE_NOT_ENABLED,        // Shader uses capability requiring a feature not enabled on device
-    SHADER_CHECKER_BAD_CAPABILITY,             // Shader uses capability not supported by Vulkan (OpenCL features)
-} SHADER_CHECKER_ERROR;
-
 typedef enum _DRAW_TYPE {
     DRAW = 0,
     DRAW_INDEXED = 1,
@@ -606,28 +392,6 @@ class FRAMEBUFFER_NODE {
     unordered_set<VkCommandBuffer> referencingCmdBuffers;
     vector<MT_FB_ATTACHMENT_INFO> attachments;
 };
-
-// Descriptor Data structures
-// Layout Node has the core layout data
-typedef struct _LAYOUT_NODE {
-    VkDescriptorSetLayout layout;
-    VkDescriptorSetLayoutCreateInfo createInfo;
-    uint32_t startIndex;                                 // 1st index of this layout
-    uint32_t endIndex;                                   // last index of this layout
-    uint32_t dynamicDescriptorCount;                     // Total count of dynamic descriptors used
-                                                         // by this layout
-    uint32_t immutableSamplerCount;                      // # of immutable samplers in this layout
-    vector<VkDescriptorType> descriptorTypes;            // Type per descriptor in this
-                                                         // layout to verify correct
-                                                         // updates
-    vector<VkShaderStageFlags> stageFlags;               // stageFlags per descriptor in this
-                                                         // layout to verify correct updates
-    unordered_map<uint32_t, uint32_t> bindingToIndexMap; // map set binding # to
-                                                         // createInfo.pBindings index
-    // Default constructor
-    _LAYOUT_NODE() : layout{}, createInfo{}, startIndex(0), endIndex(0), dynamicDescriptorCount(0), immutableSamplerCount(0){};
-} LAYOUT_NODE;
-
 // Store layouts and pushconstants for PipelineLayout
 struct PIPELINE_LAYOUT_NODE {
     vector<VkDescriptorSetLayout> descriptorSetLayouts;
@@ -641,14 +405,13 @@ class SET_NODE : public BASE_NODE {
     VkDescriptorPool pool;
     // Head of LL of all Update structs for this set
     GENERIC_HEADER *pUpdateStructs;
-    // Total num of descriptors in this set (count of its layout plus all prior layouts)
-    uint32_t descriptorCount;
+    uint32_t descriptorCount;                   // Total num of descriptors in this set
     vector<GENERIC_HEADER*> pDescriptorUpdates; // Vector where each index points to update node for its slot
-    LAYOUT_NODE *pLayout;           // Layout for this set
+    DescriptorSetLayout *p_layout;              // DescriptorSetLayout for this set
     SET_NODE *pNext;
     unordered_set<VkCommandBuffer> boundCmdBuffers; // Cmd buffers that this set has been bound to
     SET_NODE()
-        : set(VK_NULL_HANDLE), pool(VK_NULL_HANDLE), pUpdateStructs(nullptr), descriptorCount(0), pLayout(nullptr),
+        : set(VK_NULL_HANDLE), pool(VK_NULL_HANDLE), pUpdateStructs(nullptr), descriptorCount(0), p_layout(nullptr),
           pNext(nullptr){};
 };
 

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -1,0 +1,243 @@
+/* Copyright (c) 2015-2016 The Khronos Group Inc.
+ * Copyright (c) 2015-2016 Valve Corporation
+ * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (C) 2015-2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
+ * Author: Tobin Ehlis <tobine@google.com>
+ * Author: Chris Forbes <chrisf@ijw.co.nz>
+ * Author: Mark Lobodzinski <mark@lunarg.com>
+ */
+#ifndef CORE_VALIDATION_ERROR_ENUMS_H_
+#define CORE_VALIDATION_ERROR_ENUMS_H_
+
+// Mem Tracker ERROR codes
+typedef enum _MEM_TRACK_ERROR {
+    MEMTRACK_NONE,                         // Used for INFO & other non-error messages
+    MEMTRACK_INVALID_CB,                   // Cmd Buffer invalid
+    MEMTRACK_INVALID_MEM_OBJ,              // Invalid Memory Object
+    MEMTRACK_INVALID_ALIASING,             // Invalid Memory Aliasing
+    MEMTRACK_INVALID_LAYOUT,               // Invalid Layout
+    MEMTRACK_INTERNAL_ERROR,               // Bug in Mem Track Layer internal data structures
+    MEMTRACK_FREED_MEM_REF,                // MEM Obj freed while it still has obj and/or CB refs
+    MEMTRACK_MEM_OBJ_CLEAR_EMPTY_BINDINGS, // Clearing bindings on mem obj that doesn't have any bindings
+    MEMTRACK_MISSING_MEM_BINDINGS,         // Trying to retrieve mem bindings, but none found (may be internal error)
+    MEMTRACK_INVALID_OBJECT,               // Attempting to reference generic VK Object that is invalid
+    MEMTRACK_MEMORY_BINDING_ERROR,         // Error during one of many calls that bind memory to object or CB
+    MEMTRACK_MEMORY_LEAK,                  // Failure to call vkFreeMemory on Mem Obj prior to DestroyDevice
+    MEMTRACK_INVALID_STATE,                // Memory not in the correct state
+    MEMTRACK_RESET_CB_WHILE_IN_FLIGHT,     // vkResetCommandBuffer() called on a CB that hasn't completed
+    MEMTRACK_INVALID_FENCE_STATE,          // Invalid Fence State signaled or used
+    MEMTRACK_REBIND_OBJECT,                // Non-sparse object bindings are immutable
+    MEMTRACK_INVALID_USAGE_FLAG,           // Usage flags specified at image/buffer create conflict w/ use of object
+    MEMTRACK_INVALID_MAP,                  // Size flag specified at alloc is too small for mapping range
+} MEM_TRACK_ERROR;
+
+// Draw State ERROR codes
+typedef enum _DRAW_STATE_ERROR {
+    // TODO: Remove the comments here or expand them. There isn't any additional information in the
+    // comments than in the name in almost all cases.
+    DRAWSTATE_NONE,                          // Used for INFO & other non-error messages
+    DRAWSTATE_INTERNAL_ERROR,                // Error with DrawState internal data structures
+    DRAWSTATE_NO_PIPELINE_BOUND,             // Unable to identify a bound pipeline
+    DRAWSTATE_INVALID_POOL,                  // Invalid DS pool
+    DRAWSTATE_INVALID_SET,                   // Invalid DS
+    DRAWSTATE_INVALID_RENDER_AREA,           // Invalid renderArea
+    DRAWSTATE_INVALID_LAYOUT,                // Invalid DS layout
+    DRAWSTATE_INVALID_IMAGE_LAYOUT,          // Invalid Image layout
+    DRAWSTATE_INVALID_PIPELINE,              // Invalid Pipeline handle referenced
+    DRAWSTATE_INVALID_PIPELINE_LAYOUT,       // Invalid PipelineLayout
+    DRAWSTATE_INVALID_PIPELINE_CREATE_STATE, // Attempt to create a pipeline
+                                             // with invalid state
+    DRAWSTATE_INVALID_COMMAND_BUFFER,        // Invalid CommandBuffer referenced
+    DRAWSTATE_INVALID_BARRIER,               // Invalid Barrier
+    DRAWSTATE_INVALID_BUFFER,                // Invalid Buffer
+    DRAWSTATE_INVALID_QUERY,                 // Invalid Query
+    DRAWSTATE_INVALID_FENCE,                 // Invalid Fence
+    DRAWSTATE_INVALID_SEMAPHORE,             // Invalid Semaphore
+    DRAWSTATE_INVALID_EVENT,                 // Invalid Event
+    DRAWSTATE_VTX_INDEX_OUT_OF_BOUNDS,       // binding in vkCmdBindVertexData() too
+                                             // large for PSO's
+                                             // pVertexBindingDescriptions array
+    DRAWSTATE_VTX_INDEX_ALIGNMENT_ERROR,     // binding offset in
+                                             // vkCmdBindIndexBuffer() out of
+                                             // alignment based on indexType
+    // DRAWSTATE_MISSING_DOT_PROGRAM,              // No "dot" program in order
+    // to generate png image
+    DRAWSTATE_OUT_OF_MEMORY,                          // malloc failed
+    DRAWSTATE_INVALID_DESCRIPTOR_SET,                 // Descriptor Set handle is unknown
+    DRAWSTATE_DESCRIPTOR_TYPE_MISMATCH,               // Type in layout vs. update are not the
+                                                      // same
+    DRAWSTATE_DESCRIPTOR_STAGEFLAGS_MISMATCH,         // StageFlags in layout are not
+                                                      // the same throughout a single
+                                                      // VkWriteDescriptorSet update
+    DRAWSTATE_DESCRIPTOR_UPDATE_OUT_OF_BOUNDS,        // Descriptors set for update out
+                                                      // of bounds for corresponding
+                                                      // layout section
+    DRAWSTATE_DESCRIPTOR_POOL_EMPTY,                  // Attempt to allocate descriptor from a
+                                                      // pool with no more descriptors of that
+                                                      // type available
+    DRAWSTATE_CANT_FREE_FROM_NON_FREE_POOL,           // Invalid to call
+                                                      // vkFreeDescriptorSets on Sets
+                                                      // allocated from a NON_FREE Pool
+    DRAWSTATE_INVALID_UPDATE_INDEX,                   // Index of requested update is invalid for
+                                                      // specified descriptors set
+    DRAWSTATE_INVALID_UPDATE_STRUCT,                  // Struct in DS Update tree is of invalid
+                                                      // type
+    DRAWSTATE_NUM_SAMPLES_MISMATCH,                   // Number of samples in bound PSO does not
+                                                      // match number in FB of current RenderPass
+    DRAWSTATE_NO_END_COMMAND_BUFFER,                  // Must call vkEndCommandBuffer() before
+                                                      // QueueSubmit on that commandBuffer
+    DRAWSTATE_NO_BEGIN_COMMAND_BUFFER,                // Binding cmds or calling End on CB that
+                                                      // never had vkBeginCommandBuffer()
+                                                      // called on it
+    DRAWSTATE_COMMAND_BUFFER_SINGLE_SUBMIT_VIOLATION, // Cmd Buffer created with
+    // VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
+    // flag is submitted
+    // multiple times
+    DRAWSTATE_INVALID_SECONDARY_COMMAND_BUFFER, // vkCmdExecuteCommands() called
+                                                // with a primary commandBuffer
+                                                // in pCommandBuffers array
+    DRAWSTATE_VIEWPORT_NOT_BOUND,               // Draw submitted with no viewport state bound
+    DRAWSTATE_SCISSOR_NOT_BOUND,                // Draw submitted with no scissor state bound
+    DRAWSTATE_LINE_WIDTH_NOT_BOUND,             // Draw submitted with no line width state
+                                                // bound
+    DRAWSTATE_DEPTH_BIAS_NOT_BOUND,             // Draw submitted with no depth bias state
+                                                // bound
+    DRAWSTATE_BLEND_NOT_BOUND,                  // Draw submitted with no blend state bound when
+                                                // color write enabled
+    DRAWSTATE_DEPTH_BOUNDS_NOT_BOUND,           // Draw submitted with no depth bounds
+                                                // state bound when depth enabled
+    DRAWSTATE_STENCIL_NOT_BOUND,                // Draw submitted with no stencil state bound
+                                                // when stencil enabled
+    DRAWSTATE_INDEX_BUFFER_NOT_BOUND,           // Draw submitted with no depth-stencil
+                                                // state bound when depth write enabled
+    DRAWSTATE_PIPELINE_LAYOUTS_INCOMPATIBLE,    // Draw submitted PSO Pipeline
+                                                // layout that's not compatible
+                                                // with layout from
+                                                // BindDescriptorSets
+    DRAWSTATE_RENDERPASS_INCOMPATIBLE,          // Incompatible renderpasses between
+                                                // secondary cmdBuffer and primary
+                                                // cmdBuffer or framebuffer
+    DRAWSTATE_FRAMEBUFFER_INCOMPATIBLE,         // Incompatible framebuffer between
+                                                // secondary cmdBuffer and active
+                                                // renderPass
+    DRAWSTATE_INVALID_RENDERPASS,               // Use of a NULL or otherwise invalid
+                                                // RenderPass object
+    DRAWSTATE_INVALID_RENDERPASS_CMD,           // Invalid cmd submitted while a
+                                                // RenderPass is active
+    DRAWSTATE_NO_ACTIVE_RENDERPASS,             // Rendering cmd submitted without an active
+                                                // RenderPass
+    DRAWSTATE_DESCRIPTOR_SET_NOT_UPDATED,       // DescriptorSet bound but it was
+                                                // never updated. This is a warning
+                                                // code.
+    DRAWSTATE_DESCRIPTOR_SET_NOT_BOUND,         // DescriptorSet used by pipeline at
+                                                // draw time is not bound, or has been
+                                                // disturbed (which would have flagged
+                                                // previous warning)
+    DRAWSTATE_INVALID_DYNAMIC_OFFSET_COUNT,     // DescriptorSets bound with
+                                                // different number of dynamic
+                                                // descriptors that were included in
+                                                // dynamicOffsetCount
+    DRAWSTATE_CLEAR_CMD_BEFORE_DRAW,            // Clear cmd issued before any Draw in
+                                                // CommandBuffer, should use RenderPass Ops
+                                                // instead
+    DRAWSTATE_BEGIN_CB_INVALID_STATE,           // CB state at Begin call is bad. Can be
+                                                // Primary/Secondary CB created with
+                                                // mismatched FB/RP information or CB in
+                                                // RECORDING state
+    DRAWSTATE_INVALID_CB_SIMULTANEOUS_USE,      // CmdBuffer is being used in
+                                                // violation of
+    // VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT
+    // rules (i.e. simultaneous use w/o
+    // that bit set)
+    DRAWSTATE_INVALID_COMMAND_BUFFER_RESET, // Attempting to call Reset (or
+                                            // Begin on recorded cmdBuffer) that
+                                            // was allocated from Pool w/o
+    // VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT
+    // bit set
+    DRAWSTATE_VIEWPORT_SCISSOR_MISMATCH,             // Count for viewports and scissors
+                                                     // mismatch and/or state doesn't match
+                                                     // count
+    DRAWSTATE_INVALID_IMAGE_ASPECT,                  // Image aspect is invalid for the current
+                                                     // operation
+    DRAWSTATE_MISSING_ATTACHMENT_REFERENCE,          // Attachment reference must be
+                                                     // present in active subpass
+    DRAWSTATE_SAMPLER_DESCRIPTOR_ERROR,              // A Descriptor of *_SAMPLER type is
+                                                     // being updated with an invalid or bad
+                                                     // Sampler
+    DRAWSTATE_INCONSISTENT_IMMUTABLE_SAMPLER_UPDATE, // Descriptors of
+                                                     // *COMBINED_IMAGE_SAMPLER
+                                                     // type are being updated
+                                                     // where some, but not all,
+                                                     // of the updates use
+                                                     // immutable samplers
+    DRAWSTATE_IMAGEVIEW_DESCRIPTOR_ERROR,            // A Descriptor of *_IMAGE or
+                                                     // *_ATTACHMENT type is being updated
+                                                     // with an invalid or bad ImageView
+    DRAWSTATE_BUFFERVIEW_DESCRIPTOR_ERROR,           // A Descriptor of *_TEXEL_BUFFER
+                                                     // type is being updated with an
+                                                     // invalid or bad BufferView
+    DRAWSTATE_BUFFERINFO_DESCRIPTOR_ERROR,           // A Descriptor of
+    // *_[UNIFORM|STORAGE]_BUFFER_[DYNAMIC]
+    // type is being updated with an
+    // invalid or bad BufferView
+    DRAWSTATE_DYNAMIC_OFFSET_OVERFLOW,       // At draw time the dynamic offset
+                                             // combined with buffer offset and range
+                                             // oversteps size of buffer
+    DRAWSTATE_DOUBLE_DESTROY,                // Destroying an object twice
+    DRAWSTATE_OBJECT_INUSE,                  // Destroying or modifying an object in use by a
+                                             // command buffer
+    DRAWSTATE_QUEUE_FORWARD_PROGRESS,        // Queue cannot guarantee forward progress
+    DRAWSTATE_INVALID_BUFFER_MEMORY_OFFSET,  // Dynamic Buffer Offset
+                                             // violates memory requirements limit
+    DRAWSTATE_INVALID_TEXEL_BUFFER_OFFSET,   // Dynamic Texel Buffer Offsets
+                                             // violate device limit
+    DRAWSTATE_INVALID_UNIFORM_BUFFER_OFFSET, // Dynamic Uniform Buffer Offsets
+                                             // violate device limit
+    DRAWSTATE_INVALID_STORAGE_BUFFER_OFFSET, // Dynamic Storage Buffer Offsets
+                                             // violate device limit
+    DRAWSTATE_INDEPENDENT_BLEND,             // If independent blending is not enabled, all
+                                             // elements of pAttachmentsMustBeIdentical
+    DRAWSTATE_DISABLED_LOGIC_OP,             // If logic operations is not enabled, logicOpEnable
+                                             // must be VK_FALSE
+    DRAWSTATE_INVALID_LOGIC_OP,              // If logicOpEnable is VK_TRUE, logicOp must
+                                             // must be a valid VkLogicOp value
+    DRAWSTATE_INVALID_QUEUE_INDEX,           // Specified queue index exceeds number
+                                             // of queried queue families
+    DRAWSTATE_PUSH_CONSTANTS_ERROR,          // Push constants exceed maxPushConstantSize
+} DRAW_STATE_ERROR;
+
+typedef enum _SHADER_CHECKER_ERROR {
+    SHADER_CHECKER_NONE,
+    SHADER_CHECKER_INTERFACE_TYPE_MISMATCH,    // Type mismatch between shader stages or shader and pipeline
+    SHADER_CHECKER_OUTPUT_NOT_CONSUMED,        // Entry appears in output interface, but missing in input
+    SHADER_CHECKER_INPUT_NOT_PRODUCED,         // Entry appears in input interface, but missing in output
+    SHADER_CHECKER_NON_SPIRV_SHADER,           // Shader image is not SPIR-V
+    SHADER_CHECKER_INCONSISTENT_SPIRV,         // General inconsistency within a SPIR-V module
+    SHADER_CHECKER_UNKNOWN_STAGE,              // Stage is not supported by analysis
+    SHADER_CHECKER_INCONSISTENT_VI,            // VI state contains conflicting binding or attrib descriptions
+    SHADER_CHECKER_MISSING_DESCRIPTOR,         // Shader attempts to use a descriptor binding not declared in the layout
+    SHADER_CHECKER_BAD_SPECIALIZATION,         // Specialization map entry points outside specialization data block
+    SHADER_CHECKER_MISSING_ENTRYPOINT,         // Shader module does not contain the requested entrypoint
+    SHADER_CHECKER_PUSH_CONSTANT_OUT_OF_RANGE, // Push constant variable is not in a push constant range
+    SHADER_CHECKER_PUSH_CONSTANT_NOT_ACCESSIBLE_FROM_STAGE, // Push constant range exists, but not accessible from stage
+    SHADER_CHECKER_DESCRIPTOR_TYPE_MISMATCH,                // Descriptor type does not match shader resource type
+    SHADER_CHECKER_DESCRIPTOR_NOT_ACCESSIBLE_FROM_STAGE,    // Descriptor used by shader, but not accessible from stage
+    SHADER_CHECKER_FEATURE_NOT_ENABLED,                     // Shader uses capability requiring a feature not enabled on device
+    SHADER_CHECKER_BAD_CAPABILITY,                          // Shader uses capability not supported by Vulkan (OpenCL features)
+} SHADER_CHECKER_ERROR;
+
+#endif // CORE_VALIDATION_ERROR_ENUMS_H_

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -1,0 +1,262 @@
+/* Copyright (c) 2015-2016 The Khronos Group Inc.
+ * Copyright (c) 2015-2016 Valve Corporation
+ * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (C) 2015-2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Tobin Ehlis <tobine@google.com>
+ */
+#ifndef CORE_VALIDATION_DESCRIPTOR_SETS_H_
+#define CORE_VALIDATION_DESCRIPTOR_SETS_H_
+
+// Check for noexcept support
+#if defined(__clang__)
+#if __has_feature(cxx_noexcept)
+#define HAS_NOEXCEPT
+#endif
+#else
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ * 10 + __GNUC_MINOR__ >= 46
+#define HAS_NOEXCEPT
+#else
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026 && defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS
+#define HAS_NOEXCEPT
+#endif
+#endif
+#endif
+
+#ifdef HAS_NOEXCEPT
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
+#endif
+
+#pragma once
+#include "core_validation_error_enums.h"
+#include "vk_layer_logging.h"
+#include "vk_safe_struct.h"
+#include "vulkan/vk_layer.h"
+#include <unordered_map>
+#include <vector>
+
+// Descriptor Data structures
+
+/*
+ * DescriptorSetLayout class
+ *
+ * Overview - This class encapsulates the Vulkan VkDescriptorSetLayout data (layout).
+ *   A layout consists of some number of bindings, each of which has a binding#, a
+ *   type, descriptor count, stage flags, and pImmutableSamplers.
+ *
+ * Index vs Binding - A layout is created with an array of VkDescriptorSetLayoutBinding
+ *  where each array index will have a corresponding binding# that is defined in that struct.
+ *  This class, therefore, provides utility functions where you can retrieve data for
+ *  layout bindings based on either the original index into the pBindings array, or based
+ *  on the binding#.
+ *  Typically if you want to cover all of the bindings in a layout, you can do that by
+ *   iterating over GetBindingCount() bindings and using the Get*FromIndex() functions.
+ *  Otherwise, you can use the Get*FromBinding() functions to just grab binding info
+ *   for a particular binding#.
+ *
+ * Global Index - The "Index" referenced above is the index into the original pBindings
+ *  array. So there are as many indices as there are bindings.
+ *  This class also has the concept of a Global Index. For the global index functions,
+ *  there are as many global indices as there are descriptors in the layout.
+ *  For the global index, consider all of the bindings to be a flat array where
+ *  descriptor 0 of pBinding[0] is index 0 and each descriptor in the layout increments
+ *  from there. So if pBinding[0] in this example had descriptorCount of 10, then
+ *  the GlobalStartIndex of pBinding[1] will be 10 where 0-9 are the global indices
+ *  for pBinding[0].
+ */
+class DescriptorSetLayout {
+  public:
+    // Constructors and destructor
+    DescriptorSetLayout();
+    DescriptorSetLayout(debug_report_data *report_data, const VkDescriptorSetLayoutCreateInfo *p_create_info,
+                        const VkDescriptorSetLayout layout);
+    ~DescriptorSetLayout();
+    // Straightforward Get functions
+    VkDescriptorSetLayout GetDescriptorSetLayout() { return layout_; };
+    uint32_t GetTotalDescriptorCount() { return descriptor_count_; };
+    uint32_t GetDynamicDescriptorCount() { return dynamic_descriptor_count_; };
+    uint32_t GetBindingCount() { return binding_count_; };
+    // Return true if given binding is present in this layout
+    bool HasBinding(const uint32_t binding) { return binding_to_index_map_.count(binding); };
+    // Return true if this layout is compatible with passed in layout,
+    //   else return false and update error_msg with description of incompatibility
+    bool IsCompatible(DescriptorSetLayout *, string *error_msg);
+    // Various Get functions that can either be passed a binding#, which will
+    //  be automatically translated into the appropriate index from the original
+    //  pBindings array, or the index# can be passed in directly
+    VkDescriptorSetLayoutBinding const *GetDescriptorSetLayoutBindingPtrFromBinding(const uint32_t);
+    VkDescriptorSetLayoutBinding const *GetDescriptorSetLayoutBindingPtrFromIndex(const uint32_t);
+    uint32_t GetDescriptorCountFromBinding(const uint32_t);
+    uint32_t GetDescriptorCountFromIndex(const uint32_t);
+    VkDescriptorType GetTypeFromBinding(const uint32_t);
+    VkDescriptorType GetTypeFromIndex(const uint32_t);
+    VkShaderStageFlags GetStageFlagsFromBinding(const uint32_t);
+    VkSampler const *GetImmutableSamplerPtrFromBinding(const uint32_t);
+    // For a particular binding, get the global index
+    uint32_t GetGlobalStartIndexFromBinding(const uint32_t);
+    uint32_t GetGlobalEndIndexFromBinding(const uint32_t);
+
+  private:
+    VkDescriptorSetLayout layout_;
+    unordered_map<uint32_t, uint32_t> binding_to_index_map_;
+    unordered_map<uint32_t, uint32_t> binding_to_global_start_index_map_;
+    unordered_map<uint32_t, uint32_t> binding_to_global_end_index_map_;
+    VkDescriptorSetLayoutCreateFlags flags_;
+    uint32_t binding_count_; // # of bindings in this layout
+    vector<safe_VkDescriptorSetLayoutBinding> bindings_;
+    uint32_t descriptor_count_; // total # descriptors in this layout
+    uint32_t dynamic_descriptor_count_;
+};
+DescriptorSetLayout::DescriptorSetLayout()
+    : layout_(VK_NULL_HANDLE), flags_(0), binding_count_(0), descriptor_count_(0), dynamic_descriptor_count_(0) {}
+// Construct DescriptorSetLayout instance from given create info
+DescriptorSetLayout::DescriptorSetLayout(debug_report_data *report_data, const VkDescriptorSetLayoutCreateInfo *p_create_info,
+                                         const VkDescriptorSetLayout layout)
+    : layout_(layout), flags_(p_create_info->flags), binding_count_(p_create_info->bindingCount), descriptor_count_(0),
+      dynamic_descriptor_count_(0) {
+    uint32_t global_index = 0;
+    for (uint32_t i = 0; i < binding_count_; ++i) {
+        descriptor_count_ += p_create_info->pBindings[i].descriptorCount;
+        if (!binding_to_index_map_.emplace(p_create_info->pBindings[i].binding, i).second) {
+            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT,
+                    reinterpret_cast<uint64_t &>(layout_), __LINE__, DRAWSTATE_INVALID_LAYOUT, "DS",
+                    "duplicated binding number in "
+                    "VkDescriptorSetLayoutBinding");
+        }
+        binding_to_global_start_index_map_[p_create_info->pBindings[i].binding] = global_index;
+        global_index += p_create_info->pBindings[i].descriptorCount ? p_create_info->pBindings[i].descriptorCount - 1 : 0;
+        binding_to_global_end_index_map_[p_create_info->pBindings[i].binding] = global_index;
+        global_index++;
+        bindings_.push_back(safe_VkDescriptorSetLayoutBinding(&p_create_info->pBindings[i]));
+        // In cases where we should ignore pImmutableSamplers make sure it's NULL
+        if ((p_create_info->pBindings[i].pImmutableSamplers) &&
+            ((p_create_info->pBindings[i].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER) &&
+             (p_create_info->pBindings[i].descriptorType != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))) {
+            bindings_.back().pImmutableSamplers = nullptr;
+        }
+        if (p_create_info->pBindings[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC ||
+            p_create_info->pBindings[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) {
+            dynamic_descriptor_count_++;
+        }
+    }
+}
+DescriptorSetLayout::~DescriptorSetLayout() {
+    for (auto binding : bindings_) {
+        if (binding.pImmutableSamplers)
+            delete[] binding.pImmutableSamplers;
+    }
+}
+VkDescriptorSetLayoutBinding const *DescriptorSetLayout::GetDescriptorSetLayoutBindingPtrFromBinding(const uint32_t binding) {
+    if (!binding_to_index_map_.count(binding))
+        return nullptr;
+    return reinterpret_cast<VkDescriptorSetLayoutBinding const *>(&bindings_[binding_to_index_map_[binding]]);
+}
+VkDescriptorSetLayoutBinding const *DescriptorSetLayout::GetDescriptorSetLayoutBindingPtrFromIndex(const uint32_t index) {
+    if (index >= bindings_.size())
+        return nullptr;
+    return reinterpret_cast<VkDescriptorSetLayoutBinding const *>(&bindings_[index]);
+}
+// Return descriptorCount for given binding, 0 if index is unavailable
+uint32_t DescriptorSetLayout::GetDescriptorCountFromBinding(const uint32_t binding) {
+    if (!binding_to_index_map_.count(binding))
+        return 0;
+    return bindings_[binding_to_index_map_[binding]].descriptorCount;
+}
+// Return descriptorCount for given index, 0 if index is unavailable
+uint32_t DescriptorSetLayout::GetDescriptorCountFromIndex(const uint32_t index) {
+    if (index >= bindings_.size())
+        return 0;
+    return bindings_[index].descriptorCount;
+}
+// For the given binding, return descriptorType
+VkDescriptorType DescriptorSetLayout::GetTypeFromBinding(const uint32_t binding) {
+    assert(binding_to_index_map_.count(binding));
+    return bindings_[binding_to_index_map_[binding]].descriptorType;
+}
+// For the given index, return descriptorType
+VkDescriptorType DescriptorSetLayout::GetTypeFromIndex(const uint32_t index) {
+    assert(index < bindings_.size());
+    return bindings_[index].descriptorType;
+}
+// For the given binding, return stageFlags
+VkShaderStageFlags DescriptorSetLayout::GetStageFlagsFromBinding(const uint32_t binding) {
+    assert(binding_to_index_map_.count(binding));
+    return bindings_[binding_to_index_map_[binding]].stageFlags;
+}
+// For the given binding, return start index
+uint32_t DescriptorSetLayout::GetGlobalStartIndexFromBinding(const uint32_t binding) {
+    assert(binding_to_global_start_index_map_.count(binding));
+    return binding_to_global_start_index_map_[binding];
+}
+// For the given binding, return end index
+uint32_t DescriptorSetLayout::GetGlobalEndIndexFromBinding(const uint32_t binding) {
+    assert(binding_to_global_end_index_map_.count(binding));
+    return binding_to_global_end_index_map_[binding];
+}
+//
+VkSampler const *DescriptorSetLayout::GetImmutableSamplerPtrFromBinding(const uint32_t binding) {
+    assert(binding_to_index_map_.count(binding));
+    return bindings_[binding_to_index_map_[binding]].pImmutableSamplers;
+}
+// If our layout is compatible with rh_sd_layout, return true,
+//  else return false and fill in error_msg will description of what causes incompatibility
+bool DescriptorSetLayout::IsCompatible(DescriptorSetLayout *rh_ds_layout, string *error_msg) {
+    // Trivial case
+    if (layout_ == rh_ds_layout->GetDescriptorSetLayout())
+        return true;
+    if (descriptor_count_ != rh_ds_layout->descriptor_count_) {
+        stringstream error_str;
+        error_str << "DescriptorSetLayout " << layout_ << " has " << descriptor_count_ << " descriptors, but DescriptorSetLayout "
+                  << rh_ds_layout->GetDescriptorSetLayout() << " has " << rh_ds_layout->descriptor_count_ << " descriptors.";
+        *error_msg = error_str.str();
+        return false; // trivial fail case
+    }
+    // Descriptor counts match so need to go through bindings one-by-one
+    //  and verify that type and stageFlags match
+    for (auto binding : bindings_) {
+        // TODO : Do we also need to check immutable samplers?
+        // VkDescriptorSetLayoutBinding *rh_binding;
+        // rh_ds_layout->FillDescriptorSetLayoutBindingStructFromBinding(binding.binding, rh_binding);
+        if (binding.descriptorCount != rh_ds_layout->GetTotalDescriptorCount()) {
+            stringstream error_str;
+            error_str << "Binding " << binding.binding << " for DescriptorSetLayout " << layout_ << " has a descriptorCount of "
+                      << binding.descriptorCount << " but binding " << binding.binding << " for DescriptorSetLayout "
+                      << rh_ds_layout->GetDescriptorSetLayout() << " has a descriptorCount of "
+                      << rh_ds_layout->GetTotalDescriptorCount();
+            *error_msg = error_str.str();
+            return false;
+        } else if (binding.descriptorType != rh_ds_layout->GetTypeFromBinding(binding.binding)) {
+            stringstream error_str;
+            error_str << "Binding " << binding.binding << " for DescriptorSetLayout " << layout_ << " is type '"
+                      << string_VkDescriptorType(binding.descriptorType) << "' but binding " << binding.binding
+                      << " for DescriptorSetLayout " << rh_ds_layout->GetDescriptorSetLayout() << " is type '"
+                      << string_VkDescriptorType(rh_ds_layout->GetTypeFromBinding(binding.binding)) << "'";
+            *error_msg = error_str.str();
+            return false;
+        } else if (binding.stageFlags != rh_ds_layout->GetStageFlagsFromBinding(binding.binding)) {
+            stringstream error_str;
+            error_str << "Binding " << binding.binding << " for DescriptorSetLayout " << layout_ << " has stageFlags "
+                      << binding.stageFlags << " but binding " << binding.binding << " for DescriptorSetLayout "
+                      << rh_ds_layout->GetDescriptorSetLayout() << " has stageFlags "
+                      << rh_ds_layout->GetStageFlagsFromBinding(binding.binding);
+            *error_msg = error_str.str();
+            return false;
+        }
+    }
+    return true;
+}
+#endif // CORE_VALIDATION_DESCRIPTOR_SETS_H_

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -22,15 +22,16 @@
 #ifndef LAYER_LOGGING_H
 #define LAYER_LOGGING_H
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <stdbool.h>
-#include <unordered_map>
-#include <inttypes.h>
-#include "vk_loader_platform.h"
-#include "vulkan/vk_layer.h"
+#include "vk_layer_config.h"
 #include "vk_layer_data.h"
 #include "vk_layer_table.h"
+#include "vk_loader_platform.h"
+#include "vulkan/vk_layer.h"
+#include <inttypes.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unordered_map>
 
 typedef struct _debug_report_data {
     VkLayerDbgFunctionNode *g_pDbgFunctionHead;

--- a/layers/vk_layer_table.h
+++ b/layers/vk_layer_table.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "vulkan/vk_layer.h"
 #include "vulkan/vulkan.h"
 #include <unordered_map>
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -3049,7 +3049,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     // descriptors
     m_errorMonitor->SetDesiredFailureMsg(
         VK_DEBUG_REPORT_ERROR_BIT_EXT,
-        ", but corresponding set being bound has 5 descriptors.");
+        " has 2 descriptors, but DescriptorSetLayout ");
     vkCmdBindDescriptorSets(
         m_commandBuffer->GetBufferHandle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
         pipe_layout_one_desc, 0, 1, &descriptorSet[0], 0, NULL);
@@ -3059,7 +3059,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     // 4. same # of descriptors but mismatch in type
     m_errorMonitor->SetDesiredFailureMsg(
         VK_DEBUG_REPORT_ERROR_BIT_EXT,
-        " descriptor from pipelineLayout is type 'VK_DESCRIPTOR_TYPE_SAMPLER'");
+        " is type 'VK_DESCRIPTOR_TYPE_SAMPLER' but binding ");
     vkCmdBindDescriptorSets(
         m_commandBuffer->GetBufferHandle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
         pipe_layout_five_samp, 0, 1, &descriptorSet[0], 0, NULL);
@@ -3069,7 +3069,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     // 5. same # of descriptors but mismatch in stageFlags
     m_errorMonitor->SetDesiredFailureMsg(
         VK_DEBUG_REPORT_ERROR_BIT_EXT,
-        " descriptor from pipelineLayout has stageFlags ");
+        " has stageFlags 16 but binding 0 for DescriptorSetLayout ");
     vkCmdBindDescriptorSets(
         m_commandBuffer->GetBufferHandle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
         pipe_layout_fs_only, 0, 1, &descriptorSet[0], 0, NULL);
@@ -5159,9 +5159,10 @@ TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
     VkResult err;
 
     m_errorMonitor->SetDesiredFailureMsg(
-        VK_DEBUG_REPORT_ERROR_BIT_EXT, "Copy descriptor update index 0, update "
-                                       "count #1, has src update descriptor "
-                                       "type VK_DESCRIPTOR_TYPE_SAMPLER ");
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "Copy descriptor update index 0, has src update descriptor "
+        "type VK_DESCRIPTOR_TYPE_SAMPLER that does not match overlapping "
+        "dest ");
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     // VkDescriptorSetObj descriptorSet(m_device);

--- a/vk_helper.py
+++ b/vk_helper.py
@@ -1561,6 +1561,7 @@ class StructWrapperGen:
     def _generateSafeStructHeader(self):
         header = []
         header.append("//#includes, #defines, globals and such...\n")
+        header.append('#pragma once\n')
         header.append('#include "vulkan/vulkan.h"')
         return "".join(header)
 

--- a/vk_layer_documentation_generate.py
+++ b/vk_layer_documentation_generate.py
@@ -49,15 +49,15 @@ import platform
 # TODO : Need list of known validation layers to use as default input
 #  Just a couple of flat lists right now, but may need to make this input file
 #  or at least a more dynamic data structure
-layer_inputs = { 'draw_state' : {'header' : 'layers/core_validation.h',
+layer_inputs = { 'draw_state' : {'header' : 'layers/core_validation_error_enums.h',
                                  'source' : 'layers/core_validation.cpp',
                                  'generated' : False,
                                  'error_enum' : 'DRAW_STATE_ERROR'},
-                 'shader_checker' : {'header' : 'layers/core_validation.h',
+                 'shader_checker' : {'header' : 'layers/core_validation_error_enums.h',
                                  'source' : 'layers/core_validation.cpp',
                                  'generated' : False,
                                  'error_enum' : 'SHADER_CHECKER_ERROR'},
-                 'mem_tracker' : {'header' : 'layers/core_validation.h',
+                 'mem_tracker' : {'header' : 'layers/core_validation_error_enums.h',
                                   'source' : 'layers/core_validation.cpp',
                                   'generated' : False,
                                   'error_enum' : 'MEM_TRACK_ERROR'},


### PR DESCRIPTION
NOTE : Rebased this from #405. Planning to push this afternoon if I don't hear any objections.

This is the start of a refactor to pull code out of core_validation.cpp
into its own separate classes. I'm starting with descriptor set code as
it isolates reasonably well and it's old and could use some updating anyway.

For this first piece I've broken VkDescriptorSetLayout into its own
class currently called DescriptorSetLayout. I don't know if that's a great
name as it's close to VkDescriptorSetLayout, so I'm open to changing it.
Provided a brief class description in comment in new file descriptor_sets.h.

I made the class interfaces based on what other code is currently using.
I'm planning to pull more descriptor set code into its own classes and I
anticipate that will cause some flux in the class interfaces until most
of the work is done.