### PR TITLE
Tobin disable invalid mem type test

### DIFF
--- a/layers/vk_validation_layer_details.md
+++ b/layers/vk_validation_layer_details.md
@@ -160,7 +160,7 @@ The Mem Tracker portion of the VK_LAYER_LUNARG_core_validation layer tracks memo
 | Immutable Memory Binding | Validates that non-sparse memory bindings are immutable, so objects are not re-boundt | REBIND_OBJECT | vkBindBufferMemory, vkBindImageMemory | RebindMemory | NA |
 | Image/Buffer Usage bits | Verify correct USAGE bits set based on how Images and Buffers are used | INVALID_USAGE_FLAG | vkCreateImage, vkCreateBuffer, vkCreateBufferView, vkCmdCopyBuffer, vkCmdCopyQueryPoolResults, vkCmdCopyImage, vkCmdBlitImage, vkCmdCopyBufferToImage, vkCmdCopyImageToBuffer, vkCmdUpdateBuffer, vkCmdFillBuffer  | InvalidUsageBits | NA |
 | Memory Map Range Checks | Validates that Memory Mapping Requests are valid for the Memory Object (in-range, not currently mapped on Map, currently mapped on UnMap, size is non-zero) | INVALID_MAP | vkMapMemory | InvalidMemoryMapping | NA |
-| Memory Type Index Checks | Validates that specified memory type indices are valid | INVALID_MEM_TYPE | vkBindImageMemory vkBindBufferMemory | BindImageInvalidMemoryType | NA |
+| Memory Type Index Checks | Validates that specified memory type indices are valid | INVALID_MEM_TYPE | vkBindImageMemory vkBindBufferMemory | TODO | Need to fix up and re-enable BindImageInvalidMemoryType test as noted in comment in test |
 | NA | Enum used for informational messages | NONE | | TODO | None |
 | NA | Enum used for errors in the layer itself. This does not indicate an app issue, but instead a bug in the layer. | INTERNAL_ERROR | | TODO | None |
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2720,7 +2720,7 @@ TEST_F(VkLayerTest, PipelineNotBound) {
     vkDestroyDescriptorSetLayout(m_device->device(), ds_layout, NULL);
     vkDestroyDescriptorPool(m_device->device(), ds_pool, NULL);
 }
-
+#if 0 // Disabling this test for now, needs to be updated
 TEST_F(VkLayerTest, BindImageInvalidMemoryType) {
     VkResult err;
 
@@ -2768,6 +2768,12 @@ TEST_F(VkLayerTest, BindImageInvalidMemoryType) {
 
     vkGetImageMemoryRequirements(m_device->device(), image, &mem_reqs);
     mem_alloc.allocationSize = mem_reqs.size;
+    // TODO : This is not an ideal way to cause the error and triggers a segF
+    //  on at least one android driver when attempting to Allocate the memory.
+    //  That segF may or may not be a driver bug, but really what we want to do
+    //  here is find a device-supported memory type that is also not supported
+    //  for the particular image we're binding the memory too. If no such
+    //  type exists, then we can print a message and skip the test.
     // Introduce Failure, select likely invalid TypeIndex
     mem_alloc.memoryTypeIndex = 31;
 
@@ -2782,7 +2788,7 @@ TEST_F(VkLayerTest, BindImageInvalidMemoryType) {
     vkDestroyImage(m_device->device(), image, NULL);
     vkFreeMemory(m_device->device(), mem, NULL);
 }
-
+#endif
 TEST_F(VkLayerTest, BindInvalidMemory) {
     VkResult err;
     bool pass;


### PR DESCRIPTION
I'd like to turn this test off for now as it crashed on at least 1 android driver and looking at it closer I don't like the way that it induces the error when allocating memory. Based on the current spec it's not clear that the way the test is allocating is illegal (just picking an arbitrary memTypeIndex), but I believe it should be which may require a spec update.
I noted a way that the test can be updated, which is left as a later exercise.