### PR TITLE
Add NV_dedicated_allocation support to unique_objects layer

### DIFF
--- a/vk-layer-generate.py
+++ b/vk-layer-generate.py
@@ -1557,6 +1557,7 @@ class UniqueObjectsSubcommand(Subcommand):
                                              'DestroyInstance',
                                              'CreateDevice',
                                              'DestroyDevice',
+                                             'AllocateMemory',
                                              'CreateComputePipelines',
                                              'CreateGraphicsPipelines',
                                              'GetPhysicalDeviceDisplayPropertiesKHR',


### PR DESCRIPTION
Add ID substitution support for the VkDedicatedAllocationMemoryAllocateInfoNV extension structure to the unique_objects layer.  The current implementation is specific to the case where the vkAllocateMemory function's pAllocateInfo parameter references a single VkDedicatedAllocationMemoryAllocateInfoNV struct.