### PR TITLE
layers: Update clearValueCount check

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -9291,9 +9291,9 @@ TEST_F(VkLayerTest, RenderPassClearOpMismatch) {
     rp_begin.clearValueCount = 0; // Should be 1
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                         " has a clearValueCount of 0 but the "
-                                         "actual number of attachments in "
-                                         "renderPass ");
+                                         " has a clearValueCount of 0 but "
+                                         "there must be at least 1 entries in "
+                                         "pClearValues array to account for ");
 
     vkCmdBeginRenderPass(m_commandBuffer->GetBufferHandle(), &rp_begin,
                          VK_SUBPASS_CONTENTS_INLINE);


### PR DESCRIPTION
Fixes #601 

The pClearValues array is indexed by the attachment index which
means that it must be at least as large as the last LOAD_OP_CLEAR
attachment in the renderpass. Updating this check to reflect this
requirement.