### PR TITLE
layers:LX#470 Address poor use of hex vs dec output & w/a convention

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -59,9 +59,6 @@
 #include <unordered_set>
 #include <vector>
 
-using std::vector;
-using std::unordered_set;
-
 #if MTMERGE
 
 /*
@@ -147,7 +144,7 @@ class PIPELINE_NODE {
     uint32_t active_shaders;
     uint32_t duplicate_shaders;
     // Capture which slots (set#->bindings) are actually used by the shaders of this pipeline
-    unordered_map<uint32_t, unordered_set<uint32_t>> active_slots;
+    std::unordered_map<uint32_t, std::unordered_set<uint32_t>> active_slots;
     // Vtx input info (if any)
     std::vector<VkVertexInputBindingDescription> vertexBindingDescriptions;
     std::vector<VkVertexInputAttributeDescription> vertexAttributeDescriptions;
@@ -230,12 +227,12 @@ struct RENDER_PASS_NODE {
     VkRenderPass renderPass;
     VkRenderPassCreateInfo const *pCreateInfo;
     VkFramebuffer fb;
-    vector<bool> hasSelfDependency;
-    vector<DAGNode> subpassToNode;
-    vector<vector<VkFormat>> subpassColorFormats;
-    vector<MT_PASS_ATTACHMENT_INFO> attachments;
-    unordered_map<uint32_t, bool> attachment_first_read;
-    unordered_map<uint32_t, VkImageLayout> attachment_first_layout;
+    std::vector<bool> hasSelfDependency;
+    std::vector<DAGNode> subpassToNode;
+    std::vector<std::vector<VkFormat>> subpassColorFormats;
+    std::vector<MT_PASS_ATTACHMENT_INFO> attachments;
+    std::unordered_map<uint32_t, bool> attachment_first_read;
+    std::unordered_map<uint32_t, VkImageLayout> attachment_first_layout;
 
     RENDER_PASS_NODE(VkRenderPassCreateInfo const *pCreateInfo) : pCreateInfo(pCreateInfo), fb(VK_NULL_HANDLE) {
         uint32_t i;
@@ -243,7 +240,7 @@ struct RENDER_PASS_NODE {
         subpassColorFormats.reserve(pCreateInfo->subpassCount);
         for (i = 0; i < pCreateInfo->subpassCount; i++) {
             const VkSubpassDescription *subpass = &pCreateInfo->pSubpasses[i];
-            vector<VkFormat> color_formats;
+            std::vector<VkFormat> color_formats;
             uint32_t j;
 
             color_formats.reserve(subpass->colorAttachmentCount);
@@ -267,7 +264,7 @@ class PHYS_DEV_PROPERTIES_NODE {
   public:
     VkPhysicalDeviceProperties properties;
     VkPhysicalDeviceFeatures features;
-    vector<VkQueueFamilyProperties> queue_family_properties;
+    std::vector<VkQueueFamilyProperties> queue_family_properties;
 };
 
 class FENCE_NODE : public BASE_NODE {
@@ -278,9 +275,9 @@ class FENCE_NODE : public BASE_NODE {
     bool firstTimeFlag;       // Fence was created in signaled state, avoid warnings for first use
     VkFenceCreateInfo createInfo;
     std::unordered_set<VkQueue> queues;
-    vector<VkCommandBuffer> cmdBuffers;
+    std::vector<VkCommandBuffer> cmdBuffers;
     bool needsSignaled;
-    vector<VkFence> priorFences;
+    std::vector<VkFence> priorFences;
 
     // Default constructor
     FENCE_NODE() : swapchain(VK_NULL_HANDLE), firstTimeFlag(false), needsSignaled(false){};
@@ -303,14 +300,14 @@ class EVENT_NODE : public BASE_NODE {
 class QUEUE_NODE {
   public:
     VkDevice device;
-    vector<VkFence> lastFences;
+    std::vector<VkFence> lastFences;
 #if MTMERGE
     // MTMTODO : merge cmd_buffer data structs here
-    list<VkCommandBuffer> pQueueCommandBuffers;
-    list<VkDeviceMemory> pMemRefList;
+    std::list<VkCommandBuffer> pQueueCommandBuffers;
+    std::list<VkDeviceMemory> pMemRefList;
 #endif
-    vector<VkCommandBuffer> untrackedCmdBuffers;
-    unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
+    std::vector<VkCommandBuffer> untrackedCmdBuffers;
+    std::unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
 };
 
 class QUERY_POOL_NODE : public BASE_NODE {
@@ -321,14 +318,14 @@ class QUERY_POOL_NODE : public BASE_NODE {
 class FRAMEBUFFER_NODE {
   public:
     VkFramebufferCreateInfo createInfo;
-    unordered_set<VkCommandBuffer> referencingCmdBuffers;
-    vector<MT_FB_ATTACHMENT_INFO> attachments;
+    std::unordered_set<VkCommandBuffer> referencingCmdBuffers;
+    std::vector<MT_FB_ATTACHMENT_INFO> attachments;
 };
 // Store layouts and pushconstants for PipelineLayout
 struct PIPELINE_LAYOUT_NODE {
-    vector<VkDescriptorSetLayout> descriptorSetLayouts;
-    vector<cvdescriptorset::DescriptorSetLayout const *> setLayouts;
-    vector<VkPushConstantRange> pushConstantRanges;
+    std::vector<VkDescriptorSetLayout> descriptorSetLayouts;
+    std::vector<cvdescriptorset::DescriptorSetLayout const *> setLayouts;
+    std::vector<VkPushConstantRange> pushConstantRanges;
 };
 
 typedef struct _DESCRIPTOR_POOL_NODE {
@@ -337,9 +334,9 @@ typedef struct _DESCRIPTOR_POOL_NODE {
     uint32_t availableSets;                        // Available descriptor sets in this pool
 
     VkDescriptorPoolCreateInfo createInfo;
-    unordered_set<cvdescriptorset::DescriptorSet *> sets; // Collection of all sets in this pool
-    vector<uint32_t> maxDescriptorTypeCount;       // Max # of descriptors of each type in this pool
-    vector<uint32_t> availableDescriptorTypeCount; // Available # of descriptors of each type in this pool
+    std::unordered_set<cvdescriptorset::DescriptorSet *> sets; // Collection of all sets in this pool
+    std::vector<uint32_t> maxDescriptorTypeCount;       // Max # of descriptors of each type in this pool
+    std::vector<uint32_t> availableDescriptorTypeCount; // Available # of descriptors of each type in this pool
 
     _DESCRIPTOR_POOL_NODE(const VkDescriptorPool pool, const VkDescriptorPoolCreateInfo *pCreateInfo)
         : pool(pool), maxSets(pCreateInfo->maxSets), availableSets(pCreateInfo->maxSets), createInfo(*pCreateInfo),
@@ -456,7 +453,7 @@ typedef struct stencil_data {
     uint32_t reference;
 } CBStencilData;
 
-typedef struct _DRAW_DATA { vector<VkBuffer> buffers; } DRAW_DATA;
+typedef struct _DRAW_DATA { std::vector<VkBuffer> buffers; } DRAW_DATA;
 
 struct ImageSubresourcePair {
     VkImage image;
@@ -509,11 +506,11 @@ struct LAST_BOUND_STATE {
     VkPipelineLayout pipelineLayout;
     // Track each set that has been bound
     // TODO : can unique be global per CB? (do we care about Gfx vs. Compute?)
-    unordered_set<VkDescriptorSet> uniqueBoundSets;
+    std::unordered_set<VkDescriptorSet> uniqueBoundSets;
     // Ordered bound set tracking where index is set# that given set is bound to
-    vector<VkDescriptorSet> boundDescriptorSets;
+    std::vector<VkDescriptorSet> boundDescriptorSets;
     // one dynamic offset per dynamic descriptor bound to this CB
-    vector<uint32_t> dynamicOffsets;
+    std::vector<uint32_t> dynamicOffsets;
     void reset() {
         pipeline = VK_NULL_HANDLE;
         pipelineLayout = VK_NULL_HANDLE;
@@ -535,7 +532,7 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     CB_STATE state;                     // Track cmd buffer update state
     uint64_t submitCount;               // Number of times CB has been submitted
     CBStatusFlags status;               // Track status of various bindings on cmd buffer
-    vector<CMD_NODE> cmds;              // vector of commands bound to this command buffer
+    std::vector<CMD_NODE> cmds;              // vector of commands bound to this command buffer
     // Currently storing "lastBound" objects on per-CB basis
     //  long-term may want to create caches of "lastBound" states and could have
     //  each individual CMD_NODE referencing its own "lastBound" state
@@ -547,8 +544,8 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     // Store last bound state for Gfx & Compute pipeline bind points
     LAST_BOUND_STATE lastBound[VK_PIPELINE_BIND_POINT_RANGE_SIZE];
 
-    vector<VkViewport> viewports;
-    vector<VkRect2D> scissors;
+    std::vector<VkViewport> viewports;
+    std::vector<VkRect2D> scissors;
     VkRenderPassBeginInfo activeRenderPassBeginInfo;
     uint64_t fenceId;
     VkFence lastSubmittedFence;
@@ -561,31 +558,31 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     // TODO : These data structures relate to tracking resources that invalidate
     //  a cmd buffer that references them. Need to unify how we handle these
     //  cases so we don't have different tracking data for each type.
-    unordered_set<VkDescriptorSet> destroyedSets;
-    unordered_set<VkDescriptorSet> updatedSets;
-    unordered_set<VkFramebuffer> destroyedFramebuffers;
-    vector<VkEvent> waitedEvents;
-    vector<VkSemaphore> semaphores;
-    vector<VkEvent> events;
-    unordered_map<QueryObject, vector<VkEvent>> waitedEventsBeforeQueryReset;
-    unordered_map<QueryObject, bool> queryToStateMap; // 0 is unavailable, 1 is available
-    unordered_set<QueryObject> activeQueries;
-    unordered_set<QueryObject> startedQueries;
-    unordered_map<ImageSubresourcePair, IMAGE_CMD_BUF_LAYOUT_NODE> imageLayoutMap;
-    unordered_map<VkImage, vector<ImageSubresourcePair>> imageSubresourceMap;
-    unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
-    vector<DRAW_DATA> drawData;
+    std::unordered_set<VkDescriptorSet> destroyedSets;
+    std::unordered_set<VkDescriptorSet> updatedSets;
+    std::unordered_set<VkFramebuffer> destroyedFramebuffers;
+    std::vector<VkEvent> waitedEvents;
+    std::vector<VkSemaphore> semaphores;
+    std::vector<VkEvent> events;
+    std::unordered_map<QueryObject, std::vector<VkEvent>> waitedEventsBeforeQueryReset;
+    std::unordered_map<QueryObject, bool> queryToStateMap; // 0 is unavailable, 1 is available
+    std::unordered_set<QueryObject> activeQueries;
+    std::unordered_set<QueryObject> startedQueries;
+    std::unordered_map<ImageSubresourcePair, IMAGE_CMD_BUF_LAYOUT_NODE> imageLayoutMap;
+    std::unordered_map<VkImage, std::vector<ImageSubresourcePair>> imageSubresourceMap;
+    std::unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
+    std::vector<DRAW_DATA> drawData;
     DRAW_DATA currentDrawData;
     VkCommandBuffer primaryCommandBuffer;
     // Track images and buffers that are updated by this CB at the point of a draw
-    unordered_set<VkImageView> updateImages;
-    unordered_set<VkBuffer> updateBuffers;
+    std::unordered_set<VkImageView> updateImages;
+    std::unordered_set<VkBuffer> updateBuffers;
     // If cmd buffer is primary, track secondary command buffers pending
     // execution
     std::unordered_set<VkCommandBuffer> secondaryCommandBuffers;
     // MTMTODO : Scrub these data fields and merge active sets w/ lastBound as appropriate
-    vector<std::function<bool()>> validate_functions;
+    std::vector<std::function<bool()>> validate_functions;
     std::unordered_set<VkDeviceMemory> memObjs;
-    vector<std::function<bool(VkQueue)>> eventUpdates;
+    std::vector<std::function<bool(VkQueue)>> eventUpdates;
 };
 

--- a/layers/device_limits.cpp
+++ b/layers/device_limits.cpp
@@ -201,7 +201,7 @@ EnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount, Vk
         return result;
     } else {
         log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, 0, __LINE__,
-                DEVLIMITS_INVALID_INSTANCE, "DL", "Invalid instance (%#" PRIxLEAST64 ") passed into vkEnumeratePhysicalDevices().",
+                DEVLIMITS_INVALID_INSTANCE, "DL", "Invalid instance (0x%" PRIxLEAST64 ") passed into vkEnumeratePhysicalDevices().",
                 (uint64_t)instance);
     }
     return VK_ERROR_VALIDATION_FAILED_EXT;
@@ -282,7 +282,7 @@ GetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice, uint32_t
     } else {
         log_msg(phy_dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0,
                 __LINE__, DEVLIMITS_INVALID_PHYSICAL_DEVICE, "DL",
-                "Invalid physicalDevice (%#" PRIxLEAST64 ") passed into vkGetPhysicalDeviceQueueFamilyProperties().",
+                "Invalid physicalDevice (0x%" PRIxLEAST64 ") passed into vkGetPhysicalDeviceQueueFamilyProperties().",
                 (uint64_t)physicalDevice);
     }
 }
@@ -560,8 +560,8 @@ UpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount, const VkWri
                     skipCall |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                         VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0, __LINE__,
                                         DEVLIMITS_INVALID_UNIFORM_BUFFER_OFFSET, "DL",
-                                        "vkUpdateDescriptorSets(): pDescriptorWrites[%d].pBufferInfo[%d].offset (%#" PRIxLEAST64
-                                        ") must be a multiple of device limit minUniformBufferOffsetAlignment %#" PRIxLEAST64,
+                                        "vkUpdateDescriptorSets(): pDescriptorWrites[%d].pBufferInfo[%d].offset (0x%" PRIxLEAST64
+                                        ") must be a multiple of device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64,
                                         i, j, pDescriptorWrites[i].pBufferInfo[j].offset, uniformAlignment);
                 }
             }
@@ -573,8 +573,8 @@ UpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount, const VkWri
                     skipCall |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                         VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0, __LINE__,
                                         DEVLIMITS_INVALID_STORAGE_BUFFER_OFFSET, "DL",
-                                        "vkUpdateDescriptorSets(): pDescriptorWrites[%d].pBufferInfo[%d].offset (%#" PRIxLEAST64
-                                        ") must be a multiple of device limit minStorageBufferOffsetAlignment %#" PRIxLEAST64,
+                                        "vkUpdateDescriptorSets(): pDescriptorWrites[%d].pBufferInfo[%d].offset (0x%" PRIxLEAST64
+                                        ") must be a multiple of device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64,
                                         i, j, pDescriptorWrites[i].pBufferInfo[j].offset, storageAlignment);
                 }
             }

--- a/layers/image.cpp
+++ b/layers/image.cpp
@@ -48,6 +48,8 @@
 #include "vk_layer_utils.h"
 #include "vk_layer_logging.h"
 
+using namespace std;
+
 namespace image {
 
 struct layer_data {
@@ -310,7 +312,7 @@ CreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo, const VkAlloc
         skipCall |= log_msg(phy_dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
                             (uint64_t)pImage, __LINE__, IMAGE_INVALID_FORMAT_LIMITS_VIOLATION, "Image",
                             "CreateImage resource size exceeds allowable maximum "
-                            "Image resource size = %#" PRIxLEAST64 ", maximum resource size = %#" PRIxLEAST64 " ",
+                            "Image resource size = 0x%" PRIxLEAST64 ", maximum resource size = 0x%" PRIxLEAST64 " ",
                             totalSize, ImageFormatProperties.maxResourceSize);
     }
 

--- a/layers/object_tracker.h
+++ b/layers/object_tracker.h
@@ -392,7 +392,7 @@ static void destroy_surface_khr(VkInstance dispatchable_object, VkSurfaceKHR obj
         numObjs[objIndex]--;
         log_msg(mdd(dispatchable_object), VK_DEBUG_REPORT_INFORMATION_BIT_EXT, pNode->objType, object_handle, __LINE__,
                 OBJTRACK_NONE, "OBJTRACK",
-                "OBJ_STAT Destroy %s obj 0x%" PRIxLEAST64 " (%" PRIu64 " total objs remain & %" PRIu64 " %s objs).",
+                "OBJ_STAT Destroy %s obj 0x%" PRIxLEAST64 " (0x%" PRIx64 " total objs remain & 0x%" PRIx64 " %s objs).",
                 string_VkDebugReportObjectTypeEXT(pNode->objType), (uint64_t)(object), numTotalObjs, numObjs[objIndex],
                 string_VkDebugReportObjectTypeEXT(pNode->objType));
         delete pNode;

--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -75,7 +75,7 @@ debug_report_data *mid(VkInstance object) {
     dispatch_key key = get_dispatch_key(object);
     layer_data *data = get_my_data_ptr(key, layer_data_map);
 #if DISPATCH_MAP_DEBUG
-    fprintf(stderr, "MID: map: %p, object: %p, key: %p, data: %p\n", &layer_data_map, object, key, data);
+    fprintf(stderr, "MID: map:  0x%p, object:  0x%p, key:  0x%p, data:  0x%p\n", &layer_data_map, object, key, data);
 #endif
     assert(data != NULL);
 
@@ -87,7 +87,7 @@ debug_report_data *mdd(void *object) {
     dispatch_key key = get_dispatch_key(object);
     layer_data *data = get_my_data_ptr(key, layer_data_map);
 #if DISPATCH_MAP_DEBUG
-    fprintf(stderr, "MDD: map: %p, object: %p, key: %p, data: %p\n", &layer_data_map, object, key, data);
+    fprintf(stderr, "MDD: map:  0x%p, object:  0x%p, key:  0x%p, data:  0x%p\n", &layer_data_map, object, key, data);
 #endif
     assert(data != NULL);
     return data->report_data;
@@ -1664,7 +1664,7 @@ VK_LAYER_EXPORT VKAPI_ATTR void VKAPI_CALL vkDestroyDevice(VkDevice device, cons
         layer_debug_report_destroy_device(device);
 
 #if DISPATCH_MAP_DEBUG
-        fprintf(stderr, "Device: %p, key: %p\n", device, key);
+        fprintf(stderr, "Device:  0x%p, key:  0x%p\n", device, key);
 #endif
 
         get_dispatch_table(pc_device_table_map, device)->DestroyDevice(device, pAllocator);

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -341,7 +341,7 @@ static inline VKAPI_ATTR VkBool32 VKAPI_CALL log_callback(VkFlags msgFlags, VkDe
 
     print_msg_flags(msgFlags, msg_flags);
 
-    fprintf((FILE *)pUserData, "%s(%s): object: %#" PRIx64 " type: %d location: %lu msgCode: %d: %s\n", pLayerPrefix, msg_flags,
+    fprintf((FILE *)pUserData, "%s(%s): object: 0x%" PRIx64 " type: %d location: %lu msgCode: %d: %s\n", pLayerPrefix, msg_flags,
             srcObject, objType, (unsigned long)location, msgCode, pMsg);
     fflush((FILE *)pUserData);
 

--- a/layers/vk_layer_table.cpp
+++ b/layers/vk_layer_table.cpp
@@ -40,10 +40,10 @@ VkLayerInstanceDispatchTable *instance_dispatch_table(void *object) {
     instance_table_map::const_iterator it = tableInstanceMap.find((void *)key);
 #if DISPATCH_MAP_DEBUG
     if (it != tableInstanceMap.end()) {
-        fprintf(stderr, "instance_dispatch_table: map: %p, object: %p, key: %p, table: %p\n", &tableInstanceMap, object, key,
+        fprintf(stderr, "instance_dispatch_table: map:  0x%p, object:  0x%p, key:  0x%p, table:  0x%p\n", &tableInstanceMap, object, key,
                 it->second);
     } else {
-        fprintf(stderr, "instance_dispatch_table: map: %p, object: %p, key: %p, table: UNKNOWN\n", &tableInstanceMap, object, key);
+        fprintf(stderr, "instance_dispatch_table: map:  0x%p, object:  0x%p, key:  0x%p, table: UNKNOWN\n", &tableInstanceMap, object, key);
     }
 #endif
     assert(it != tableInstanceMap.end() && "Not able to find instance dispatch entry");
@@ -54,9 +54,9 @@ void destroy_dispatch_table(device_table_map &map, dispatch_key key) {
 #if DISPATCH_MAP_DEBUG
     device_table_map::const_iterator it = map.find((void *)key);
     if (it != map.end()) {
-        fprintf(stderr, "destroy device dispatch_table: map: %p, key: %p, table: %p\n", &map, key, it->second);
+        fprintf(stderr, "destroy device dispatch_table: map:  0x%p, key:  0x%p, table:  0x%p\n", &map, key, it->second);
     } else {
-        fprintf(stderr, "destroy device dispatch table: map: %p, key: %p, table: UNKNOWN\n", &map, key);
+        fprintf(stderr, "destroy device dispatch table: map:  0x%p, key:  0x%p, table: UNKNOWN\n", &map, key);
         assert(it != map.end());
     }
 #endif
@@ -67,9 +67,9 @@ void destroy_dispatch_table(instance_table_map &map, dispatch_key key) {
 #if DISPATCH_MAP_DEBUG
     instance_table_map::const_iterator it = map.find((void *)key);
     if (it != map.end()) {
-        fprintf(stderr, "destroy instance dispatch_table: map: %p, key: %p, table: %p\n", &map, key, it->second);
+        fprintf(stderr, "destroy instance dispatch_table: map:  0x%p, key:  0x%p, table:  0x%p\n", &map, key, it->second);
     } else {
-        fprintf(stderr, "destroy instance dispatch table: map: %p, key: %p, table: UNKNOWN\n", &map, key);
+        fprintf(stderr, "destroy instance dispatch table: map:  0x%p, key:  0x%p, table: UNKNOWN\n", &map, key);
         assert(it != map.end());
     }
 #endif
@@ -85,10 +85,10 @@ VkLayerDispatchTable *get_dispatch_table(device_table_map &map, void *object) {
     device_table_map::const_iterator it = map.find((void *)key);
 #if DISPATCH_MAP_DEBUG
     if (it != map.end()) {
-        fprintf(stderr, "device_dispatch_table: map: %p, object: %p, key: %p, table: %p\n", &tableInstanceMap, object, key,
+        fprintf(stderr, "device_dispatch_table: map:  0x%p, object:  0x%p, key:  0x%p, table:  0x%p\n", &tableInstanceMap, object, key,
                 it->second);
     } else {
-        fprintf(stderr, "device_dispatch_table: map: %p, object: %p, key: %p, table: UNKNOWN\n", &tableInstanceMap, object, key);
+        fprintf(stderr, "device_dispatch_table: map:  0x%p, object:  0x%p, key:  0x%p, table: UNKNOWN\n", &tableInstanceMap, object, key);
     }
 #endif
     assert(it != map.end() && "Not able to find device dispatch entry");
@@ -101,10 +101,10 @@ VkLayerInstanceDispatchTable *get_dispatch_table(instance_table_map &map, void *
     instance_table_map::const_iterator it = map.find((void *)key);
 #if DISPATCH_MAP_DEBUG
     if (it != map.end()) {
-        fprintf(stderr, "instance_dispatch_table: map: %p, object: %p, key: %p, table: %p\n", &tableInstanceMap, object, key,
+        fprintf(stderr, "instance_dispatch_table: map:  0x%p, object:  0x%p, key:  0x%p, table:  0x%p\n", &tableInstanceMap, object, key,
                 it->second);
     } else {
-        fprintf(stderr, "instance_dispatch_table: map: %p, object: %p, key: %p, table: UNKNOWN\n", &tableInstanceMap, object, key);
+        fprintf(stderr, "instance_dispatch_table: map:  0x%p, object:  0x%p, key:  0x%p, table: UNKNOWN\n", &tableInstanceMap, object, key);
     }
 #endif
     assert(it != map.end() && "Not able to find instance dispatch entry");
@@ -145,11 +145,11 @@ VkLayerInstanceDispatchTable *initInstanceTable(VkInstance instance, const PFN_v
         pTable = new VkLayerInstanceDispatchTable;
         map[(void *)key] = pTable;
 #if DISPATCH_MAP_DEBUG
-        fprintf(stderr, "New, Instance: map: %p, key: %p, table: %p\n", &map, key, pTable);
+        fprintf(stderr, "New, Instance: map:  0x%p, key:  0x%p, table:  0x%p\n", &map, key, pTable);
 #endif
     } else {
 #if DISPATCH_MAP_DEBUG
-        fprintf(stderr, "Instance: map: %p, key: %p, table: %p\n", &map, key, it->second);
+        fprintf(stderr, "Instance: map:  0x%p, key:  0x%p, table:  0x%p\n", &map, key, it->second);
 #endif
         return it->second;
     }
@@ -172,11 +172,11 @@ VkLayerDispatchTable *initDeviceTable(VkDevice device, const PFN_vkGetDeviceProc
         pTable = new VkLayerDispatchTable;
         map[(void *)key] = pTable;
 #if DISPATCH_MAP_DEBUG
-        fprintf(stderr, "New, Device: map: %p, key: %p, table: %p\n", &map, key, pTable);
+        fprintf(stderr, "New, Device: map:  0x%p, key:  0x%p, table:  0x%p\n", &map, key, pTable);
 #endif
     } else {
 #if DISPATCH_MAP_DEBUG
-        fprintf(stderr, "Device: map: %p, key: %p, table: %p\n", &map, key, it->second);
+        fprintf(stderr, "Device: map:  0x%p, key:  0x%p, table:  0x%p\n", &map, key, it->second);
 #endif
         return it->second;
     }

--- a/vk-layer-generate.py
+++ b/vk-layer-generate.py
@@ -268,19 +268,19 @@ class Subcommand(object):
                 if 'pUserData' == name:
                     return ("%i", "((pUserData == 0) ? 0 : *(pUserData))")
                 if 'const' in vk_type.lower():
-                    return ("%p", "(void*)(%s)" % name)
+                    return ("0x%p", "(void*)(%s)" % name)
                 return ("%i", "*(%s)" % name)
             return ("%i", name)
         # TODO : This is special-cased as there's only one "format" param currently and it's nice to expand it
         if "VkFormat" == vk_type:
             if cpp:
-                return ("%p", "&%s" % name)
+                return ("0x%p", "&%s" % name)
             return ("{%s.channelFormat = %%s, %s.numericFormat = %%s}" % (name, name), "string_VK_COLOR_COMPONENT_FORMAT(%s.channelFormat), string_VK_FORMAT_RANGE_SIZE(%s.numericFormat)" % (name, name))
         if output_param:
-            return ("%p", "(void*)*%s" % name)
+            return ("0x%p", "(void*)*%s" % name)
         if vk_helper.is_type(vk_type, 'struct') and '*' not in vk_type:
-            return ("%p", "(void*)(&%s)" % name)
-        return ("%p", "(void*)(%s)" % name)
+            return ("0x%p", "(void*)(&%s)" % name)
+        return ("0x%p", "(void*)(%s)" % name)
 
     def _gen_create_msg_callback(self):
         r_body = []


### PR DESCRIPTION
1) Introduce convention of explicitly placing "0x" before hex
    format requests for clarity (don't use "%#")
2) All lower case in hex output (except w/stringstream which refuses
    to do anything but uppercase, possibly only on windows).
3) Decorated pointers are printed for all Vulkan structure types.
3) Some intelligence in generators based on Vulkan variable name:
     if the Vulkan variable name contains ("flag", "bit", "offset",
     "handle", "buffer", "object", "mask") it will be output in
     hexadecimal format

Change-Id: Idbae73bfdaa3bc059543d43b209373cd0bcbc099