### PR TITLE
layers: Emit safe_*::ptr() members to eliminate some cast noise

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2502,7 +2502,7 @@ static bool validate_pipeline_shader_stage(layer_data *dev_data, VkPipelineShade
 // Validate that the shaders used by the given pipeline and store the active_slots
 //  that are actually used by the pipeline into pPipeline->active_slots
 static bool validate_and_capture_pipeline_shader_state(layer_data *my_data, PIPELINE_NODE *pPipeline) {
-    auto pCreateInfo = reinterpret_cast<VkGraphicsPipelineCreateInfo const *>(&pPipeline->graphicsPipelineCI);
+    auto pCreateInfo = pPipeline->graphicsPipelineCI.ptr();
     int vertex_stage = get_shader_stage_id(VK_SHADER_STAGE_VERTEX_BIT);
     int fragment_stage = get_shader_stage_id(VK_SHADER_STAGE_FRAGMENT_BIT);
 
@@ -2516,8 +2516,7 @@ static bool validate_and_capture_pipeline_shader_state(layer_data *my_data, PIPE
     auto pipelineLayout = pCreateInfo->layout != VK_NULL_HANDLE ? &my_data->pipelineLayoutMap[pCreateInfo->layout] : nullptr;
 
     for (uint32_t i = 0; i < pCreateInfo->stageCount; i++) {
-        VkPipelineShaderStageCreateInfo const *pStage =
-            reinterpret_cast<VkPipelineShaderStageCreateInfo const *>(&pCreateInfo->pStages[i]);
+        auto pStage = &pCreateInfo->pStages[i];
         auto stage_id = get_shader_stage_id(pStage->stage);
         pass &= validate_pipeline_shader_stage(my_data, pStage, pPipeline, pipelineLayout,
                                                &shaders[stage_id], &entrypoints[stage_id]);
@@ -2563,7 +2562,7 @@ static bool validate_and_capture_pipeline_shader_state(layer_data *my_data, PIPE
 }
 
 static bool validate_compute_pipeline(layer_data *my_data, PIPELINE_NODE *pPipeline) {
-    auto pCreateInfo = reinterpret_cast<VkComputePipelineCreateInfo const *>(&pPipeline->computePipelineCI);
+    auto pCreateInfo = pPipeline->computePipelineCI.ptr();
 
     auto pipelineLayout = pCreateInfo->layout != VK_NULL_HANDLE ? &my_data->pipelineLayoutMap[pCreateInfo->layout] : nullptr;
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -163,12 +163,12 @@ DescriptorSetLayout::~DescriptorSetLayout() {
 VkDescriptorSetLayoutBinding const *DescriptorSetLayout::GetDescriptorSetLayoutBindingPtrFromBinding(const uint32_t binding) {
     if (!binding_to_index_map_.count(binding))
         return nullptr;
-    return reinterpret_cast<VkDescriptorSetLayoutBinding const *>(&bindings_[binding_to_index_map_[binding]]);
+    return bindings_[binding_to_index_map_[binding]].ptr();
 }
 VkDescriptorSetLayoutBinding const *DescriptorSetLayout::GetDescriptorSetLayoutBindingPtrFromIndex(const uint32_t index) {
     if (index >= bindings_.size())
         return nullptr;
-    return reinterpret_cast<VkDescriptorSetLayoutBinding const *>(&bindings_[index]);
+    return bindings_[index].ptr();
 }
 // Return descriptorCount for given binding, 0 if index is unavailable
 uint32_t DescriptorSetLayout::GetDescriptorCountFromBinding(const uint32_t binding) {

--- a/vk_helper.py
+++ b/vk_helper.py
@@ -1602,6 +1602,8 @@ class StructWrapperGen:
             ss_decls.append("    %s();" % (ss_name))
             ss_decls.append("    ~%s();" % (ss_name))
             ss_decls.append("    void initialize(const %s* pInStruct);" % (s))
+            ss_decls.append("    %s *ptr() { return reinterpret_cast<%s *>(this); }" % (s, s))
+            ss_decls.append("    %s const *ptr() const { return reinterpret_cast<%s const *>(this); }" % (s, s))
             ss_decls.append("};")
             if s in ifdef_dict:
                 ss_decls.append('#endif')


### PR DESCRIPTION
These casts were annoying noise, and uncheckable. Move them into the
generator where we know the one type that makes sense.

Drop spurious reinterpret_cast of stage create info to itself -- it's
all raw types once the root pCreateInfo is unwrapped.

Signed-off-by: Chris Forbes <chrisforbes@google.com>