### PR TITLE
layers: Fix bug with renderpass state in cmd buffer

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9609,8 +9609,10 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass(VkCommandBuffer commandBuffer) {
         skip_call |= validatePrimaryCommandBuffer(dev_data, pCB, "vkCmdEndRenderPass");
         skip_call |= addCmd(dev_data, pCB, CMD_ENDRENDERPASS, "vkCmdEndRenderPass()");
         TransitionFinalSubpassLayouts(dev_data, pCB, &pCB->activeRenderPassBeginInfo);
+        // Reset renderPass state for this CB
         pCB->activeRenderPass = nullptr;
         pCB->activeSubpass = 0;
+        pCB->activeSubpassContents = VK_SUBPASS_CONTENTS_INLINE;
         pCB->activeFramebuffer = VK_NULL_HANDLE;
     }
     lock.unlock();


### PR DESCRIPTION
When a CmdEndRenderPass is called, reset the command buffer's activeSubpassContents
to the default value of VK_SUBPASS_CONTENTS_INLINE.
This fixes a but where, if a previously renderpass in a cmd buffer had been in
VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS mode, then a subsequent renderpass
in that same mode will incorrectly hit an error about an invalid call to
vkCmdBeginRenderPass() within a secondary cmd buffer subpass.