### PR TITLE
Fix semaphore tracking for CB simultaneously inflight

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -318,6 +318,22 @@ VkBufferViewCreateInfo *getBufferViewInfo(const layer_data *my_data, VkBufferVie
     return bv_it->second.get();
 }
 
+FENCE_NODE *getFenceNode(layer_data *dev_data, VkFence fence) {
+    auto it = dev_data->fenceMap.find(fence);
+    if (it == dev_data->fenceMap.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+QUEUE_NODE *getQueueNode(layer_data *dev_data, VkQueue queue) {
+    auto it = dev_data->queueMap.find(queue);
+    if (it == dev_data->queueMap.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
 static VkDeviceMemory *get_object_mem_binding(layer_data *my_data, uint64_t handle, VkDebugReportObjectTypeEXT type) {
     switch (type) {
     case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT: {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4841,6 +4841,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(VkDevice device, uint32_t queueFamilyI
     auto result = dev_data->queues.emplace(*pQueue);
     if (result.second == true) {
         QUEUE_NODE *pQNode = &dev_data->queueMap[*pQueue];
+        pQNode->queue = *pQueue;
         pQNode->device = device;
     }
 }
@@ -5593,6 +5594,7 @@ CreateFence(VkDevice device, const VkFenceCreateInfo *pCreateInfo, const VkAlloc
     if (VK_SUCCESS == result) {
         std::lock_guard<std::mutex> lock(global_lock);
         auto &fence_node = dev_data->fenceMap[*pFence];
+        fence_node.fence = *pFence;
         fence_node.createInfo = *pCreateInfo;
         fence_node.needsSignaled = true;
         if (pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3675,8 +3675,6 @@ static void resetCB(layer_data *dev_data, const VkCommandBuffer cb) {
         pCB->activeRenderPass = nullptr;
         pCB->activeSubpassContents = VK_SUBPASS_CONTENTS_INLINE;
         pCB->activeSubpass = 0;
-        pCB->lastSubmittedFence = VK_NULL_HANDLE;
-        pCB->lastSubmittedQueue = VK_NULL_HANDLE;
         pCB->destroyedSets.clear();
         pCB->updatedSets.clear();
         pCB->destroyedFramebuffers.clear();
@@ -4582,8 +4580,6 @@ QueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, V
             if (pCBNode) {
                 pCBNode->semaphores = semaphoreList;
                 pCBNode->submitCount++; // increment submit count
-                pCBNode->lastSubmittedFence = fence;
-                pCBNode->lastSubmittedQueue = queue;
                 skipCall |= validatePrimaryCommandBufferState(dev_data, pCBNode);
                 // Call submit-time functions to validate/update state
                 for (auto &function : pCBNode->validate_functions) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4305,6 +4305,12 @@ static void updateTrackedCommandBuffers(layer_data *dev_data, VkQueue queue, VkQ
             fence_node->second.queues.insert(other_queue_data->first);
         }
     }
+    // TODO: Stealing the untracked CBs out of the signaling queue isn't really
+    // correct. A subsequent submission + wait, or a QWI on that queue, or
+    // another semaphore dependency to a third queue may /all/ provide
+    // suitable proof that the work we're stealing here has completed on the
+    // device, but we've lost that information by moving the tracking between
+    // queues.
     if (fence != VK_NULL_HANDLE) {
         auto fence_data = dev_data->fenceMap.find(fence);
         if (fence_data == dev_data->fenceMap.end()) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4535,6 +4535,10 @@ QueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, V
     auto pFence = getFenceNode(dev_data, fence);
     skipCall |= ValidateFenceForSubmit(dev_data, pFence);
 
+    if (skipCall) {
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+
     // TODO : Review these old print functions and clean up as appropriate
     print_mem_list(dev_data);
     printCBList(dev_data);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -217,7 +217,7 @@ class FENCE_NODE : public BASE_NODE {
     bool firstTimeFlag;       // Fence was created in signaled state, avoid warnings for first use
     VkFenceCreateInfo createInfo;
     std::unordered_set<VkQueue> queues;
-    std::vector<VkCommandBuffer> cmdBuffers;
+    std::vector<CB_SUBMISSION> submissions;
     bool needsSignaled;
     std::vector<VkFence> priorFences;
 
@@ -250,7 +250,7 @@ class QUEUE_NODE {
     std::list<VkCommandBuffer> pQueueCommandBuffers;
     std::list<VkDeviceMemory> pMemRefList;
 #endif
-    std::vector<VkCommandBuffer> untrackedCmdBuffers;
+    std::vector<CB_SUBMISSION> untrackedSubmissions;
     std::unordered_map<VkEvent, VkPipelineStageFlags> eventToStageMap;
     std::unordered_map<QueryObject, bool> queryToStateMap; // 0 is unavailable, 1 is available
 };

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -212,6 +212,7 @@ class FENCE_NODE : public BASE_NODE {
   public:
     using BASE_NODE::in_use;
 
+    VkFence fence;
     VkSwapchainKHR swapchain; // Swapchain that this fence is submitted against or NULL
     bool firstTimeFlag;       // Fence was created in signaled state, avoid warnings for first use
     VkFenceCreateInfo createInfo;
@@ -241,6 +242,7 @@ class EVENT_NODE : public BASE_NODE {
 
 class QUEUE_NODE {
   public:
+    VkQueue queue;
     VkDevice device;
     std::vector<VkFence> lastFences;
 #if MTMERGE

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -423,7 +423,6 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     VkCommandBufferAllocateInfo createInfo;
     VkCommandBufferBeginInfo beginInfo;
     VkCommandBufferInheritanceInfo inheritanceInfo;
-    // VkFence fence;                      // fence tracking this cmd buffer
     VkDevice device;                    // device this CB belongs to
     uint64_t numCmds;                   // number of cmds in this CB
     uint64_t drawCount[NUM_DRAW_TYPES]; // Count of each type of draw in this CB
@@ -440,7 +439,6 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     std::vector<VkViewport> viewports;
     std::vector<VkRect2D> scissors;
     VkRenderPassBeginInfo activeRenderPassBeginInfo;
-    uint64_t fenceId;
     RENDER_PASS_NODE *activeRenderPass;
     VkSubpassContents activeSubpassContents;
     uint32_t activeSubpass;
@@ -481,6 +479,7 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
 
     ~GLOBAL_CB_NODE();
 };
+
 // Fwd declarations of layer_data and helpers to look-up state from layer_data maps
 namespace core_validation {
 struct layer_data;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -453,7 +453,6 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     std::unordered_set<VkFramebuffer> destroyedFramebuffers;
     std::unordered_set<VkEvent> waitedEvents;
     std::vector<VkEvent> writeEventsBeforeWait;
-    std::vector<VkSemaphore> semaphores;
     std::vector<VkEvent> events;
     std::unordered_map<QueryObject, std::unordered_set<VkEvent>> waitedEventsBeforeQueryReset;
     std::unordered_map<QueryObject, bool> queryToStateMap; // 0 is unavailable, 1 is available

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -441,8 +441,6 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     std::vector<VkRect2D> scissors;
     VkRenderPassBeginInfo activeRenderPassBeginInfo;
     uint64_t fenceId;
-    VkFence lastSubmittedFence;
-    VkQueue lastSubmittedQueue;
     RENDER_PASS_NODE *activeRenderPass;
     VkSubpassContents activeSubpassContents;
     uint32_t activeSubpass;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -480,6 +480,14 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     ~GLOBAL_CB_NODE();
 };
 
+struct CB_SUBMISSION {
+    CB_SUBMISSION(VkCommandBuffer cb, std::vector<VkSemaphore> const & semaphores)
+        : cb(cb), semaphores(semaphores) {}
+
+    VkCommandBuffer cb;
+    std::vector<VkSemaphore> semaphores;
+};
+
 // Fwd declarations of layer_data and helpers to look-up state from layer_data maps
 namespace core_validation {
 struct layer_data;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -4095,17 +4095,10 @@ TEST_F(VkLayerTest, DynamicStencilRefNotBound) {
 }
 
 TEST_F(VkLayerTest, CommandBufferTwoSubmits) {
-    vk_testing::Fence testFence;
-
     m_errorMonitor->SetDesiredFailureMsg(
         VK_DEBUG_REPORT_ERROR_BIT_EXT,
         "was begun w/ VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT set, but has "
         "been submitted");
-
-    VkFenceCreateInfo fenceInfo = {};
-    fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
-    fenceInfo.pNext = NULL;
-    fenceInfo.flags = 0;
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
@@ -4117,8 +4110,6 @@ TEST_F(VkLayerTest, CommandBufferTwoSubmits) {
     m_commandBuffer->ClearAllBuffers(m_clear_color, m_depth_clear_color,
                                      m_stencil_clear_color, NULL);
     EndCommandBuffer();
-
-    testFence.init(*m_device, fenceInfo);
 
     // Bypass framework since it does the waits automatically
     VkResult err = VK_SUCCESS;
@@ -4133,12 +4124,12 @@ TEST_F(VkLayerTest, CommandBufferTwoSubmits) {
     submit_info.signalSemaphoreCount = 0;
     submit_info.pSignalSemaphores = NULL;
 
-    err = vkQueueSubmit(m_device->m_queue, 1, &submit_info, testFence.handle());
+    err = vkQueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     ASSERT_VK_SUCCESS(err);
 
     // Cause validation error by re-submitting cmd buffer that should only be
     // submitted once
-    err = vkQueueSubmit(m_device->m_queue, 1, &submit_info, testFence.handle());
+    err = vkQueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
 
     m_errorMonitor->VerifyFound();
 }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2237,6 +2237,61 @@ TEST_F(VkLayerTest, ResetUnsignaledFence) {
     m_errorMonitor->VerifyNotFound();
 }
 
+TEST_F(VkLayerTest, CommandBufferSimultaneousUseSync)
+{
+    m_errorMonitor->ExpectSuccess();
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    VkResult err;
+
+    // Record (empty!) command buffer that can be submitted multiple times
+    // simultaneously.
+    VkCommandBufferBeginInfo cbbi = {
+        VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
+        VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT, nullptr
+    };
+    m_commandBuffer->BeginCommandBuffer(&cbbi);
+    m_commandBuffer->EndCommandBuffer();
+
+    VkFenceCreateInfo fci = { VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0 };
+    VkFence fence;
+    err = vkCreateFence(m_device->device(), &fci, nullptr, &fence);
+    ASSERT_VK_SUCCESS(err);
+
+    VkSemaphoreCreateInfo sci = { VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, nullptr, 0 };
+    VkSemaphore s1, s2;
+    err = vkCreateSemaphore(m_device->device(), &sci, nullptr, &s1);
+    ASSERT_VK_SUCCESS(err);
+    err = vkCreateSemaphore(m_device->device(), &sci, nullptr, &s2);
+    ASSERT_VK_SUCCESS(err);
+
+    // Submit CB once signaling s1, with fence so we can roll forward to its retirement.
+    VkSubmitInfo si = { VK_STRUCTURE_TYPE_SUBMIT_INFO, nullptr, 0, nullptr, nullptr,
+        1, &m_commandBuffer->handle(), 1, &s1 };
+    err = vkQueueSubmit(m_device->m_queue, 1, &si, fence);
+    ASSERT_VK_SUCCESS(err);
+
+    // Submit CB again, signaling s2.
+    si.pSignalSemaphores = &s2;
+    err = vkQueueSubmit(m_device->m_queue, 1, &si, VK_NULL_HANDLE);
+    ASSERT_VK_SUCCESS(err);
+
+    // Wait for fence.
+    err = vkWaitForFences(m_device->device(), 1, &fence, VK_TRUE, UINT64_MAX);
+    ASSERT_VK_SUCCESS(err);
+
+    // CB is still in flight from second submission, but semaphore s1 is no
+    // longer in flight. delete it.
+    vkDestroySemaphore(m_device->device(), s1, nullptr);
+
+    m_errorMonitor->VerifyNotFound();
+
+    // Force device idle and clean up remaining objects
+    vkDeviceWaitIdle(m_device->device());
+    vkDestroySemaphore(m_device->device(), s2, nullptr);
+    vkDestroyFence(m_device->device(), fence, nullptr);
+}
+
 TEST_F(VkLayerTest, InvalidUsageBits)
 {
     TEST_DESCRIPTION(


### PR DESCRIPTION
This series tidies up around CB submission a bit, and moves the semaphore sets into a new CB_SUBMISSION structure. This allows correct tracking of the different semaphore sets associated with each simultaneous submission of the same CB.