### PR TITLE
Tobin gh695 pipeline layout lifetime

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2058,7 +2058,7 @@ static VkDescriptorSetLayoutBinding const * get_descriptor_binding(PIPELINE_LAYO
     if (!pipelineLayout)
         return nullptr;
 
-    if (slot.first >= pipelineLayout->descriptorSetLayouts.size())
+    if (slot.first >= pipelineLayout->setLayouts.size())
         return nullptr;
 
     return pipelineLayout->setLayouts[slot.first]->GetDescriptorSetLayoutBindingPtrFromBinding(slot.second);
@@ -2301,11 +2301,11 @@ static bool verify_set_layout_compatibility(layer_data *my_data, const cvdescrip
         errorMsg = errorStr.str();
         return false;
     }
-    if (layoutIndex >= pipeline_layout->descriptorSetLayouts.size()) {
+    auto num_sets = pipeline_layout->setLayouts.size();
+    if (layoutIndex >= num_sets) {
         stringstream errorStr;
-        errorStr << "VkPipelineLayout (" << layout << ") only contains " << pipeline_layout->descriptorSetLayouts.size()
-                 << " setLayouts corresponding to sets 0-" << pipeline_layout->descriptorSetLayouts.size() - 1
-                 << ", but you're attempting to bind set to index " << layoutIndex;
+        errorStr << "VkPipelineLayout (" << layout << ") only contains " << num_sets << " setLayouts corresponding to sets 0-"
+                 << num_sets - 1 << ", but you're attempting to bind set to index " << layoutIndex;
         errorMsg = errorStr.str();
         return false;
     }
@@ -6063,10 +6063,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(VkDevice device, const VkPip
     if (VK_SUCCESS == result) {
         std::lock_guard<std::mutex> lock(global_lock);
         PIPELINE_LAYOUT_NODE &plNode = dev_data->pipelineLayoutMap[*pPipelineLayout];
-        plNode.descriptorSetLayouts.resize(pCreateInfo->setLayoutCount);
         plNode.setLayouts.resize(pCreateInfo->setLayoutCount);
         for (i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-            plNode.descriptorSetLayouts[i] = pCreateInfo->pSetLayouts[i];
             plNode.setLayouts[i] = getDescriptorSetLayout(dev_data, pCreateInfo->pSetLayouts[i]);
         }
         plNode.pushConstantRanges.resize(pCreateInfo->pushConstantRangeCount);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5342,9 +5342,10 @@ DestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallback
 
 VKAPI_ATTR void VKAPI_CALL
 DestroyPipelineLayout(VkDevice device, VkPipelineLayout pipelineLayout, const VkAllocationCallbacks *pAllocator) {
-    get_my_data_ptr(get_dispatch_key(device), layer_data_map)
-        ->device_dispatch_table->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
-    // TODO : Clean up any internal data structures using this obj.
+    layer_data *dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
+    dev_data->device_dispatch_table->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
+
+    dev_data->pipelineLayoutMap.erase(pipelineLayout);
 }
 
 VKAPI_ATTR void VKAPI_CALL

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2611,7 +2611,7 @@ static bool validate_pipeline_shader_stage(debug_report_data *report_data,
     std::map<descriptor_slot_t, interface_var> descriptor_uses;
     collect_interface_by_descriptor_slot(report_data, module, accessible_ids, descriptor_uses);
 
-    auto pipelineLayout = pipeline->pipelineLayout;
+    auto pipelineLayout = pipeline->pipeline_layout;
 
     /* validate push constant usage */
     pass &= validate_push_constant_usage(report_data, &pipelineLayout->pushConstantRanges,
@@ -5859,7 +5859,7 @@ CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t
         pPipeNode[i] = new PIPELINE_NODE;
         pPipeNode[i]->initGraphicsPipeline(&pCreateInfos[i]);
         pPipeNode[i]->render_pass_ci.initialize(getRenderPass(dev_data, pCreateInfos[i].renderPass)->pCreateInfo);
-        pPipeNode[i]->pipelineLayout = getPipelineLayout(dev_data, pCreateInfos[i].layout);
+        pPipeNode[i]->pipeline_layout = getPipelineLayout(dev_data, pCreateInfos[i].layout);
 
         skip_call |= verifyPipelineCreateState(dev_data, device, pPipeNode, i);
     }
@@ -5903,7 +5903,7 @@ CreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t 
         // Create and initialize internal tracking data structure
         pPipeNode[i] = new PIPELINE_NODE;
         pPipeNode[i]->initComputePipeline(&pCreateInfos[i]);
-        pPipeNode[i]->pipelineLayout = getPipelineLayout(dev_data, pCreateInfos[i].layout);
+        pPipeNode[i]->pipeline_layout = getPipelineLayout(dev_data, pCreateInfos[i].layout);
         // memcpy(&pPipeNode[i]->computePipelineCI, (const void *)&pCreateInfos[i], sizeof(VkComputePipelineCreateInfo));
 
         // TODO: Add Compute Pipeline Verification

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5345,7 +5345,9 @@ DestroyPipelineLayout(VkDevice device, VkPipelineLayout pipelineLayout, const Vk
     layer_data *dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
     dev_data->device_dispatch_table->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
 
+    std::unique_lock<std::mutex> lock(global_lock);
     dev_data->pipelineLayoutMap.erase(pipelineLayout);
+    lock.unlock();
 }
 
 VKAPI_ATTR void VKAPI_CALL

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2614,8 +2614,7 @@ static bool validate_pipeline_shader_stage(debug_report_data *report_data,
     auto pipelineLayout = pipeline->pipeline_layout;
 
     /* validate push constant usage */
-    pass &= validate_push_constant_usage(report_data, &pipelineLayout->pushConstantRanges,
-                                        module, accessible_ids, pStage->stage);
+    pass &= validate_push_constant_usage(report_data, &pipelineLayout.pushConstantRanges, module, accessible_ids, pStage->stage);
 
     /* validate descriptor use */
     for (auto use : descriptor_uses) {
@@ -2623,7 +2622,7 @@ static bool validate_pipeline_shader_stage(debug_report_data *report_data,
         pipeline->active_slots[use.first.first].insert(use.first.second);
 
         /* verify given pipelineLayout has requested setLayout with requested binding */
-        const auto & binding = get_descriptor_binding(pipelineLayout, use.first);
+        const auto &binding = get_descriptor_binding(&pipelineLayout, use.first);
         unsigned required_descriptor_count;
 
         if (!binding) {
@@ -5859,7 +5858,7 @@ CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t
         pPipeNode[i] = new PIPELINE_NODE;
         pPipeNode[i]->initGraphicsPipeline(&pCreateInfos[i]);
         pPipeNode[i]->render_pass_ci.initialize(getRenderPass(dev_data, pCreateInfos[i].renderPass)->pCreateInfo);
-        pPipeNode[i]->pipeline_layout = getPipelineLayout(dev_data, pCreateInfos[i].layout);
+        pPipeNode[i]->pipeline_layout = *getPipelineLayout(dev_data, pCreateInfos[i].layout);
 
         skip_call |= verifyPipelineCreateState(dev_data, device, pPipeNode, i);
     }
@@ -5903,7 +5902,7 @@ CreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t 
         // Create and initialize internal tracking data structure
         pPipeNode[i] = new PIPELINE_NODE;
         pPipeNode[i]->initComputePipeline(&pCreateInfos[i]);
-        pPipeNode[i]->pipeline_layout = getPipelineLayout(dev_data, pCreateInfos[i].layout);
+        pPipeNode[i]->pipeline_layout = *getPipelineLayout(dev_data, pCreateInfos[i].layout);
         // memcpy(&pPipeNode[i]->computePipelineCI, (const void *)&pCreateInfos[i], sizeof(VkComputePipelineCreateInfo));
 
         // TODO: Add Compute Pipeline Verification

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -125,12 +125,6 @@ struct IMAGE_LAYOUT_NODE {
     VkFormat format;
 };
 
-// Store layouts and pushconstants for PipelineLayout
-struct PIPELINE_LAYOUT_NODE {
-    std::vector<cvdescriptorset::DescriptorSetLayout const *> set_layouts;
-    std::vector<VkPushConstantRange> push_constant_ranges;
-};
-
 class PIPELINE_NODE {
   public:
     VkPipeline pipeline;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -127,7 +127,6 @@ struct IMAGE_LAYOUT_NODE {
 
 // Store layouts and pushconstants for PipelineLayout
 struct PIPELINE_LAYOUT_NODE {
-    std::vector<VkDescriptorSetLayout> descriptorSetLayouts;
     std::vector<cvdescriptorset::DescriptorSetLayout const *> setLayouts;
     std::vector<VkPushConstantRange> pushConstantRanges;
 };

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -127,8 +127,8 @@ struct IMAGE_LAYOUT_NODE {
 
 // Store layouts and pushconstants for PipelineLayout
 struct PIPELINE_LAYOUT_NODE {
-    std::vector<cvdescriptorset::DescriptorSetLayout const *> setLayouts;
-    std::vector<VkPushConstantRange> pushConstantRanges;
+    std::vector<cvdescriptorset::DescriptorSetLayout const *> set_layouts;
+    std::vector<VkPushConstantRange> push_constant_ranges;
 };
 
 class PIPELINE_NODE {

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -149,13 +149,13 @@ class PIPELINE_NODE {
     bool blendConstantsEnabled; // Blend constants enabled for any attachments
     // Store RPCI b/c renderPass may be destroyed after Pipeline creation
     safe_VkRenderPassCreateInfo render_pass_ci;
-    PIPELINE_LAYOUT_NODE const *pipelineLayout;
+    PIPELINE_LAYOUT_NODE const *pipeline_layout;
 
     // Default constructor
     PIPELINE_NODE()
         : pipeline{}, graphicsPipelineCI{}, computePipelineCI{}, active_shaders(0), duplicate_shaders(0), active_slots(),
           vertexBindingDescriptions(), vertexAttributeDescriptions(), attachments(), blendConstantsEnabled(false), render_pass_ci(),
-          pipelineLayout(nullptr) {}
+          pipeline_layout(nullptr) {}
 
     void initGraphicsPipeline(const VkGraphicsPipelineCreateInfo *pCreateInfo) {
         graphicsPipelineCI.initialize(pCreateInfo);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -149,13 +149,13 @@ class PIPELINE_NODE {
     bool blendConstantsEnabled; // Blend constants enabled for any attachments
     // Store RPCI b/c renderPass may be destroyed after Pipeline creation
     safe_VkRenderPassCreateInfo render_pass_ci;
-    PIPELINE_LAYOUT_NODE const *pipeline_layout;
+    PIPELINE_LAYOUT_NODE pipeline_layout;
 
     // Default constructor
     PIPELINE_NODE()
         : pipeline{}, graphicsPipelineCI{}, computePipelineCI{}, active_shaders(0), duplicate_shaders(0), active_slots(),
           vertexBindingDescriptions(), vertexAttributeDescriptions(), attachments(), blendConstantsEnabled(false), render_pass_ci(),
-          pipeline_layout(nullptr) {}
+          pipeline_layout() {}
 
     void initGraphicsPipeline(const VkGraphicsPipelineCreateInfo *pCreateInfo) {
         graphicsPipelineCI.initialize(pCreateInfo);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -426,10 +426,25 @@ template <> struct hash<ImageSubresourcePair> {
 };
 }
 
+// Store layouts and pushconstants for PipelineLayout
+struct PIPELINE_LAYOUT_NODE {
+    VkPipelineLayout layout;
+    std::vector<cvdescriptorset::DescriptorSetLayout const *> set_layouts;
+    std::vector<VkPushConstantRange> push_constant_ranges;
+
+    PIPELINE_LAYOUT_NODE() : layout(VK_NULL_HANDLE), set_layouts{}, push_constant_ranges{} {}
+
+    void reset() {
+        layout = VK_NULL_HANDLE;
+        set_layouts.clear();
+        push_constant_ranges.clear();
+    }
+};
+
 // Track last states that are bound per pipeline bind point (Gfx & Compute)
 struct LAST_BOUND_STATE {
     VkPipeline pipeline;
-    VkPipelineLayout pipelineLayout;
+    PIPELINE_LAYOUT_NODE pipeline_layout;
     // Track each set that has been bound
     // TODO : can unique be global per CB? (do we care about Gfx vs. Compute?)
     std::unordered_set<cvdescriptorset::DescriptorSet *> uniqueBoundSets;
@@ -440,7 +455,7 @@ struct LAST_BOUND_STATE {
 
     void reset() {
         pipeline = VK_NULL_HANDLE;
-        pipelineLayout = VK_NULL_HANDLE;
+        pipeline_layout.reset();
         uniqueBoundSets.clear();
         boundDescriptorSets.clear();
         dynamicOffsets.clear();

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -6942,7 +6942,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     // verify_set_layout_compatibility fail cases:
     // 1. invalid VkPipelineLayout (layout) passed into vkCmdBindDescriptorSets
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         " due to: invalid VkPipelineLayout ");
+                                         "Invalid VkPipelineLayout Object ");
     vkCmdBindDescriptorSets(m_commandBuffer->GetBufferHandle(),
                             VK_PIPELINE_BIND_POINT_GRAPHICS,
                             (VkPipelineLayout)((size_t)0xbaadb1be), 0, 1,
@@ -7014,6 +7014,11 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
                             pipe_layout_fs_only, 0, 1, &ds0_fs_only, 0, NULL);
     m_errorMonitor->VerifyFound();
 
+    // Now that we're done actively using the pipelineLayout that gfx pipeline
+    //  was created with, we should be able to delete it. Do that now to verify
+    //  that validation obeys pipelineLayout lifetime
+    vkDestroyPipelineLayout(m_device->device(), pipe_layout_fs_only, NULL);
+
     // Cause draw-time errors due to PSO incompatibilities
     // 1. Error due to not binding required set (we actually use same code as
     // above to disturb set0)
@@ -7042,7 +7047,6 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     m_errorMonitor->VerifyFound();
 
     // Remaining clean-up
-    vkDestroyPipelineLayout(m_device->device(), pipe_layout_fs_only, NULL);
     for (uint32_t i = 0; i < NUM_LAYOUTS; ++i) {
         vkDestroyDescriptorSetLayout(m_device->device(), ds_layout[i], NULL);
     }


### PR DESCRIPTION
Fixes #695 

Save PIPELINE_LAYOUT_NODE struct for last bound VkPipelineLayout and use that to perform compatibility checks. This makes sure that validation doesn't rely on VkPipelineLayout node existing beyond its spec-defined lifetime.

As it turns out, we weren't removing entries from pipelineLayoutMap() ad VkPipelineLayout destroy time, so that code was added as well.

Also updated an existing test to destroy VkPipelineLayout node earlier and verify that it's not required to be alive in order to perform compatibility validation.