### PR TITLE
Move DeviceLimits validation checks into Core/Parameter_Validation layers

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -105,6 +105,8 @@ struct shader_module;
 // TODO : Split this into separate structs for instance and device level data?
 struct layer_data {
     VkInstance instance;
+    unique_ptr<INSTANCE_STATE> instance_state;
+
 
     debug_report_data *report_data;
     std::vector<VkDebugReportCallbackEXT> logging_callback;
@@ -145,10 +147,11 @@ struct layer_data {
     // Device specific data
     PHYS_DEV_PROPERTIES_NODE phys_dev_properties;
     VkPhysicalDeviceMemoryProperties phys_dev_mem_props;
+    unique_ptr<PHYSICAL_DEVICE_STATE> physicalDeviceState;
 
     layer_data()
-        : report_data(nullptr), device_dispatch_table(nullptr), instance_dispatch_table(nullptr), device_extensions(),
-          device(VK_NULL_HANDLE), phys_dev_properties{}, phys_dev_mem_props{} {};
+        : instance_state(nullptr), report_data(nullptr), device_dispatch_table(nullptr), instance_dispatch_table(nullptr),
+          device_extensions(), device(VK_NULL_HANDLE), phys_dev_properties{}, phys_dev_mem_props{}, physicalDeviceState(nullptr){};
 };
 
 // TODO : Do we need to guard access to layer_data_map w/ lock?
@@ -3939,7 +3942,7 @@ CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallba
                                      pCreateInfo->ppEnabledExtensionNames);
 
     init_core_validation(instance_data, pAllocator);
-
+    instance_data->instance_state = unique_ptr<INSTANCE_STATE>(new INSTANCE_STATE());
     ValidateLayerOrdering(*pCreateInfo);
 
     return result;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -279,3 +279,33 @@ struct COMMAND_POOL_NODE {
     // TODO: why is this std::list?
     std::list<VkCommandBuffer> commandBuffers; // container of cmd buffers allocated from this pool
 };
