### PR TITLE
Replace call sequence errors with warnings for device query APIs

### DIFF
--- a/layers/device_limits.cpp
+++ b/layers/device_limits.cpp
@@ -166,15 +166,16 @@ EnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount, Vk
             my_data->instanceState->vkEnumeratePhysicalDevicesState = QUERY_COUNT;
         } else {
             if (UNCALLED == my_data->instanceState->vkEnumeratePhysicalDevicesState) {
-                // Flag error here, shouldn't be calling this without having queried count
+                // Flag warning here. You can call this without having queried the count, but it may not be
+                // robust on platforms with multiple physical devices.
                 skipCall |=
-                    log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, 0,
-                            __LINE__, DEVLIMITS_MUST_QUERY_COUNT, "DL",
-                            "Invalid call sequence to vkEnumeratePhysicalDevices() w/ non-NULL pPhysicalDevices. You should first "
+                    log_msg(my_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, 0,
+                            __LINE__, DEVLIMITS_MISSING_QUERY_COUNT, "DL",
+                            "Call sequence has vkEnumeratePhysicalDevices() w/ non-NULL pPhysicalDevices. You should first "
                             "call vkEnumeratePhysicalDevices() w/ NULL pPhysicalDevices to query pPhysicalDeviceCount.");
             } // TODO : Could also flag a warning if re-calling this function in QUERY_DETAILS state
             else if (my_data->instanceState->physicalDevicesCount != *pPhysicalDeviceCount) {
-                // TODO: Having actual count match count from app is not a requirement, so this can be a warning
+                // Having actual count match count from app is not a requirement, so this can be a warning
                 skipCall |= log_msg(my_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT,
                                     VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0, __LINE__, DEVLIMITS_COUNT_MISMATCH, "DL",
                                     "Call to vkEnumeratePhysicalDevices() w/ pPhysicalDeviceCount value %u, but actual count "
@@ -247,9 +248,9 @@ GetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice physicalDevice, uint32_t
             // Verify that for each physical device, this function is called first with NULL pQueueFamilyProperties ptr in order to
             // get count
             if (UNCALLED == phy_dev_data->physicalDeviceState->vkGetPhysicalDeviceQueueFamilyPropertiesState) {
-                skipCall |= log_msg(phy_dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                    VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0, __LINE__, DEVLIMITS_MUST_QUERY_COUNT, "DL",
-                                    "Invalid call sequence to vkGetPhysicalDeviceQueueFamilyProperties() w/ non-NULL "
+                skipCall |= log_msg(phy_dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT,
+                                    VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0, __LINE__, DEVLIMITS_MISSING_QUERY_COUNT, "DL",
+                                    "Call sequence has vkGetPhysicalDeviceQueueFamilyProperties() w/ non-NULL "
                                     "pQueueFamilyProperties. You should first call vkGetPhysicalDeviceQueueFamilyProperties() w/ "
                                     "NULL pQueueFamilyProperties to query pCount.");
             }

--- a/layers/device_limits.h
+++ b/layers/device_limits.h
@@ -30,6 +30,7 @@ enum DEV_LIMITS_ERROR {
     DEVLIMITS_INVALID_PHYSICAL_DEVICE,       // Invalid physical device used
     DEVLIMITS_INVALID_INHERITED_QUERY,       // Invalid use of inherited query
     DEVLIMITS_INVALID_ATTACHMENT_COUNT,      // Invalid value for the number of attachments
+    DEVLIMITS_MISSING_QUERY_COUNT,           // Did not make initial call to an API to query the count
     DEVLIMITS_MUST_QUERY_COUNT,              // Failed to make initial call to an API to query the count
     DEVLIMITS_INVALID_CALL_SEQUENCE,         // Flag generic case of an invalid call sequence by the app
     DEVLIMITS_INVALID_FEATURE_REQUESTED,     // App requested a feature not supported by physical device


### PR DESCRIPTION
Fixes #630 

The issue was created for vkEnumeratePhysicalDevices, but also applies to GetPhysicalDeviceQueueFamilyProperties. This MR addresses both.

It adds a new enum to distinguish these warnings from one remaining case (vkCreateDevice) where you really must have called an enumeration API first.

Change-Id: I1505f4a2b339ac7ef435da8b3ec2f85612026a42