### PR TITLE
tests: assert CreatePipelineRelaxedTypeMatch success

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -10776,7 +10776,11 @@ TEST_F(VkLayerTest, CreatePipelineRelaxedTypeMatch)
     descriptorSet.AppendDummy();
     descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
 
-    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+    VkResult err = VK_SUCCESS;
+    err =
+        pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+    ASSERT_VK_SUCCESS(err);
+
 
     m_errorMonitor->VerifyNotFound();
 }


### PR DESCRIPTION
Check that vkCreateGraphicsPipelines succeeds in
CreatePipelineRelaxedTypeMatch.
Some devices incorrectly fail to return success on this call.
Both the driver and the layers should return VK_SUCCESS.