+
+// Stuff from Device Limits Layer
+enum CALL_STATE {
+    UNCALLED,      // Function has not been called
+    QUERY_COUNT,   // Function called once to query a count
+    QUERY_DETAILS, // Function called w/ a count to query details
+};
+
+struct INSTANCE_STATE {
+    // Track the call state and array size for physical devices
+    CALL_STATE vkEnumeratePhysicalDevicesState;
+    uint32_t physicalDevicesCount;
+    INSTANCE_STATE() : vkEnumeratePhysicalDevicesState(UNCALLED), physicalDevicesCount(0) {};
+};
+
+struct PHYSICAL_DEVICE_STATE {
+    // Track the call state and array sizes for various query functions
+    CALL_STATE vkGetPhysicalDeviceQueueFamilyPropertiesState;
+    uint32_t queueFamilyPropertiesCount;
+    CALL_STATE vkGetPhysicalDeviceLayerPropertiesState;
+    uint32_t deviceLayerCount;
+    CALL_STATE vkGetPhysicalDeviceExtensionPropertiesState;
+    uint32_t deviceExtensionCount;
+    CALL_STATE vkGetPhysicalDeviceFeaturesState;
+    PHYSICAL_DEVICE_STATE()
+        : vkGetPhysicalDeviceQueueFamilyPropertiesState(UNCALLED), queueFamilyPropertiesCount(0),
+        vkGetPhysicalDeviceLayerPropertiesState(UNCALLED), deviceLayerCount(0),
+        vkGetPhysicalDeviceExtensionPropertiesState(UNCALLED), deviceExtensionCount(0),
+        vkGetPhysicalDeviceFeaturesState(UNCALLED) {};
+};

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -290,8 +290,8 @@ enum CALL_STATE {
 struct INSTANCE_STATE {
     // Track the call state and array size for physical devices
     CALL_STATE vkEnumeratePhysicalDevicesState;
-    uint32_t physicalDevicesCount;
-    INSTANCE_STATE() : vkEnumeratePhysicalDevicesState(UNCALLED), physicalDevicesCount(0) {};
+    uint32_t physical_devices_count;
+    INSTANCE_STATE() : vkEnumeratePhysicalDevicesState(UNCALLED), physical_devices_count(0) {};
 };
 
 struct PHYSICAL_DEVICE_STATE {
@@ -299,13 +299,11 @@ struct PHYSICAL_DEVICE_STATE {
     CALL_STATE vkGetPhysicalDeviceQueueFamilyPropertiesState;
     uint32_t queueFamilyPropertiesCount;
     CALL_STATE vkGetPhysicalDeviceLayerPropertiesState;
-    uint32_t deviceLayerCount;
     CALL_STATE vkGetPhysicalDeviceExtensionPropertiesState;
-    uint32_t deviceExtensionCount;
     CALL_STATE vkGetPhysicalDeviceFeaturesState;
     PHYSICAL_DEVICE_STATE()
-        : vkGetPhysicalDeviceQueueFamilyPropertiesState(UNCALLED), queueFamilyPropertiesCount(0),
-        vkGetPhysicalDeviceLayerPropertiesState(UNCALLED), deviceLayerCount(0),
-        vkGetPhysicalDeviceExtensionPropertiesState(UNCALLED), deviceExtensionCount(0),
+        : vkGetPhysicalDeviceQueueFamilyPropertiesState(UNCALLED),
+        vkGetPhysicalDeviceLayerPropertiesState(UNCALLED),
+        vkGetPhysicalDeviceExtensionPropertiesState(UNCALLED),
         vkGetPhysicalDeviceFeaturesState(UNCALLED) {};
 };

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -255,8 +255,8 @@ enum DEV_LIMITS_ERROR {
     DEVLIMITS_INVALID_CALL_SEQUENCE,         // Flag generic case of an invalid call sequence by the app
     DEVLIMITS_INVALID_FEATURE_REQUESTED,     // App requested a feature not supported by physical device
     DEVLIMITS_COUNT_MISMATCH,                // App requesting a count value different than actual value
-    DEVLIMITS_INVALID_QUEUE_CREATE_REQUEST,  // Invalid queue requested based on queue family properties
-    DEVLIMITS_INVALID_UNIFORM_BUFFER_OFFSET, // Uniform buffer offset violates device limit granularity
-    DEVLIMITS_INVALID_STORAGE_BUFFER_OFFSET, // Storage buffer offset violates device limit granularity
+// LUGMAL     DEVLIMITS_INVALID_QUEUE_CREATE_REQUEST,  // Invalid queue requested based on queue family properties -> deleted
+// LUGMAL    DEVLIMITS_INVALID_UNIFORM_BUFFER_OFFSET, // Uniform buffer offset violates device limit granularity -> device_limit
+// LUGMAL    DEVLIMITS_INVALID_STORAGE_BUFFER_OFFSET, // Storage buffer offset violates device limit granularity -> device_limit
 };
 #endif // CORE_VALIDATION_ERROR_ENUMS_H_

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -222,6 +222,7 @@ enum DRAW_STATE_ERROR {
     DRAWSTATE_PUSH_CONSTANTS_ERROR,          // Push constants exceed maxPushConstantSize
 };
 
+// Shader Checker ERROR codes
 enum SHADER_CHECKER_ERROR {
     SHADER_CHECKER_NONE,
     SHADER_CHECKER_INTERFACE_TYPE_MISMATCH,    // Type mismatch between shader stages or shader and pipeline
@@ -242,4 +243,20 @@ enum SHADER_CHECKER_ERROR {
     SHADER_CHECKER_BAD_CAPABILITY,                          // Shader uses capability not supported by Vulkan (OpenCL features)
 };
 
+// Device Limits ERROR codes
+enum DEV_LIMITS_ERROR {
+    DEVLIMITS_NONE,                          // Used for INFO & other non-error messages
+    DEVLIMITS_INVALID_INSTANCE,              // Invalid instance used
+    DEVLIMITS_INVALID_PHYSICAL_DEVICE,       // Invalid physical device used
+    DEVLIMITS_INVALID_INHERITED_QUERY,       // Invalid use of inherited query
+    DEVLIMITS_INVALID_ATTACHMENT_COUNT,      // Invalid value for the number of attachments
+    DEVLIMITS_MISSING_QUERY_COUNT,           // Did not make initial call to an API to query the count
+    DEVLIMITS_MUST_QUERY_COUNT,              // Failed to make initial call to an API to query the count
+    DEVLIMITS_INVALID_CALL_SEQUENCE,         // Flag generic case of an invalid call sequence by the app
+    DEVLIMITS_INVALID_FEATURE_REQUESTED,     // App requested a feature not supported by physical device
+    DEVLIMITS_COUNT_MISMATCH,                // App requesting a count value different than actual value
+    DEVLIMITS_INVALID_QUEUE_CREATE_REQUEST,  // Invalid queue requested based on queue family properties
+    DEVLIMITS_INVALID_UNIFORM_BUFFER_OFFSET, // Uniform buffer offset violates device limit granularity
+    DEVLIMITS_INVALID_STORAGE_BUFFER_OFFSET, // Storage buffer offset violates device limit granularity
+};
 #endif // CORE_VALIDATION_ERROR_ENUMS_H_

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -248,15 +248,10 @@ enum DEV_LIMITS_ERROR {
     DEVLIMITS_NONE,                          // Used for INFO & other non-error messages
     DEVLIMITS_INVALID_INSTANCE,              // Invalid instance used
     DEVLIMITS_INVALID_PHYSICAL_DEVICE,       // Invalid physical device used
-// LUGMAL    DEVLIMITS_INVALID_INHERITED_QUERY,       // Invalid use of inherited query              -> PV DEVICE_FEATURE
-// LUGMAL    DEVLIMITS_INVALID_ATTACHMENT_COUNT,      // Invalid value for the number of attachments -> PV DEVICE_LIMIT
     DEVLIMITS_MISSING_QUERY_COUNT,           // Did not make initial call to an API to query the count
     DEVLIMITS_MUST_QUERY_COUNT,              // Failed to make initial call to an API to query the count
-    DEVLIMITS_INVALID_CALL_SEQUENCE,         // Flag generic case of an invalid call sequence by the app
     DEVLIMITS_INVALID_FEATURE_REQUESTED,     // App requested a feature not supported by physical device
     DEVLIMITS_COUNT_MISMATCH,                // App requesting a count value different than actual value
-// LUGMAL     DEVLIMITS_INVALID_QUEUE_CREATE_REQUEST,  // Invalid queue requested based on queue family properties -> deleted
-// LUGMAL    DEVLIMITS_INVALID_UNIFORM_BUFFER_OFFSET, // Uniform buffer offset violates device limit granularity -> device_limit
-// LUGMAL    DEVLIMITS_INVALID_STORAGE_BUFFER_OFFSET, // Storage buffer offset violates device limit granularity -> device_limit
+    DEVLIMITS_INVALID_QUEUE_CREATE_REQUEST,  // Invalid queue requested based on queue family properties
 };
 #endif // CORE_VALIDATION_ERROR_ENUMS_H_

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -248,8 +248,8 @@ enum DEV_LIMITS_ERROR {
     DEVLIMITS_NONE,                          // Used for INFO & other non-error messages
     DEVLIMITS_INVALID_INSTANCE,              // Invalid instance used
     DEVLIMITS_INVALID_PHYSICAL_DEVICE,       // Invalid physical device used
-    DEVLIMITS_INVALID_INHERITED_QUERY,       // Invalid use of inherited query
-    DEVLIMITS_INVALID_ATTACHMENT_COUNT,      // Invalid value for the number of attachments
+// LUGMAL    DEVLIMITS_INVALID_INHERITED_QUERY,       // Invalid use of inherited query              -> PV DEVICE_FEATURE
+// LUGMAL    DEVLIMITS_INVALID_ATTACHMENT_COUNT,      // Invalid value for the number of attachments -> PV DEVICE_LIMIT
     DEVLIMITS_MISSING_QUERY_COUNT,           // Did not make initial call to an API to query the count
     DEVLIMITS_MUST_QUERY_COUNT,              // Failed to make initial call to an API to query the count
     DEVLIMITS_INVALID_CALL_SEQUENCE,         // Flag generic case of an invalid call sequence by the app

--- a/layers/parameter_validation_utils.h
+++ b/layers/parameter_validation_utils.h
@@ -49,6 +49,10 @@ enum ErrorCode {
     UNRECOGNIZED_VALUE,   // A Vulkan enumeration, VkFlags, or VkBool32 parameter
                           // contains a value that is not recognized as valid for
                           // that type.
+    DEVICE_LIMIT,         // A specified parameter exceeds the limits returned
+                          // by the physical device
+    DEVICE_FEATURE,       // Use of a requested feature is not supported by
+                          // the device
     FAILURE_RETURN_CODE,  // A Vulkan return code indicating a failure condition
                           // was encountered.
 };

--- a/layers/vk_validation_layer_details.md
+++ b/layers/vk_validation_layer_details.md
@@ -10,7 +10,6 @@ This is a meta-layer managed by the loader. Specifying this layer name will caus
 
  - VK_LAYER_GOOGLE_threading
  - VK_LAYER_LUNARG_parameter_validation
- - VK_LAYER_LUNARG_device_limits
  - VK_LAYER_LUNARG_object_tracker
  - VK_LAYER_LUNARG_image
  - VK_LAYER_LUNARG_core_validation
@@ -141,7 +140,7 @@ It flags errors when inconsistencies are found across interfaces between shader 
 | NA | Enum used for informational messages | NONE | | TODO | None |
 
 ### VK_LAYER_LUNARG_core_validation Shader Checker Pending Work
- 
+
 See the Khronos github repository for Vulkan-LoaderAndValidationLayers for additional pending issues, or to submit new validation requests
 
 ### VK_LAYER_LUNARG_core_validation Memory Tracker Details Table
@@ -169,6 +168,20 @@ The Mem Tracker portion of the VK_LAYER_LUNARG_core_validation layer tracks memo
 
 See the Khronos github repository for Vulkan-LoaderAndValidationLayers for additional pending issues, or to submit new validation requests
 
+### VK_LAYER_LUNARG_core_validation Memory Device Limits Details Table
+Each device specifies a set of Device Limits with which the appropriate parameters should comply.  The core_validation layer contains device-limits related checks for which some amount of saved state information is necessary to complete the check.
+
+| Check | Overview | ENUM DEVLIMITS_* | Relevant API | Testname | Notes/TODO |
+| ----- | -------- | ---------------- | ---------------- | -------- | ---------- |
+| Valid instance | If an invalid instance is used, this error will be flagged | INVALID_INSTANCE | vkEnumeratePhysicalDevices | TODO | VK_LAYER_LUNARG_object_tracker should also catch this so if we made sure VK_LAYER_LUNARG_object_tracker was always on top, we could avoid this check |
+| Valid physical device | Enum used for informational messages | INVALID_PHYSICAL_DEVICE | vkEnumeratePhysicalDevices | TODO | VK_LAYER_LUNARG_object_tracker should also catch this so if we made sure VK_LAYER_LUNARG_object_tracker was always on top, we could avoid this check |
+| Query count checked | Signifies that a query call such as vkEnumeratePhysicalDevices or vkGetPhysicalDeviceQueueFamilyProperties has been called without querying the count | MISSING_QUERY_COUNT | vkEnumeratePhysicalDevices vkGetPhysicalDeviceQueueFamilyProperties | TODO | None |
+| Querying array counts | For API calls where an array count should be queried with an initial call and a NULL array pointer, verify that such a call was made before making a call with non-null array pointer. | MUST_QUERY_COUNT | vkEnumeratePhysicalDevices vkGetPhysicalDeviceQueueFamilyProperties | TODO | Create focused test |
+| Array count value | For API calls where an array of details is queried, verify that the size of the requested array matches the size of the array supported by the device. | COUNT_MISMATCH | vkEnumeratePhysicalDevices vkGetPhysicalDeviceQueueFamilyProperties | TODO | Create focused test |
+| Queue Creation | When creating/requesting queues, make sure that QueueFamilyPropertiesIndex and index/count within that queue family are valid. | INVALID_QUEUE_CREATE_REQUEST | vkGetDeviceQueue vkCreateDevice | TODO | Create focused test |
+| NA | Enum used for informational messages | NONE | | TODO | None |
+
+
 ## VK_LAYER_LUNARG_parameter_validation
 
 ### VK_LAYER_LUNARG_parameter_validation Overview
@@ -185,6 +198,8 @@ The VK_LAYER_LUNARG_parameter_validation layer validates parameter values and fl
 | Required Parameter | Verifies that a required parameter was not specified as 0 or NULL | REQUIRED_PARAMETER | | RequiredParameter | NA |
 | Reserved Parameter | Verifies that a parameter reserved for future use was specified as 0 or NULL | RESERVED_PARAMETER | | ReservedParameter | NA |
 | Unrecognized Value | Verifies that a Vulkan enumeration, VkFlags, or VkBool32 parameter contains a value that is recognized as valid for that type | UNRECOGNIZED_VALUE | | UnrecognizedValue | NA |
+| Device Limit Violation | Verifies that a parameter is within the limits advertised by the gpu | DEVICE_LIMIT | vkUpdateDescriptorSets vkCreateRenderPass | Todo | NA |
+| Device Feature Violation | Verifies that a requested feature is supported by the gpu | DEVICE_FEATURE | vkBeginCommandBuffer | Todo | NA |
 | Failed Call Return Code | Provides a description of a failure code returned by a Vulkan API call | FAILURE_RETURN_CODE | | FailedReturnValue | NA |
 | NA | Enum used for informational messages | NONE | | TODO | None |
 


### PR DESCRIPTION
Move the stateful checks into CV and the stateless-ish checks into PV.  Note that this change leaves the DeviceLimits layer intact as it will be removed in a subsequent PR.