### PR TITLE
layers: fix CMakeLists.txt to support non MSVC win builds

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -167,9 +167,15 @@ target_include_directories(VkLayer_core_validation PRIVATE ${SPIRV_TOOLS_INCLUDE
 target_link_libraries(VkLayer_core_validation ${SPIRV_TOOLS_LIBRARIES})
 
 if (WIN32)
-    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/VkLayer_utils.dll COPY_SRC_PATH)
-    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../demos/$<CONFIGURATION>/ COPY_DST_PATH)
-    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../tests/$<CONFIGURATION>/ COPY_DST_TEST_PATH)
+    if (CMAKE_GENERATOR MATCHES "^Visual Studio.*")
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/VkLayer_utils.dll COPY_SRC_PATH)
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../demos/$<CONFIGURATION>/ COPY_DST_PATH)
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../tests/$<CONFIGURATION>/ COPY_DST_TEST_PATH)
+    else()
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/VkLayer_utils.dll COPY_SRC_PATH)
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../demos/ COPY_DST_PATH)
+        file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../tests/ COPY_DST_TEST_PATH)
+    endif()
     # Copy layer utils library to correct locations
     add_custom_command(TARGET VkLayer_utils
                        POST_BUILD

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -11,7 +11,11 @@ if (WIN32)
     if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
         foreach (config_file ${LAYER_JSON_FILES})
             FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/windows/${config_file}.json src_json)
-            FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/${config_file}.json dst_json)
+            if (CMAKE_GENERATOR MATCHES "^Visual Studio.*")
+                FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/${config_file}.json dst_json)
+            else()
+                FILE(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${config_file}.json dst_json)
+            endif()
             add_custom_target(${config_file}-json ALL
                 COMMAND copy ${src_json} ${dst_json}
                 VERBATIM


### PR DESCRIPTION
Fix a recent change broke windows builds that don't use the VC IDE or decorate build trees like VC does

Change-Id: I93c8a559c4255408a6fa890b2a3e4d81822d1cea