### PR TITLE
Modify warning msgs: add debug output message header

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -142,11 +142,10 @@ run_vk_layer_xml_generate(Threading thread_check.h)
 run_vk_layer_generate(unique_objects unique_objects.cpp)
 run_vk_layer_xml_generate(ParamChecker parameter_validation.h)
 
+
 # Layer Utils Library
-# For Windows, we use a static lib because the Windows loader has a fairly restrictive loader search
-# path that can't be easily modified to point it to the same directory that contains the layers.
 if (WIN32)
-    add_library(VkLayer_utils STATIC vk_layer_config.cpp vk_layer_extension_utils.cpp vk_layer_utils.cpp)
+    add_library(VkLayer_utils SHARED vk_layer_config.cpp vk_layer_extension_utils.cpp vk_layer_utils.cpp VkLayer_utils.def)
 else()
     add_library(VkLayer_utils SHARED vk_layer_config.cpp vk_layer_extension_utils.cpp vk_layer_utils.cpp)
     install(TARGETS VkLayer_utils DESTINATION ${PROJECT_BINARY_DIR}/install_staging)
@@ -166,3 +165,18 @@ add_vk_layer(parameter_validation parameter_validation.cpp parameter_validation.
 target_include_directories(VkLayer_core_validation PRIVATE ${GLSLANG_SPIRV_INCLUDE_DIR})
 target_include_directories(VkLayer_core_validation PRIVATE ${SPIRV_TOOLS_INCLUDE_DIR})
 target_link_libraries(VkLayer_core_validation ${SPIRV_TOOLS_LIBRARIES})
+
+if (WIN32)
+    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/VkLayer_utils.dll COPY_SRC_PATH)
+    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../demos/$<CONFIGURATION>/ COPY_DST_PATH)
+    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../tests/$<CONFIGURATION>/ COPY_DST_TEST_PATH)
+    # Copy layer utils library to correct locations
+    add_custom_command(TARGET VkLayer_utils
+                       POST_BUILD
+                       COMMAND xcopy /Y /I ${COPY_SRC_PATH} ${COPY_DST_PATH}
+                       COMMENT "Copying VkLayer_utils.dll to demos dir")
+    add_custom_command(TARGET VkLayer_utils
+                       POST_BUILD
+                       COMMAND xcopy /Y /I ${COPY_SRC_PATH} ${COPY_DST_TEST_PATH}
+                       COMMENT "Copying VkLayer_utils.dll to demos dir")
+endif()

--- a/layers/VkLayer_utils.def
+++ b/layers/VkLayer_utils.def
@@ -43,3 +43,5 @@ vk_string_validate
 layer_debug_actions
 util_GetExtensionProperties
 util_GetLayerProperties
+LogMessageInitialized
+SetLogMessageInitialized

--- a/layers/VkLayer_utils.def
+++ b/layers/VkLayer_utils.def
@@ -1,0 +1,45 @@
+;;;; Begin Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Vulkan
+;
+; Copyright (c) 2015-2016 The Khronos Group Inc.
+; Copyright (c) 2015-2016 Valve Corporation
+; Copyright (c) 2015-2016 LunarG, Inc.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+;
+;  Author: Mark Lobodzinski <mark@LunarG.com>
+;;;;  End Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; The following is required on Windows for exporting symbols from the DLL
+
+LIBRARY VkLayer_utils
+EXPORTS
+vk_format_is_depth_or_stencil
+vk_format_is_depth_and_stencil
+vk_format_is_stencil_only
+vk_format_is_depth_only
+vk_format_is_norm
+vk_format_is_int
+vk_format_is_uint
+vk_format_is_sint
+vk_format_is_float
+vk_format_is_srgb
+vk_format_is_compressed
+vk_format_get_compatibility_class
+vk_format_get_size
+vk_format_get_channel_count
+vk_safe_modulo
+vk_string_validate
+layer_debug_actions
+util_GetExtensionProperties
+util_GetLayerProperties

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -32,6 +32,17 @@
 
 #define MAX_CHARS_PER_LINE 4096
 
