### PR TITLE
tests: #437 Start testing the WSI swapchain validation layer

### DIFF
--- a/layers/swapchain.cpp
+++ b/layers/swapchain.cpp
@@ -859,6 +859,14 @@ vkDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface, const VkAllocatio
     layer_data *my_data = get_my_data_ptr(get_dispatch_key(instance), layer_data_map);
     std::unique_lock<std::mutex> lock(global_lock);
     SwpSurface *pSurface = &my_data->surfaceMap[surface];
+    SwpInstance *pInstance = &(my_data->instanceMap[instance]);
+
+    // Validate that the platform extension was enabled:
+    if (pInstance && !pInstance->surfaceExtensionEnabled) {
+        skipCall |= LOG_ERROR(VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, pInstance, "VkInstance", SWAPCHAIN_EXT_NOT_ENABLED_BUT_USED,
+                              "%s() called even though the %s extension was not enabled for this VkInstance.", __FUNCTION__,
+                              VK_KHR_SURFACE_EXTENSION_NAME);
+    }
 
     // Regardless of skipCall value, do some internal cleanup:
     if (pSurface) {

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -652,6 +652,33 @@ TEST_F(VkLayerTest, EnableWsiBeforeUse) {
 #endif // VK_USE_PLATFORM_XCB_KHR
 
 
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+    // Use the functions from the VK_KHR_xlib_surface extension without enabling
+    // that extension:
+
+    // Create a surface:
+    VkXlibSurfaceCreateInfoKHR xlib_create_info = {};
+#if 0
+#endif
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkCreateXlibSurfaceKHR(instance(), &xlib_create_info, NULL, &surface);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Tell whether an Xlib VisualID supports presentation:
+    Display *dpy = NULL;
+    VisualID visual = 0;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    vkGetPhysicalDeviceXlibPresentationSupportKHR(gpu(), 0, dpy, visual);
+    m_errorMonitor->VerifyFound();
+#endif // VK_USE_PLATFORM_XLIB_KHR
+
+
     // Use the functions from the VK_KHR_surface extension without enabling
     // that extension:
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -610,6 +610,182 @@ TEST_F(VkLayerTest, CallBeginCommandBufferBeforeCompletion)
 }
 #endif
 
+TEST_F(VkLayerTest, EnableWsiBeforeUse) {
+    VkResult err;
+    bool pass;
+
+    VkSurfaceKHR surface = VK_NULL_HANDLE;
+    VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+    VkSwapchainCreateInfoKHR swapchain_create_info = {};
+    uint32_t swapchain_image_count = 0;
+//    VkImage swapchain_images[1] = {VK_NULL_HANDLE};
+    uint32_t image_index = 0;
+//    VkPresentInfoKHR present_info = {};
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+    // Use the functions from the VK_KHR_xcb_surface extension without enabling
+    // that extension:
+
+    // Create a surface:
+    VkXcbSurfaceCreateInfoKHR xcb_create_info = {};
+#if 0
+#endif
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkCreateXcbSurfaceKHR(instance(), &xcb_create_info, NULL, &surface);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Tell whether an xcb_visualid_t supports presentation:
+    xcb_connection_t *connection = NULL;
+    xcb_visualid_t visual_id = 0;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    vkGetPhysicalDeviceXcbPresentationSupportKHR(gpu(), 0, connection,
+        visual_id);
+    m_errorMonitor->VerifyFound();
+#endif // VK_USE_PLATFORM_XCB_KHR
+
+
+    // Use the functions from the VK_KHR_surface extension without enabling
+    // that extension:
+
+    // Destroy a surface:
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    vkDestroySurfaceKHR(instance(), surface, NULL);
+    m_errorMonitor->VerifyFound();
+
+    // Check if surface supports presentation:
+    VkBool32 supported = false;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkGetPhysicalDeviceSurfaceSupportKHR(gpu(), 0, surface, &supported);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Check surface capabilities:
+    VkSurfaceCapabilitiesKHR capabilities = {};
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), surface,
+        &capabilities);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Check surface formats:
+    uint32_t format_count = 0;
+    VkSurfaceFormatKHR *formats = NULL;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkGetPhysicalDeviceSurfaceFormatsKHR(gpu(), surface,
+        &format_count, formats);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Check surface present modes:
+    uint32_t present_mode_count = 0;
+    VkSurfaceFormatKHR *present_modes = NULL;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkGetPhysicalDeviceSurfaceFormatsKHR(gpu(), surface,
+        &present_mode_count, present_modes);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+
+    // Use the functions from the VK_KHR_swapchain extension without enabling
+    // that extension:
+
+    // Create a swapchain:
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    swapchain_create_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+    swapchain_create_info.pNext = NULL;
+#if 0
+    swapchain_create_info.flags = 0;
+    swapchain_create_info.surface = 0;
+    swapchain_create_info.minImageCount = 0;
+    swapchain_create_info.imageFormat = 0;
+    swapchain_create_info.imageColorSpace = 0;
+    swapchain_create_info.imageExtent.width = 0;
+    swapchain_create_info.imageExtent.height = 0;
+    swapchain_create_info.imageArrayLayers = 0;
+    swapchain_create_info.imageUsage = 0;
+    swapchain_create_info.imageSharingMode = 0;
+    swapchain_create_info.queueFamilyIndexCount = 0;
+    swapchain_create_info.preTransform = 0;
+    swapchain_create_info.compositeAlpha = 0;
+    swapchain_create_info.presentMode = 0;
+    swapchain_create_info.clipped = 0;
+    swapchain_create_info.oldSwapchain = NULL;
+#endif
+    err = vkCreateSwapchainKHR(m_device->device(), &swapchain_create_info,
+                               NULL, &swapchain);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Get the images from the swapchain:
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkGetSwapchainImagesKHR(m_device->device(), swapchain,
+                                  &swapchain_image_count, NULL);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Try to acquire an image:
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkAcquireNextImageKHR(m_device->device(), swapchain, 0,
+                                VK_NULL_HANDLE, VK_NULL_HANDLE, &image_index);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Try to present an image:
+#if 0   // NOTE: Currently can't test this because a real swapchain is needed
+        // (as opposed to the fake one we created) in order for the layer to
+        // lookup the VkDevice used to enable the extension:
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+    present_info.pNext = NULL;
+#if 0
+#endif
+    err = vkQueuePresentKHR(m_device->m_queue, &present_info);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+#endif
+
+    // Destroy the swapchain:
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    vkDestroySwapchainKHR(m_device->device(), swapchain, NULL);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(VkLayerTest, MapMemWithoutHostVisibleBit) {
     VkResult err;
     bool pass;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -283,6 +283,7 @@ class VkLayerTest : public VkRenderFramework {
         instance_layer_names.push_back("VK_LAYER_LUNARG_core_validation");
         instance_layer_names.push_back("VK_LAYER_LUNARG_device_limits");
         instance_layer_names.push_back("VK_LAYER_LUNARG_image");
+        instance_layer_names.push_back("VK_LAYER_LUNARG_swapchain");
         instance_layer_names.push_back("VK_LAYER_GOOGLE_unique_objects");
 
         device_layer_names.push_back("VK_LAYER_GOOGLE_threading");
@@ -291,6 +292,7 @@ class VkLayerTest : public VkRenderFramework {
         device_layer_names.push_back("VK_LAYER_LUNARG_core_validation");
         device_layer_names.push_back("VK_LAYER_LUNARG_device_limits");
         device_layer_names.push_back("VK_LAYER_LUNARG_image");
+        device_layer_names.push_back("VK_LAYER_LUNARG_swapchain");
         device_layer_names.push_back("VK_LAYER_GOOGLE_unique_objects");
 
         this->app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -624,6 +624,110 @@ TEST_F(VkLayerTest, EnableWsiBeforeUse) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
+#ifdef NEED_TO_TEST_THIS_ON_PLATFORM
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    // Use the functions from the VK_KHR_android_surface extension without
+    // enabling that extension:
+
+    // Create a surface:
+    VkAndroidSurfaceCreateInfoKHR android_create_info = {};
+#if 0
+#endif
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkCreateAndroidSurfaceKHR(instance(), &android_create_info, NULL,
+        &surface);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+#endif // VK_USE_PLATFORM_ANDROID_KHR
+
+
+#if defined(VK_USE_PLATFORM_MIR_KHR)
+    // Use the functions from the VK_KHR_mir_surface extension without enabling
+    // that extension:
+
+    // Create a surface:
+    VkMirSurfaceCreateInfoKHR mir_create_info = {};
+#if 0
+#endif
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkCreateMirSurfaceKHR(instance(), &mir_create_info, NULL, &surface);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Tell whether an mir_connection supports presentation:
+    MirConnection *mir_connection = NULL;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    vkGetPhysicalDeviceMirPresentationSupportKHR(gpu(), 0, mir_connection,
+        visual_id);
+    m_errorMonitor->VerifyFound();
+#endif // VK_USE_PLATFORM_MIR_KHR
+
+
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+    // Use the functions from the VK_KHR_wayland_surface extension without
+    // enabling that extension:
+
+    // Create a surface:
+    VkWaylandSurfaceCreateInfoKHR wayland_create_info = {};
+#if 0
+#endif
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkCreateWaylandSurfaceKHR(instance(), &wayland_create_info, NULL,
+                                    &surface);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Tell whether an wayland_display supports presentation:
+    struct wl_display wayland_display = {};
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    vkGetPhysicalDeviceWaylandPresentationSupportKHR(gpu(), 0,
+                                                     &wayland_display);
+    m_errorMonitor->VerifyFound();
+#endif // VK_USE_PLATFORM_WAYLAND_KHR
+
+
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+    // Use the functions from the VK_KHR_win32_surface extension without
+    // enabling that extension:
+
+    // Create a surface:
+    VkWin32SurfaceCreateInfoKHR win32_create_info = {};
+#if 0
+#endif
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    err = vkCreateWin32SurfaceKHR(instance(), &win32_create_info, NULL,
+                                  &surface);
+    pass = (err != VK_SUCCESS);
+    ASSERT_TRUE(pass);
+    m_errorMonitor->VerifyFound();
+
+    // Tell whether win32 supports presentation:
+    struct wl_display win32_display = {};
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "extension was not enabled for this");
+    vkGetPhysicalDeviceWin32PresentationSupportKHR(gpu(), 0,
+                                                     &win32_display);
+    m_errorMonitor->VerifyFound();
+#endif // VK_USE_PLATFORM_WAYLAND_KHR
+#endif // NEED_TO_TEST_THIS_ON_PLATFORM
+
+
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     // Use the functions from the VK_KHR_xcb_surface extension without enabling
     // that extension:
@@ -641,12 +745,12 @@ TEST_F(VkLayerTest, EnableWsiBeforeUse) {
     m_errorMonitor->VerifyFound();
 
     // Tell whether an xcb_visualid_t supports presentation:
-    xcb_connection_t *connection = NULL;
+    xcb_connection_t *xcb_connection = NULL;
     xcb_visualid_t visual_id = 0;
     m_errorMonitor->SetDesiredFailureMsg(
         VK_DEBUG_REPORT_ERROR_BIT_EXT,
         "extension was not enabled for this");
-    vkGetPhysicalDeviceXcbPresentationSupportKHR(gpu(), 0, connection,
+    vkGetPhysicalDeviceXcbPresentationSupportKHR(gpu(), 0, xcb_connection,
         visual_id);
     m_errorMonitor->VerifyFound();
 #endif // VK_USE_PLATFORM_XCB_KHR

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -58,6 +58,7 @@ class VkRenderFramework : public VkTestFramework {
     VkRenderFramework();
     ~VkRenderFramework();
 
+    VkInstance instance() { return inst; }
     VkDevice device() { return m_device->device(); }
     VkPhysicalDevice gpu() { return objs[0]; }
     VkRenderPass renderPass() { return m_renderPass; }


### PR DESCRIPTION
    This is the initial version of the EnableWsiBeforeUse test case.  It verifies
    that the swapchain validation layer issues an error if any of the WSI functions
    are called when the corresponding extension isn't enabled.  This Initial
    version tests the functions for the following extensions:
    
    - VK_KHR_xcb_surface
    - VK_KHR_surface
    - VK_KHR_swapchain
    
    There is curently one exception: vkQueuePresentKHR().  This function dispatches
    from a VkQueue.  The layer uses the swapchain parameter in order to look up the
    VkDevice that the extension should have been enabled for.  Since we didn't
    create a real swapchain, the lookup doesn't occur (the layer doesn't chase NULL
    pointers), and so the error doesn't occur.
    
    This test case still needs to test the following extensions:
    
    - VK_KHR_android_surface
    - VK_KHR_mir_surface
    - VK_KHR_wayland_surface
    - VK_KHR_win32_surface
    - VK_KHR_xlib_surface
    
    When the swapchain layer supports the following extensions, this test case
    should test them:
    
    - VK_KHR_display
    - VK_KHR_display_swapchain

Note: The test code caught that one WSI function (vkDestroySurfaceKHR()) wasn't checking whether the VK_KHR_surface extension was enabled.  That is fixed with this pull request.