### PR TITLE
layers: Don't produce spurious validation errors for sample count

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2836,7 +2836,6 @@ static bool validatePipelineDrawtimeState(layer_data const *my_data,
         if (pCB->activeRenderPass) {
             const VkRenderPassCreateInfo *render_pass_info = pCB->activeRenderPass->pCreateInfo;
             const VkSubpassDescription *subpass_desc = &render_pass_info->pSubpasses[pCB->activeSubpass];
-            VkSampleCountFlagBits subpass_num_samples = VkSampleCountFlagBits(0);
             uint32_t i;
 
             const safe_VkPipelineColorBlendStateCreateInfo *color_blend_state = pPipeline->graphicsPipelineCI.pColorBlendState;
@@ -2852,6 +2851,8 @@ static bool validatePipelineDrawtimeState(layer_data const *my_data,
                                 reinterpret_cast<const uint64_t &>(pPipeline->pipeline));
             }
 
+            VkSampleCountFlagBits subpass_num_samples = VkSampleCountFlagBits(0);
+
             for (i = 0; i < subpass_desc->colorAttachmentCount; i++) {
                 VkSampleCountFlagBits samples;
 
@@ -2866,6 +2867,7 @@ static bool validatePipelineDrawtimeState(layer_data const *my_data,
                     break;
                 }
             }
+
             if ((subpass_desc->pDepthStencilAttachment != NULL) &&
                 (subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED)) {
                 const VkSampleCountFlagBits samples =
@@ -2876,8 +2878,7 @@ static bool validatePipelineDrawtimeState(layer_data const *my_data,
                     subpass_num_samples = static_cast<VkSampleCountFlagBits>(-1);
             }
 
-            if (((subpass_desc->colorAttachmentCount > 0) || (subpass_desc->pDepthStencilAttachment != NULL)) &&
-                (pso_num_samples != subpass_num_samples)) {
+            if (subpass_num_samples && pso_num_samples != subpass_num_samples) {
                 skip_call |=
                         log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,
                                 reinterpret_cast<const uint64_t &>(pPipeline->pipeline), __LINE__, DRAWSTATE_NUM_SAMPLES_MISMATCH, "DS",


### PR DESCRIPTION
Previously we would emit a spurious validation error if the only
color or depth attachment references were VK_ATTACHMENT_UNUSED.

Fixes #705 