### PR TITLE
layers: GH463 Fix layout compatibility check

### DIFF
--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -241,9 +241,7 @@ bool DescriptorSetLayout::IsCompatible(DescriptorSetLayout *rh_ds_layout, string
     //  and verify that type and stageFlags match
     for (auto binding : bindings_) {
         // TODO : Do we also need to check immutable samplers?
-        // VkDescriptorSetLayoutBinding *rh_binding;
-        // rh_ds_layout->FillDescriptorSetLayoutBindingStructFromBinding(binding->binding, rh_binding);
-        if (binding->descriptorCount != rh_ds_layout->GetTotalDescriptorCount()) {
+        if (binding->descriptorCount != rh_ds_layout->GetDescriptorCountFromBinding(binding->binding)) {
             stringstream error_str;
             error_str << "Binding " << binding->binding << " for DescriptorSetLayout " << layout_ << " has a descriptorCount of "
                       << binding->descriptorCount << " but binding " << binding->binding << " for DescriptorSetLayout "


### PR DESCRIPTION
Fix for #463 
After lh and rh layout descriptorCounts were verified to be the same, the
next check was testing the descriptor count for each binding in the lh binding
against the entire descriptor count for the rh layout. The check should be made
just against the descriptor count for the specific binding we're checking in
the rh layout.