### PR TITLE
Fix crash when shutting down Smoke test in Windows

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5575,6 +5575,9 @@ DestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocatio
     for (auto cb : pPool->commandBuffers) {
         clear_cmd_buf_and_mem_references(dev_data, cb);
         auto cb_node = getCBNode(dev_data, cb);
+        for (auto obj : cb_node->object_bindings) {
+            removeCommandBufferBinding(dev_data, &obj, cb_node);
+        }
         dev_data->commandBufferMap.erase(cb); // Remove this command buffer
         delete cb_node;                       // delete CB info structure
     }


### PR DESCRIPTION
Commit a86b57c caused a Windows crash when shutting down smoketest.
Command buffer cleanup for object bindings wasn't happening when
calling DestroyCommandPool.