### PR TITLE
Add helper functions and use them in DescriptorSet class

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2037,7 +2037,7 @@ static FRAMEBUFFER_NODE *getFramebuffer(layer_data *my_data, VkFramebuffer frame
     return &it->second;
 }
 
-static cvdescriptorset::DescriptorSetLayout const *getDescriptorSetLayout(layer_data const *my_data, VkDescriptorSetLayout dsLayout) {
+cvdescriptorset::DescriptorSetLayout const *getDescriptorSetLayout(layer_data const *my_data, VkDescriptorSetLayout dsLayout) {
     auto it = my_data->descriptorSetLayoutMap.find(dsLayout);
     if (it == my_data->descriptorSetLayoutMap.end()) {
         return nullptr;
@@ -3166,7 +3166,7 @@ static void deletePipelines(layer_data *my_data) {
 // Block of code at start here specifically for managing/tracking DSs
 
 // Return Pool node ptr for specified pool or else NULL
-static DESCRIPTOR_POOL_NODE *getPoolNode(const layer_data *dev_data, const VkDescriptorPool pool) {
+DESCRIPTOR_POOL_NODE *getPoolNode(const layer_data *dev_data, const VkDescriptorPool pool) {
     auto pool_it = dev_data->descriptorPoolMap.find(pool);
     if (pool_it == dev_data->descriptorPoolMap.end()) {
         return NULL;
@@ -5914,8 +5914,7 @@ ResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescript
 static bool PreCallValidateAllocateDescriptorSets(layer_data *dev_data, const VkDescriptorSetAllocateInfo *pAllocateInfo,
                                                   cvdescriptorset::AllocateDescriptorSetsData *common_data) {
     // All state checks for AllocateDescriptorSets is done in single function
-    return cvdescriptorset::ValidateAllocateDescriptorSets(dev_data->report_data, pAllocateInfo, dev_data->descriptorSetLayoutMap,
-                                                           dev_data->descriptorPoolMap, common_data);
+    return cvdescriptorset::ValidateAllocateDescriptorSets(dev_data->report_data, pAllocateInfo, dev_data, common_data);
 }
 // Allocation state was good and call down chain was made so update state based on allocating descriptor sets
 static void PostCallRecordAllocateDescriptorSets(layer_data *dev_data, const VkDescriptorSetAllocateInfo *pAllocateInfo,

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5907,8 +5907,7 @@ static void PostCallRecordAllocateDescriptorSets(layer_data *dev_data, const VkD
                                                  const cvdescriptorset::AllocateDescriptorSetsData *common_data) {
     // All the updates are contained in a single cvdescriptorset function
     cvdescriptorset::PerformAllocateDescriptorSets(pAllocateInfo, pDescriptorSets, common_data, &dev_data->descriptorPoolMap,
-                                                   &dev_data->setMap, dev_data, dev_data->descriptorSetLayoutMap,
-                                                   dev_data->device_extensions.imageToSwapchainMap,
+                                                   &dev_data->setMap, dev_data, dev_data->device_extensions.imageToSwapchainMap,
                                                    dev_data->device_extensions.swapchainMap);
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -261,6 +261,14 @@ struct shader_module {
 // TODO : This can be much smarter, using separate locks for separate global data
 static std::mutex global_lock;
 
+// Return sampler node ptr for specified sampler or else NULL
+SAMPLER_NODE *getSamplerNode(const layer_data *my_data, const VkSampler sampler) {
+    auto sampler_it = my_data->samplerMap.find(sampler);
+    if (sampler_it == my_data->samplerMap.end()) {
+        return nullptr;
+    }
+    return sampler_it->second.get();
+}
 // Return buffer node ptr for specified buffer or else NULL
 BUFFER_NODE *getBufferNode(const layer_data *my_data, const VkBuffer buffer) {
     auto buff_it = my_data->bufferMap.find(buffer);
@@ -5885,7 +5893,7 @@ static void PostCallRecordAllocateDescriptorSets(layer_data *dev_data, const VkD
     // All the updates are contained in a single cvdescriptorset function
     cvdescriptorset::PerformAllocateDescriptorSets(
         pAllocateInfo, pDescriptorSets, common_data, &dev_data->descriptorPoolMap, &dev_data->setMap, dev_data,
-        dev_data->descriptorSetLayoutMap, dev_data->samplerMap, dev_data->imageViewMap, dev_data->imageMap,
+        dev_data->descriptorSetLayoutMap, dev_data->imageViewMap, dev_data->imageMap,
         dev_data->device_extensions.imageToSwapchainMap, dev_data->device_extensions.swapchainMap);
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -262,7 +262,7 @@ struct shader_module {
 static std::mutex global_lock;
 
 // Return ImageViewCreateInfo ptr for specified imageView or else NULL
-VkImageViewCreateInfo *getImageViewData(const layer_data *dev_data, const VkImageView image_view) {
+VkImageViewCreateInfo *getImageViewData(const layer_data *dev_data, VkImageView image_view) {
     auto iv_it = dev_data->imageViewMap.find(image_view);
     if (iv_it == dev_data->imageViewMap.end()) {
         return nullptr;
@@ -270,7 +270,7 @@ VkImageViewCreateInfo *getImageViewData(const layer_data *dev_data, const VkImag
     return iv_it->second.get();
 }
 // Return sampler node ptr for specified sampler or else NULL
-SAMPLER_NODE *getSamplerNode(const layer_data *dev_data, const VkSampler sampler) {
+SAMPLER_NODE *getSamplerNode(const layer_data *dev_data, VkSampler sampler) {
     auto sampler_it = dev_data->samplerMap.find(sampler);
     if (sampler_it == dev_data->samplerMap.end()) {
         return nullptr;
@@ -278,7 +278,7 @@ SAMPLER_NODE *getSamplerNode(const layer_data *dev_data, const VkSampler sampler
     return sampler_it->second.get();
 }
 // Return image node ptr for specified image or else NULL
-IMAGE_NODE *getImageNode(const layer_data *dev_data, const VkImage image) {
+IMAGE_NODE *getImageNode(const layer_data *dev_data, VkImage image) {
     auto img_it = dev_data->imageMap.find(image);
     if (img_it == dev_data->imageMap.end()) {
         return nullptr;
@@ -286,7 +286,7 @@ IMAGE_NODE *getImageNode(const layer_data *dev_data, const VkImage image) {
     return img_it->second.get();
 }
 // Return buffer node ptr for specified buffer or else NULL
-BUFFER_NODE *getBufferNode(const layer_data *dev_data, const VkBuffer buffer) {
+BUFFER_NODE *getBufferNode(const layer_data *dev_data, VkBuffer buffer) {
     auto buff_it = dev_data->bufferMap.find(buffer);
     if (buff_it == dev_data->bufferMap.end()) {
         return nullptr;
@@ -294,7 +294,7 @@ BUFFER_NODE *getBufferNode(const layer_data *dev_data, const VkBuffer buffer) {
     return buff_it->second.get();
 }
 // Return swapchain node for specified swapchain or else NULL
-SWAPCHAIN_NODE *getSwapchainNode(const layer_data *dev_data, const VkSwapchainKHR swapchain) {
+SWAPCHAIN_NODE *getSwapchainNode(const layer_data *dev_data, VkSwapchainKHR swapchain) {
     auto swp_it = dev_data->device_extensions.swapchainMap.find(swapchain);
     if (swp_it == dev_data->device_extensions.swapchainMap.end()) {
         return nullptr;
@@ -302,7 +302,7 @@ SWAPCHAIN_NODE *getSwapchainNode(const layer_data *dev_data, const VkSwapchainKH
     return swp_it->second.get();
 }
 // Return swapchain for specified image or else NULL
-VkSwapchainKHR getSwapchainFromImage(const layer_data *dev_data, const VkImage image) {
+VkSwapchainKHR getSwapchainFromImage(const layer_data *dev_data, VkImage image) {
     auto img_it = dev_data->device_extensions.imageToSwapchainMap.find(image);
     if (img_it == dev_data->device_extensions.imageToSwapchainMap.end()) {
         return VK_NULL_HANDLE;
@@ -310,7 +310,7 @@ VkSwapchainKHR getSwapchainFromImage(const layer_data *dev_data, const VkImage i
     return img_it->second;
 }
 // Return buffer node ptr for specified buffer or else NULL
-VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *my_data, const VkBufferView buffer_view) {
+VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *my_data, VkBufferView buffer_view) {
     auto bv_it = my_data->bufferViewMap.find(buffer_view);
     if (bv_it == my_data->bufferViewMap.end()) {
         return nullptr;
@@ -2668,7 +2668,7 @@ static bool validate_compute_pipeline(debug_report_data *report_data, PIPELINE_N
                                           &module, &entrypoint, enabledFeatures, shaderModuleMap);
 }
 // Return Set node ptr for specified set or else NULL
-cvdescriptorset::DescriptorSet *getSetNode(const layer_data *my_data, const VkDescriptorSet set) {
+cvdescriptorset::DescriptorSet *getSetNode(const layer_data *my_data, VkDescriptorSet set) {
     auto set_it = my_data->setMap.find(set);
     if (set_it == my_data->setMap.end()) {
         return NULL;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -174,6 +174,9 @@ struct DEVICE_MEM_INFO {
     VkImage image; // If memory is bound to image, this will have VkImage handle, else VK_NULL_HANDLE
     MemRange memRange;
     void *pData, *pDriverData;
+    DEVICE_MEM_INFO(void *disp_object, const VkDeviceMemory in_mem, const VkMemoryAllocateInfo *p_alloc_info)
+        : object(disp_object), valid(false), mem(in_mem), allocInfo(*p_alloc_info), image(VK_NULL_HANDLE), memRange{}, pData(0),
+          pDriverData(0){};
 };
 
 class SWAPCHAIN_NODE {
@@ -484,6 +487,7 @@ namespace core_validation {
 struct layer_data;
 cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, const VkDescriptorSet);
 BUFFER_NODE *getBufferNode(const layer_data *, const VkBuffer);
+DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, const VkDeviceMemory);
 }
 
 #endif // CORE_VALIDATION_TYPES_H_

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -493,6 +493,7 @@ VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *, const VkBufferView
 SAMPLER_NODE *getSamplerNode(const layer_data *, const VkSampler);
 VkImageViewCreateInfo *getImageViewData(const layer_data *, const VkImageView);
 VkSwapchainKHR getSwapchainFromImage(const layer_data *, const VkImage);
+SWAPCHAIN_NODE *getSwapchainNode(const layer_data *, const VkSwapchainKHR);
 }
 
 #endif // CORE_VALIDATION_TYPES_H_

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -62,11 +62,6 @@ class BASE_NODE {
     std::atomic_int in_use;
 };
 
-namespace core_validation {
-struct layer_data;
-cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, const VkDescriptorSet);
-}
-
 struct DESCRIPTOR_POOL_NODE {
     VkDescriptorPool pool;
     uint32_t maxSets;       // Max descriptor sets allowed in this pool
@@ -484,5 +479,11 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
 
     ~GLOBAL_CB_NODE();
 };
+// Fwd declarations of layer_data and helpers to look-up state from layer_data maps
+namespace core_validation {
+struct layer_data;
+cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, const VkDescriptorSet);
+BUFFER_NODE *getBufferNode(const layer_data *, const VkBuffer);
+}
 
 #endif // CORE_VALIDATION_TYPES_H_

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -62,6 +62,11 @@ class BASE_NODE {
     std::atomic_int in_use;
 };
 
+namespace core_validation {
+struct layer_data;
+cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, const VkDescriptorSet);
+}
+
 struct DESCRIPTOR_POOL_NODE {
     VkDescriptorPool pool;
     uint32_t maxSets;       // Max descriptor sets allowed in this pool

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -485,15 +485,15 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
 // Fwd declarations of layer_data and helpers to look-up state from layer_data maps
 namespace core_validation {
 struct layer_data;
-cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, const VkDescriptorSet);
-BUFFER_NODE *getBufferNode(const layer_data *, const VkBuffer);
-IMAGE_NODE *getImageNode(const layer_data *, const VkImage);
-DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, const VkDeviceMemory);
-VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *, const VkBufferView);
-SAMPLER_NODE *getSamplerNode(const layer_data *, const VkSampler);
-VkImageViewCreateInfo *getImageViewData(const layer_data *, const VkImageView);
-VkSwapchainKHR getSwapchainFromImage(const layer_data *, const VkImage);
-SWAPCHAIN_NODE *getSwapchainNode(const layer_data *, const VkSwapchainKHR);
+cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, VkDescriptorSet);
+BUFFER_NODE *getBufferNode(const layer_data *, VkBuffer);
+IMAGE_NODE *getImageNode(const layer_data *, VkImage);
+DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, VkDeviceMemory);
+VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *, VkBufferView);
+SAMPLER_NODE *getSamplerNode(const layer_data *, VkSampler);
+VkImageViewCreateInfo *getImageViewData(const layer_data *, VkImageView);
+VkSwapchainKHR getSwapchainFromImage(const layer_data *, VkImage);
+SWAPCHAIN_NODE *getSwapchainNode(const layer_data *, VkSwapchainKHR);
 }
 
 #endif // CORE_VALIDATION_TYPES_H_

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -487,6 +487,7 @@ namespace core_validation {
 struct layer_data;
 cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, const VkDescriptorSet);
 BUFFER_NODE *getBufferNode(const layer_data *, const VkBuffer);
+IMAGE_NODE *getImageNode(const layer_data *, const VkImage);
 DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, const VkDeviceMemory);
 VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *, const VkBufferView);
 SAMPLER_NODE *getSamplerNode(const layer_data *, const VkSampler);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -488,6 +488,7 @@ struct layer_data;
 cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, const VkDescriptorSet);
 BUFFER_NODE *getBufferNode(const layer_data *, const VkBuffer);
 DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, const VkDeviceMemory);
+VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *, const VkBufferView);
 }
 
 #endif // CORE_VALIDATION_TYPES_H_

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -54,6 +54,7 @@
 
 // Fwd declarations
 namespace cvdescriptorset {
+class DescriptorSetLayout;
 class DescriptorSet;
 };
 
@@ -486,6 +487,8 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
 namespace core_validation {
 struct layer_data;
 cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, VkDescriptorSet);
+cvdescriptorset::DescriptorSetLayout const *getDescriptorSetLayout(layer_data const *, VkDescriptorSetLayout);
+DESCRIPTOR_POOL_NODE *getPoolNode(const layer_data *, const VkDescriptorPool);
 BUFFER_NODE *getBufferNode(const layer_data *, VkBuffer);
 IMAGE_NODE *getImageNode(const layer_data *, VkImage);
 DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, VkDeviceMemory);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -492,6 +492,7 @@ DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, const VkDeviceMemory);
 VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *, const VkBufferView);
 SAMPLER_NODE *getSamplerNode(const layer_data *, const VkSampler);
 VkImageViewCreateInfo *getImageViewData(const layer_data *, const VkImageView);
+VkSwapchainKHR getSwapchainFromImage(const layer_data *, const VkImage);
 }
 
 #endif // CORE_VALIDATION_TYPES_H_

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -489,6 +489,7 @@ cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, const VkDescripto
 BUFFER_NODE *getBufferNode(const layer_data *, const VkBuffer);
 DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, const VkDeviceMemory);
 VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *, const VkBufferView);
+SAMPLER_NODE *getSamplerNode(const layer_data *, const VkSampler);
 }
 
 #endif // CORE_VALIDATION_TYPES_H_

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -490,6 +490,7 @@ BUFFER_NODE *getBufferNode(const layer_data *, const VkBuffer);
 DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, const VkDeviceMemory);
 VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *, const VkBufferView);
 SAMPLER_NODE *getSamplerNode(const layer_data *, const VkSampler);
+VkImageViewCreateInfo *getImageViewData(const layer_data *, const VkImageView);
 }
 
 #endif // CORE_VALIDATION_TYPES_H_

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1280,7 +1280,6 @@ void cvdescriptorset::PerformAllocateDescriptorSets(
     const VkDescriptorSetAllocateInfo *p_alloc_info, const VkDescriptorSet *descriptor_sets,
     const AllocateDescriptorSetsData *ds_data, std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *pool_map,
     std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *set_map, const core_validation::layer_data *dev_data,
-    const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &layout_map,
     const std::unordered_map<VkImage, VkSwapchainKHR> &image_to_swapchain_map,
     const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &swapchain_map) {
     auto pool_state = (*pool_map)[p_alloc_info->descriptorPool];

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -269,8 +269,7 @@ void PerformAllocateDescriptorSets(
     std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *,
     std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *, const core_validation::layer_data *,
     const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
-    const std::unordered_map<VkBuffer, BUFFER_NODE> &, const std::unordered_map<VkDeviceMemory, DEVICE_MEM_INFO> &,
-    const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> &,
+    const std::unordered_map<VkDeviceMemory, DEVICE_MEM_INFO> &, const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> &,
     const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> &,
     const std::unordered_map<VkImageView, VkImageViewCreateInfo> &, const std::unordered_map<VkImage, IMAGE_NODE> &,
     const std::unordered_map<VkImage, VkSwapchainKHR> &, const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
@@ -296,7 +295,7 @@ void PerformAllocateDescriptorSets(
 class DescriptorSet : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
-    DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const std::unordered_map<VkBuffer, BUFFER_NODE> *,
+    DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const core_validation::layer_data *,
                   const std::unordered_map<VkDeviceMemory, DEVICE_MEM_INFO> *,
                   const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> *,
                   const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> *,
@@ -378,7 +377,7 @@ class DescriptorSet : public BASE_NODE {
     std::unordered_set<GLOBAL_CB_NODE *> bound_cmd_buffers_;
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
     // Ptrs to object containers to verify bound data
-    const std::unordered_map<VkBuffer, BUFFER_NODE> *buffer_map_;
+    const core_validation::layer_data *device_data_;
     const std::unordered_map<VkDeviceMemory, DEVICE_MEM_INFO> *memory_map_;
     const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> *buffer_view_map_;
     const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> *sampler_map_;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -360,7 +360,7 @@ class DescriptorSet : public BASE_NODE {
     const DescriptorSetLayout *p_layout_;
     std::unordered_set<GLOBAL_CB_NODE *> bound_cmd_buffers_;
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
-    // Ptrs to object containers to verify bound data
+    // Ptr to device data used for various data look-ups
     const core_validation::layer_data *device_data_;
 };
 }

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -162,7 +162,6 @@ class Descriptor {
 //  performs common functions with both sampler and image descriptors so they can share their common functions
 bool ValidateSampler(const VkSampler, const core_validation::layer_data *);
 bool ValidateImageUpdate(VkImageView, VkImageLayout, VkDescriptorType, const core_validation::layer_data *,
-                         const std::unordered_map<VkImage, VkSwapchainKHR> *,
                          const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *, std::string *);
 
 class SamplerDescriptor : public Descriptor {
@@ -267,7 +266,6 @@ void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const Vk
                                    std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *,
                                    std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *,
                                    const core_validation::layer_data *,
-                                   const std::unordered_map<VkImage, VkSwapchainKHR> &,
                                    const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
 
 /*
@@ -292,7 +290,6 @@ class DescriptorSet : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
     DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const core_validation::layer_data *,
-                  const std::unordered_map<VkImage, VkSwapchainKHR> *,
                   const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *);
     ~DescriptorSet();
     // A number of common Get* functions that return data based on layout from which this set was created
@@ -371,7 +368,6 @@ class DescriptorSet : public BASE_NODE {
     // Ptrs to object containers to verify bound data
     const core_validation::layer_data *device_data_;
     // TODO : For next 3 maps all we really need (currently) is an image to format mapping
-    const std::unordered_map<VkImage, VkSwapchainKHR> *image_to_swapchain_map_;
     const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *swapchain_map_;
 };
 }

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -267,7 +267,6 @@ void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const Vk
                                    std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *,
                                    std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *,
                                    const core_validation::layer_data *,
-                                   const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
                                    const std::unordered_map<VkImage, VkSwapchainKHR> &,
                                    const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -161,8 +161,7 @@ class Descriptor {
 // Shared helper functions - These are useful because the shared sampler image descriptor type
 //  performs common functions with both sampler and image descriptors so they can share their common functions
 bool ValidateSampler(const VkSampler, const core_validation::layer_data *);
-bool ValidateImageUpdate(VkImageView, VkImageLayout, VkDescriptorType,
-                         const std::unordered_map<VkImageView, VkImageViewCreateInfo> *,
+bool ValidateImageUpdate(VkImageView, VkImageLayout, VkDescriptorType, const core_validation::layer_data *,
                          const std::unordered_map<VkImage, IMAGE_NODE> *, const std::unordered_map<VkImage, VkSwapchainKHR> *,
                          const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *, std::string *);
 
@@ -269,7 +268,6 @@ void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const Vk
                                    std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *,
                                    const core_validation::layer_data *,
                                    const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
-                                   const std::unordered_map<VkImageView, VkImageViewCreateInfo> &,
                                    const std::unordered_map<VkImage, IMAGE_NODE> &,
                                    const std::unordered_map<VkImage, VkSwapchainKHR> &,
                                    const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
@@ -296,8 +294,7 @@ class DescriptorSet : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
     DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const core_validation::layer_data *,
-                  const std::unordered_map<VkImageView, VkImageViewCreateInfo> *, const std::unordered_map<VkImage, IMAGE_NODE> *,
-                  const std::unordered_map<VkImage, VkSwapchainKHR> *,
+                  const std::unordered_map<VkImage, IMAGE_NODE> *, const std::unordered_map<VkImage, VkSwapchainKHR> *,
                   const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *);
     ~DescriptorSet();
     // A number of common Get* functions that return data based on layout from which this set was created
@@ -375,7 +372,6 @@ class DescriptorSet : public BASE_NODE {
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
     // Ptrs to object containers to verify bound data
     const core_validation::layer_data *device_data_;
-    const std::unordered_map<VkImageView, VkImageViewCreateInfo> *image_view_map_;
     // TODO : For next 3 maps all we really need (currently) is an image to format mapping
     const std::unordered_map<VkImage, IMAGE_NODE> *image_map_;
     const std::unordered_map<VkImage, VkSwapchainKHR> *image_to_swapchain_map_;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -253,30 +253,27 @@ struct AllocateDescriptorSetsData {
 };
 // Helper functions for descriptor set functions that cross multiple sets
 // "Validate" will make sure an update is ok without actually performing it
-bool ValidateUpdateDescriptorSets(const debug_report_data *,
-                                  const std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> &, uint32_t,
+bool ValidateUpdateDescriptorSets(const debug_report_data *, const core_validation::layer_data *, uint32_t,
                                   const VkWriteDescriptorSet *, uint32_t, const VkCopyDescriptorSet *);
 // "Perform" does the update with the assumption that ValidateUpdateDescriptorSets() has passed for the given update
-void PerformUpdateDescriptorSets(const std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> &, uint32_t,
-                                 const VkWriteDescriptorSet *, uint32_t, const VkCopyDescriptorSet *);
+void PerformUpdateDescriptorSets(const core_validation::layer_data *, uint32_t, const VkWriteDescriptorSet *, uint32_t,
+                                 const VkCopyDescriptorSet *);
 // Validate that Allocation state is ok
 bool ValidateAllocateDescriptorSets(const debug_report_data *, const VkDescriptorSetAllocateInfo *,
                                     const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
                                     const std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> &,
                                     AllocateDescriptorSetsData *);
 // Update state based on allocating new descriptorsets
-void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const VkDescriptorSet *, const AllocateDescriptorSetsData *,
-                                   std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *,
-                                   std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *,
-                                   const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
-                                   const std::unordered_map<VkBuffer, BUFFER_NODE> &,
-                                   const std::unordered_map<VkDeviceMemory, DEVICE_MEM_INFO> &,
-                                   const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> &,
-                                   const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> &,
-                                   const std::unordered_map<VkImageView, VkImageViewCreateInfo> &,
-                                   const std::unordered_map<VkImage, IMAGE_NODE> &,
-                                   const std::unordered_map<VkImage, VkSwapchainKHR> &,
-                                   const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
+void PerformAllocateDescriptorSets(
+    const VkDescriptorSetAllocateInfo *, const VkDescriptorSet *, const AllocateDescriptorSetsData *,
+    std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *,
+    std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *, const core_validation::layer_data *,
+    const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
+    const std::unordered_map<VkBuffer, BUFFER_NODE> &, const std::unordered_map<VkDeviceMemory, DEVICE_MEM_INFO> &,
+    const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> &,
+    const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> &,
+    const std::unordered_map<VkImageView, VkImageViewCreateInfo> &, const std::unordered_map<VkImage, IMAGE_NODE> &,
+    const std::unordered_map<VkImage, VkSwapchainKHR> &, const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
 
 /*
  * DescriptorSet class

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -269,7 +269,6 @@ void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const Vk
                                    std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *,
                                    const core_validation::layer_data *,
                                    const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
-                                   const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> &,
                                    const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> &,
                                    const std::unordered_map<VkImageView, VkImageViewCreateInfo> &,
                                    const std::unordered_map<VkImage, IMAGE_NODE> &,
@@ -298,7 +297,6 @@ class DescriptorSet : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
     DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const core_validation::layer_data *,
-                  const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> *,
                   const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> *,
                   const std::unordered_map<VkImageView, VkImageViewCreateInfo> *, const std::unordered_map<VkImage, IMAGE_NODE> *,
                   const std::unordered_map<VkImage, VkSwapchainKHR> *,

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -264,15 +264,17 @@ bool ValidateAllocateDescriptorSets(const debug_report_data *, const VkDescripto
                                     const std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> &,
                                     AllocateDescriptorSetsData *);
 // Update state based on allocating new descriptorsets
-void PerformAllocateDescriptorSets(
-    const VkDescriptorSetAllocateInfo *, const VkDescriptorSet *, const AllocateDescriptorSetsData *,
-    std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *,
-    std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *, const core_validation::layer_data *,
-    const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
-    const std::unordered_map<VkDeviceMemory, DEVICE_MEM_INFO> &, const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> &,
-    const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> &,
-    const std::unordered_map<VkImageView, VkImageViewCreateInfo> &, const std::unordered_map<VkImage, IMAGE_NODE> &,
-    const std::unordered_map<VkImage, VkSwapchainKHR> &, const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
+void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const VkDescriptorSet *, const AllocateDescriptorSetsData *,
+                                   std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *,
+                                   std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *,
+                                   const core_validation::layer_data *,
+                                   const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
+                                   const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> &,
+                                   const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> &,
+                                   const std::unordered_map<VkImageView, VkImageViewCreateInfo> &,
+                                   const std::unordered_map<VkImage, IMAGE_NODE> &,
+                                   const std::unordered_map<VkImage, VkSwapchainKHR> &,
+                                   const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
 
 /*
  * DescriptorSet class
@@ -296,7 +298,6 @@ class DescriptorSet : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
     DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const core_validation::layer_data *,
-                  const std::unordered_map<VkDeviceMemory, DEVICE_MEM_INFO> *,
                   const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> *,
                   const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> *,
                   const std::unordered_map<VkImageView, VkImageViewCreateInfo> *, const std::unordered_map<VkImage, IMAGE_NODE> *,
@@ -378,7 +379,6 @@ class DescriptorSet : public BASE_NODE {
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
     // Ptrs to object containers to verify bound data
     const core_validation::layer_data *device_data_;
-    const std::unordered_map<VkDeviceMemory, DEVICE_MEM_INFO> *memory_map_;
     const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> *buffer_view_map_;
     const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> *sampler_map_;
     const std::unordered_map<VkImageView, VkImageViewCreateInfo> *image_view_map_;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -161,8 +161,7 @@ class Descriptor {
 // Shared helper functions - These are useful because the shared sampler image descriptor type
 //  performs common functions with both sampler and image descriptors so they can share their common functions
 bool ValidateSampler(const VkSampler, const core_validation::layer_data *);
-bool ValidateImageUpdate(VkImageView, VkImageLayout, VkDescriptorType, const core_validation::layer_data *,
-                         const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *, std::string *);
+bool ValidateImageUpdate(VkImageView, VkImageLayout, VkDescriptorType, const core_validation::layer_data *, std::string *);
 
 class SamplerDescriptor : public Descriptor {
   public:
@@ -265,8 +264,7 @@ bool ValidateAllocateDescriptorSets(const debug_report_data *, const VkDescripto
 void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const VkDescriptorSet *, const AllocateDescriptorSetsData *,
                                    std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *,
                                    std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *,
-                                   const core_validation::layer_data *,
-                                   const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
+                                   const core_validation::layer_data *);
 
 /*
  * DescriptorSet class
@@ -289,8 +287,7 @@ void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const Vk
 class DescriptorSet : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
-    DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const core_validation::layer_data *,
-                  const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *);
+    DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const core_validation::layer_data *);
     ~DescriptorSet();
     // A number of common Get* functions that return data based on layout from which this set was created
     uint32_t GetTotalDescriptorCount() const { return p_layout_ ? p_layout_->GetTotalDescriptorCount() : 0; };
@@ -367,8 +364,6 @@ class DescriptorSet : public BASE_NODE {
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
     // Ptrs to object containers to verify bound data
     const core_validation::layer_data *device_data_;
-    // TODO : For next 3 maps all we really need (currently) is an image to format mapping
-    const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *swapchain_map_;
 };
 }
 #endif // CORE_VALIDATION_DESCRIPTOR_SETS_H_

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -162,7 +162,7 @@ class Descriptor {
 //  performs common functions with both sampler and image descriptors so they can share their common functions
 bool ValidateSampler(const VkSampler, const core_validation::layer_data *);
 bool ValidateImageUpdate(VkImageView, VkImageLayout, VkDescriptorType, const core_validation::layer_data *,
-                         const std::unordered_map<VkImage, IMAGE_NODE> *, const std::unordered_map<VkImage, VkSwapchainKHR> *,
+                         const std::unordered_map<VkImage, VkSwapchainKHR> *,
                          const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *, std::string *);
 
 class SamplerDescriptor : public Descriptor {
@@ -268,7 +268,6 @@ void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const Vk
                                    std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *,
                                    const core_validation::layer_data *,
                                    const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
-                                   const std::unordered_map<VkImage, IMAGE_NODE> &,
                                    const std::unordered_map<VkImage, VkSwapchainKHR> &,
                                    const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> &);
 
@@ -294,7 +293,7 @@ class DescriptorSet : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
     DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const core_validation::layer_data *,
-                  const std::unordered_map<VkImage, IMAGE_NODE> *, const std::unordered_map<VkImage, VkSwapchainKHR> *,
+                  const std::unordered_map<VkImage, VkSwapchainKHR> *,
                   const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *);
     ~DescriptorSet();
     // A number of common Get* functions that return data based on layout from which this set was created
@@ -373,7 +372,6 @@ class DescriptorSet : public BASE_NODE {
     // Ptrs to object containers to verify bound data
     const core_validation::layer_data *device_data_;
     // TODO : For next 3 maps all we really need (currently) is an image to format mapping
-    const std::unordered_map<VkImage, IMAGE_NODE> *image_map_;
     const std::unordered_map<VkImage, VkSwapchainKHR> *image_to_swapchain_map_;
     const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *swapchain_map_;
 };

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -257,9 +257,7 @@ void PerformUpdateDescriptorSets(const core_validation::layer_data *, uint32_t, 
                                  const VkCopyDescriptorSet *);
 // Validate that Allocation state is ok
 bool ValidateAllocateDescriptorSets(const debug_report_data *, const VkDescriptorSetAllocateInfo *,
-                                    const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
-                                    const std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> &,
-                                    AllocateDescriptorSetsData *);
+                                    const core_validation::layer_data *, AllocateDescriptorSetsData *);
 // Update state based on allocating new descriptorsets
 void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const VkDescriptorSet *, const AllocateDescriptorSetsData *,
                                    std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_NODE *> *,

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -160,7 +160,7 @@ class Descriptor {
 };
 // Shared helper functions - These are useful because the shared sampler image descriptor type
 //  performs common functions with both sampler and image descriptors so they can share their common functions
-bool ValidateSampler(const VkSampler, const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> *);
+bool ValidateSampler(const VkSampler, const core_validation::layer_data *);
 bool ValidateImageUpdate(VkImageView, VkImageLayout, VkDescriptorType,
                          const std::unordered_map<VkImageView, VkImageViewCreateInfo> *,
                          const std::unordered_map<VkImage, IMAGE_NODE> *, const std::unordered_map<VkImage, VkSwapchainKHR> *,
@@ -269,7 +269,6 @@ void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const Vk
                                    std::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> *,
                                    const core_validation::layer_data *,
                                    const std::unordered_map<VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout *> &,
-                                   const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> &,
                                    const std::unordered_map<VkImageView, VkImageViewCreateInfo> &,
                                    const std::unordered_map<VkImage, IMAGE_NODE> &,
                                    const std::unordered_map<VkImage, VkSwapchainKHR> &,
@@ -297,7 +296,6 @@ class DescriptorSet : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
     DescriptorSet(const VkDescriptorSet, const DescriptorSetLayout *, const core_validation::layer_data *,
-                  const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> *,
                   const std::unordered_map<VkImageView, VkImageViewCreateInfo> *, const std::unordered_map<VkImage, IMAGE_NODE> *,
                   const std::unordered_map<VkImage, VkSwapchainKHR> *,
                   const std::unordered_map<VkSwapchainKHR, SWAPCHAIN_NODE *> *);
@@ -377,8 +375,6 @@ class DescriptorSet : public BASE_NODE {
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
     // Ptrs to object containers to verify bound data
     const core_validation::layer_data *device_data_;
-    const std::unordered_map<VkBufferView, VkBufferViewCreateInfo> *buffer_view_map_;
-    const std::unordered_map<VkSampler, std::unique_ptr<SAMPLER_NODE>> *sampler_map_;
     const std::unordered_map<VkImageView, VkImageViewCreateInfo> *image_view_map_;
     // TODO : For next 3 maps all we really need (currently) is an image to format mapping
     const std::unordered_map<VkImage, IMAGE_NODE> *image_map_;


### PR DESCRIPTION
Kill almost all of the maps in DescriptorSet class and use utility functions to look-up data blocks from generic layer_data ptr.
Also migrated a few of the maps to use unique_ptrs which kills some delete calls and unifies the helper function interfaces.