### PR TITLE
Stroyan thread tuning

### DIFF
--- a/layers/threading.cpp
+++ b/layers/threading.cpp
@@ -318,7 +318,7 @@ AllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo *pAllo
     // Record mapping from command buffer to command pool
     if (VK_SUCCESS == result) {
         for (uint32_t index = 0; index < pAllocateInfo->commandBufferCount; index++) {
-            std::lock_guard<std::mutex> lock(global_lock);
+            std::lock_guard<std::mutex> lock(command_pool_lock);
             command_pool_map[pCommandBuffers[index]] = pAllocateInfo->commandPool;
         }
     }
@@ -343,7 +343,7 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(VkDevice device, VkCommandPool com
     finishWriteObject(my_data, commandPool);
     for (uint32_t index = 0; index < commandBufferCount; index++) {
         finishWriteObject(my_data, pCommandBuffers[index], lockCommandPool);
-        std::lock_guard<std::mutex> lock(global_lock);
+        std::lock_guard<std::mutex> lock(command_pool_lock);
         command_pool_map.erase(pCommandBuffers[index]);
     }
 }

--- a/layers/threading.h
+++ b/layers/threading.h
@@ -48,6 +48,28 @@ struct object_use_data {
 
 struct layer_data;
 
+namespace threading {
+volatile bool vulkan_in_use = false;
+volatile bool vulkan_multi_threaded = false;
+// starting check if an application is using vulkan from multiple threads.
+inline bool startMultiThread() {
+    if (vulkan_multi_threaded) {
+        return true;
+    }
+    if (vulkan_in_use) {
+        vulkan_multi_threaded = true;
+        return true;
+    }
+    vulkan_in_use = true;
+    return false;
+}
+
+// finishing check if an application is using vulkan from multiple threads.
+inline void finishMultiThread() {
+    vulkan_in_use = false;
+}
+} // namespace threading
+
 template <typename T> class counter {
   public:
     const char *typeName;


### PR DESCRIPTION
These changes reduce the overhead of the threading layer.
The number of mutexes is increased to reduce contention between threads.
The parameter reference counters are only updated once multiple threads are seen overlapping calls to vulkan.