+// Flag for ONE-TIME debug output initialization
+static bool log_message_initialized = false;
+
+// Accessor functions to ensure the correct instance of the shared flag gets used
+const bool LogMessageInitialized() {
+    return log_message_initialized;
+}
+void SetLogMessageInitialized() {
+    log_message_initialized = true;
+}
+
 class ConfigFile {
   public:
     ConfigFile();

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -63,6 +63,8 @@ VkFlags GetLayerOptionFlags(std::string _option, std::unordered_map<std::string,
 
 void setLayerOption(const char *_option, const char *_val);
 void print_msg_flags(VkFlags msgFlags, char *msg_flags);
+const bool LogMessageInitialized();
+void SetLogMessageInitialized();
 
 #ifdef __cplusplus
 }

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -104,17 +104,52 @@ static inline void RemoveAllMessageCallbacks(debug_report_data *debug_data, VkLa
     *list_head = NULL;
 }
 
+static inline bool OutputLogMsgHeader(const debug_report_data *debug_data, VkFlags msgFlags) {
+    bool output = false;
+    VkLayerDbgFunctionNode *pTrav =
+        (debug_data->debug_callback_list != NULL) ? debug_data->debug_callback_list : debug_data->default_debug_callback_list;
+
+    while (pTrav) {
+        const char *message_header = "Legend:\n\n"
+                               "*******************************************************************************************\n"
+                               "* Vulkan Validation Layer Debug Output                                                    *\n"
+                               "*                                                                                         *\n"
+                               "* Debug Output Type Definitions:                                                          *\n"
+                               "* ------------------------------                                                          *\n"
+                               "* ERROR: Errors are output when a validation layer detects that some application behavior *\n"
+                               "*        has violated the Vulkan Specification.                                           *\n"
+                               "* WARN:  Warnings are output in cases where mistakes are commonly made and do NOT         *\n"
+                               "*        necessarily indicate that an app has violated the Vulkan Specification.          *\n"
+                               "*        Warnings basically translate to 'Did you really mean to do this?'                *\n"
+                               "* PERF:  Performance Warnings are output in cases where a possible inefficiency has been  *\n"
+                               "*        detected.  These also do NOT imply that the specification was violated.          *\n"
+                               "* INFO:  These log messages are for informational purposes only. For instance, the        *\n"
+                               "*        core_validation layer can print out lists of memory objects and their bindings   *\n"
+                               "*        which may help with debugging or improving application efficiency.               *\n"
+                               "*******************************************************************************************\n";
+
+        if (pTrav->msgFlags & msgFlags) {
+            pTrav->pfnMsgCallback(VK_DEBUG_REPORT_DEBUG_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT, 0, 0,
+                VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT, "", message_header, pTrav->pUserData);
+            output |= true;
+        }
+        pTrav = pTrav->pNext;
+    }
+    return output;
+}
+
 // Utility function to handle reporting
 static inline bool debug_report_log_msg(const debug_report_data *debug_data, VkFlags msgFlags,
                                         VkDebugReportObjectTypeEXT objectType, uint64_t srcObject, size_t location, int32_t msgCode,
                                         const char *pLayerPrefix, const char *pMsg) {
     bool bail = false;
-    VkLayerDbgFunctionNode *pTrav = NULL;
+    VkLayerDbgFunctionNode *pTrav =
+        (debug_data->debug_callback_list != NULL) ? debug_data->debug_callback_list : debug_data->default_debug_callback_list;
 
-    if (debug_data->debug_callback_list != NULL) {
-        pTrav = debug_data->debug_callback_list;
-    } else {
-        pTrav = debug_data->default_debug_callback_list;
+    if ((LogMessageInitialized() == false) && (strcmp(pLayerPrefix, "DebugReport") != 0)) {
+        if (OutputLogMsgHeader(debug_data, msgFlags) == true) {
+            SetLogMessageInitialized();
+        }
     }
 
     while (pTrav) {
@@ -151,6 +186,7 @@ debug_report_create_instance(VkLayerInstanceDispatchTable *table, VkInstance ins
             debug_data->g_DEBUG_REPORT = true;
         }
     }
+
     return debug_data;
 }
 


### PR DESCRIPTION
This PR should print a message header to stdout with the first validation message that gets printed.  Looking for wording changes to the error/warn/perf warn definitions in particular.