### PR TITLE
layers: Move `fb` from RENDER_PASS_NODE to GLOBAL_CB_NODE

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3755,6 +3755,7 @@ static void resetCB(layer_data *dev_data, const VkCommandBuffer cb) {
             }
         }
         pCB->framebuffers.clear();
+        pCB->activeFramebuffer = nullptr;
 
     }
 }
@@ -8774,10 +8775,10 @@ CmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *p
             auto pass_data = dev_data->renderPassMap.find(pRenderPassBegin->renderPass);
             if (pass_data != dev_data->renderPassMap.end()) {
                 RENDER_PASS_NODE* pRPNode = pass_data->second;
-                pRPNode->fb = pRenderPassBegin->framebuffer;
+                pCB->activeFramebuffer = pRenderPassBegin->framebuffer;
                 auto cb_data = dev_data->commandBufferMap.find(commandBuffer);
                 for (size_t i = 0; i < pRPNode->attachments.size(); ++i) {
-                    MT_FB_ATTACHMENT_INFO &fb_info = dev_data->frameBufferMap[pRPNode->fb].attachments[i];
+                    MT_FB_ATTACHMENT_INFO &fb_info = dev_data->frameBufferMap[pRenderPassBegin->framebuffer].attachments[i];
                     if (pRPNode->attachments[i].load_op == VK_ATTACHMENT_LOAD_OP_CLEAR) {
                         if (cb_data != dev_data->commandBufferMap.end()) {
                             std::function<bool()> function = [=]() {
@@ -8873,7 +8874,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass(VkCommandBuffer commandBuffer) {
         RENDER_PASS_NODE* pRPNode = cb_data->second->activeRenderPass;
         if (pRPNode) {
             for (size_t i = 0; i < pRPNode->attachments.size(); ++i) {
-                MT_FB_ATTACHMENT_INFO &fb_info = dev_data->frameBufferMap[pRPNode->fb].attachments[i];
+                MT_FB_ATTACHMENT_INFO &fb_info = dev_data->frameBufferMap[cb_data->second->activeFramebuffer].attachments[i];
                 if (pRPNode->attachments[i].store_op == VK_ATTACHMENT_STORE_OP_STORE) {
                     if (cb_data != dev_data->commandBufferMap.end()) {
                         std::function<bool()> function = [=]() {
@@ -8903,6 +8904,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass(VkCommandBuffer commandBuffer) {
         TransitionFinalSubpassLayouts(commandBuffer, &pCB->activeRenderPassBeginInfo);
         pCB->activeRenderPass = nullptr;
         pCB->activeSubpass = 0;
+        pCB->activeFramebuffer = nullptr;
     }
     lock.unlock();
     if (!skipCall)
@@ -9061,7 +9063,7 @@ static bool validateFramebuffer(layer_data *dev_data, VkCommandBuffer primaryBuf
     if (!pSubCB->beginInfo.pInheritanceInfo) {
         return skip_call;
     }
-    VkFramebuffer primary_fb = pCB->activeRenderPass->fb;
+    VkFramebuffer primary_fb = pCB->activeFramebuffer;
     VkFramebuffer secondary_fb = pSubCB->beginInfo.pInheritanceInfo->framebuffer;
     if (secondary_fb != VK_NULL_HANDLE) {
         if (primary_fb != secondary_fb) {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -226,7 +226,6 @@ struct DAGNode {
 struct RENDER_PASS_NODE {
     VkRenderPass renderPass;
     VkRenderPassCreateInfo const *pCreateInfo;
-    VkFramebuffer fb;
     std::vector<bool> hasSelfDependency;
     std::vector<DAGNode> subpassToNode;
     std::vector<std::vector<VkFormat>> subpassColorFormats;
@@ -234,7 +233,7 @@ struct RENDER_PASS_NODE {
     std::unordered_map<uint32_t, bool> attachment_first_read;
     std::unordered_map<uint32_t, VkImageLayout> attachment_first_layout;
 
-    RENDER_PASS_NODE(VkRenderPassCreateInfo const *pCreateInfo) : pCreateInfo(pCreateInfo), fb(VK_NULL_HANDLE) {
+    RENDER_PASS_NODE(VkRenderPassCreateInfo const *pCreateInfo) : pCreateInfo(pCreateInfo) {
         uint32_t i;
 
         subpassColorFormats.reserve(pCreateInfo->subpassCount);
@@ -553,6 +552,7 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     RENDER_PASS_NODE *activeRenderPass;
     VkSubpassContents activeSubpassContents;
     uint32_t activeSubpass;
+    VkFramebuffer activeFramebuffer;
     std::unordered_set<VkFramebuffer> framebuffers;
     // Track descriptor sets that are destroyed or updated while bound to CB
     // TODO : These data structures relate to tracking resources that invalidate


### PR DESCRIPTION
This is part of a renderpass instance, not of the renderpass itself.
If stored where MT put it, things go horribly wrong when recording
command buffers in parallel.

Signed-off-by: Chris Forbes <chrisforbes@google.com>