### PR TITLE
layers: Fix dynamic descriptor count

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -50,7 +50,7 @@ cvdescriptorset::DescriptorSetLayout::DescriptorSetLayout(debug_report_data *rep
         }
         if (p_create_info->pBindings[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC ||
             p_create_info->pBindings[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) {
-            dynamic_descriptor_count_++;
+            dynamic_descriptor_count_ += p_create_info->pBindings[i].descriptorCount;
         }
     }
 }


### PR DESCRIPTION
When creating descriptor set layout, we were only incrementing the dynamic descriptor
count by 1 regardless of the number of descriptors in a binding. This fix increments
the count by the number of descriptors in the binding.