### PR TITLE
layers: Fix object lifetime bugs in DescriptorSetLayout

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7001,7 +7001,7 @@ vkCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipel
                             // Validate Dynamic Offset Minimums
                             uint32_t cur_dyn_offset = totalDynamicDescriptors;
                             for (uint32_t d = 0; d < pSet->descriptorCount; d++) {
-                                if (pSet->p_layout->GetTypeFromIndex(d) == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) {
+                                if (pSet->p_layout->GetTypeFromGlobalIndex(d) == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) {
                                     if (vk_safe_modulo(
                                             pDynamicOffsets[cur_dyn_offset],
                                             dev_data->phys_dev_properties.properties.limits.minUniformBufferOffsetAlignment) != 0) {
@@ -7015,7 +7015,7 @@ vkCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipel
                                             dev_data->phys_dev_properties.properties.limits.minUniformBufferOffsetAlignment);
                                     }
                                     cur_dyn_offset++;
-                                } else if (pSet->p_layout->GetTypeFromIndex(d) == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) {
+                                } else if (pSet->p_layout->GetTypeFromGlobalIndex(d) == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) {
                                     if (vk_safe_modulo(
                                             pDynamicOffsets[cur_dyn_offset],
                                             dev_data->phys_dev_properties.properties.limits.minStorageBufferOffsetAlignment) != 0) {

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -104,6 +104,7 @@ class DescriptorSetLayout {
     uint32_t GetDescriptorCountFromIndex(const uint32_t);
     VkDescriptorType GetTypeFromBinding(const uint32_t);
     VkDescriptorType GetTypeFromIndex(const uint32_t);
+    VkDescriptorType GetTypeFromGlobalIndex(const uint32_t);
     VkShaderStageFlags GetStageFlagsFromBinding(const uint32_t);
     VkSampler const *GetImmutableSamplerPtrFromBinding(const uint32_t);
     // For a particular binding, get the global index
@@ -190,6 +191,17 @@ VkDescriptorType DescriptorSetLayout::GetTypeFromBinding(const uint32_t binding)
 VkDescriptorType DescriptorSetLayout::GetTypeFromIndex(const uint32_t index) {
     assert(index < bindings_.size());
     return bindings_[index]->descriptorType;
+}
+// For the given global index, return descriptorType
+//  Currently just counting up through bindings_, may improve this in future
+VkDescriptorType DescriptorSetLayout::GetTypeFromGlobalIndex(const uint32_t index) {
+    auto global_offset = 0;
+    for (auto binding : bindings_) {
+        global_offset += binding->descriptorCount;
+        if (index < global_offset)
+            return binding->descriptorType;
+    }
+    assert(0); // requested global index is out of bounds
 }
 // For the given binding, return stageFlags
 VkShaderStageFlags DescriptorSetLayout::GetStageFlagsFromBinding(const uint32_t binding) {


### PR DESCRIPTION
Incomplete copy construction of DescriptorSetLayout and safe_* types
causes embedded pointers (such as pImmutableSamplers) to become invalid
before they should. Fixing this for now by moving DescriptorSetLayout
and its embedded safe_* struct to ptrs within their containers and
explicitly deleting.