### PR TITLE
Tobin 2 test fixes

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1049,7 +1049,7 @@ TEST_F(VkLayerTest, IgnoreUnrelatedDescriptor) {
         image_create_info.mipLevels = 1;
         image_create_info.arrayLayers = 1;
         image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
-        image_create_info.tiling = VK_IMAGE_TILING_LINEAR;
+        image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
         image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
         image_create_info.flags = 0;
         VkResult err =

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -224,7 +224,7 @@ VkFormat VkTestFramework::GetFormat(VkInstance instance,
     }
     printf("Error - device does not support VK_FORMAT_B8G8R8A8_UNORM nor "
            "VK_FORMAT_R8G8B8A8_UNORM - exiting\n");
-    exit(0);
+    exit(1);
 }
 
 void VkTestFramework::Finish() {}


### PR DESCRIPTION
Fixes for 2 minor test bugs.

1. On device that doesn't support RGBA8 or BGRA8 exit(1) instead of exit(0)
2. Use optimal tiling for image on IgnoreUnrelatedDescriptor test
