### PR TITLE
layers: Don't use instance pointer after it has been destroyed

### DIFF
--- a/layers/unique_objects.h
+++ b/layers/unique_objects.h
@@ -192,10 +192,10 @@ VkResult explicit_CreateInstance(const VkInstanceCreateInfo *pCreateInfo, const 
 
 void explicit_DestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator) {
     dispatch_key key = get_dispatch_key(instance);
-    get_dispatch_table(unique_objects_instance_table_map, instance)->DestroyInstance(instance, pAllocator);
-    layer_data_map.erase(key);
     VkLayerInstanceDispatchTable *pDisp = get_dispatch_table(unique_objects_instance_table_map, instance);
     instanceExtMap.erase(pDisp);
+    get_dispatch_table(unique_objects_instance_table_map, instance)->DestroyInstance(instance, pAllocator);
+    layer_data_map.erase(key);
 }
 
 // Handle CreateDevice

--- a/layers/unique_objects.h
+++ b/layers/unique_objects.h
@@ -194,7 +194,7 @@ void explicit_DestroyInstance(VkInstance instance, const VkAllocationCallbacks *
     dispatch_key key = get_dispatch_key(instance);
     VkLayerInstanceDispatchTable *pDisp = get_dispatch_table(unique_objects_instance_table_map, instance);
     instanceExtMap.erase(pDisp);
-    get_dispatch_table(unique_objects_instance_table_map, instance)->DestroyInstance(instance, pAllocator);
+    pDisp->DestroyInstance(instance, pAllocator);
     layer_data_map.erase(key);
 }
 


### PR DESCRIPTION
In unique_objects' explicit_DestroyInstance, the recently introduced
second get_dispatch_table was using a destroyed instance as a lookup
key, failing to find an entry (since the driver controls that memory
and probably freed it), and was crashing consistently on PixelC.

Instead, use the instance pointer to cleanup instanceExtMap before
calling down to the ICD's DestroyInstance.

This was causing random crashes on PixelC so we had to take it offline until we could debug it.  This now passes on all platforms in our test farm.