### PR TITLE
Fixed unintialised memory in cube demo

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -2942,6 +2942,7 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
 
     memset(demo, 0, sizeof(*demo));
     demo->frameCount = INT32_MAX;
+    demo->use_xlib = false;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--use_staging") == 0) {


### PR DESCRIPTION
Structure initialised at demos/cube.c:3145 using linux, 3082 in android and 1979. It might be a good idea to rename the declaration of the variable "demo" so it is different to the structure "demo".