### PR TITLE
Report array subscript values in parameter_validation messages

### DIFF
--- a/layers/parameter_name.h
+++ b/layers/parameter_name.h
@@ -1,0 +1,148 @@
+/* Copyright (c) 2016 The Khronos Group Inc.
+ * Copyright (c) 2016 Valve Corporation
+ * Copyright (c) 2016 LunarG, Inc.
+ * Copyright (c) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef PARAMETER_NAME_H
+#define PARAMETER_NAME_H
+
+#include <cassert>
+#include <sstream>
+#include <string>
+#include <vector>
+
+/**
+ * Parameter name string supporting deferred formatting for array subscripts.
+ *
+ * Custom parameter name class with support for deferred formatting of names containing array subscripts.  The class stores
+ * a format string and a vector of index values, and performs string formatting when an accessor function is called to
+ * retrieve the name string.  This class was primarily designed to be used with validation functions that receive a parameter name
+ * string and value as arguments, and print an error message that includes the parameter name when the value fails a validation
+ * test.  Using standard strings with these validation functions requires that parameter names containing array subscripts be
+ * formatted before each validation function is called, performing the string formatting even when the value passes validation
+ * and the string is not used:
+ *         sprintf(name, "pCreateInfo[%d].sType", i);
+ *         validate_stype(name, pCreateInfo[i].sType);
+ *
+ * With the ParameterName class, a format string and a vector of format values are stored by the ParameterName object that is
+ * provided to the validation function.  String formatting is then performed only when the validation function retrieves the
+ * name string from the ParameterName object:
+ *         validate_stype(ParameterName("pCreateInfo[%i].sType", IndexVector{ i }), pCreateInfo[i].sType);
+ */
+class ParameterName {
+  public:
+    /// Container for index values to be used with parameter name string formatting.
+    typedef std::vector<size_t> IndexVector;
+
+    /// Format specifier for the parameter name string, to be replaced by an index value.  The parameter name string must contain
+    /// one format specifier for each index value specified.
+    const std::string IndexFormatSpecifier = "%i";
+
+  public:
+    /**
+     * Construct a ParameterName object from a string literal, without formatting.
+     *
+     * @param source Paramater name string without format specifiers.
+     *
+     * @pre The source string must not contain the %i format specifier.
+     */
+    ParameterName(const char *source) : source_(source) { assert(IsValid()); }
+
+    /**
+    * Construct a ParameterName object from a std::string object, without formatting.
+    *
+    * @param source Paramater name string without format specifiers.
+    *
+    * @pre The source string must not contain the %i format specifier.
+    */
+    ParameterName(const std::string &source) : source_(source) { assert(IsValid()); }
+
+    /**
+    * Construct a ParameterName object from a std::string object, without formatting.
+    *
+    * @param source Paramater name string without format specifiers.
+    *
+    * @pre The source string must not contain the %i format specifier.
+    */
+    ParameterName(const std::string &&source) : source_(std::move(source)) { assert(IsValid()); }
+
+    /**
+    * Construct a ParameterName object from a std::string object, with formatting.
+    *
+    * @param source Paramater name string with format specifiers.
+    * @param args Array index values to be used for formatting.
+    *
+    * @pre The number of %i format specifiers contained by the source string must match the number of elements contained
+    *      by the index vector.
+    */
+    ParameterName(const std::string &source, const IndexVector &args) : source_(source), args_(args) { assert(IsValid()); }
+
+    /**
+    * Construct a ParameterName object from a std::string object, with formatting.
+    *
+    * @param source Paramater name string with format specifiers.
+    * @param args Array index values to be used for formatting.
+    *
+    * @pre The number of %i format specifiers contained by the source string must match the number of elements contained
+    *      by the index vector.
+    */
+    ParameterName(const std::string &&source, const IndexVector &&args) : source_(std::move(source)), args_(std::move(args)) {
+        assert(IsValid());
+    }
+
+    /// Retrive the formatted name string.
+    std::string get_name() const { return (args_.empty()) ? source_ : Format(); }
+
+  private:
+    /// Replace the %i format specifiers in the source string with the values from the index vector.
+    std::string Format() const {
+        std::string::size_type current = 0;
+        std::string::size_type last = 0;
+        std::stringstream format;
+
+        for (size_t index : args_) {
+            current = source_.find(IndexFormatSpecifier, last);
+            if (current == std::string::npos) {
+                break;
+            }
+            format << source_.substr(last, (current - last)) << index;
+            last = current + IndexFormatSpecifier.length();
+        }
+
+        format << source_.substr(last, std::string::npos);
+
+        return format.str();
+    }
+
+    /// Check that the number of %i format specifiers in the source string matches the number of elements in the index vector.
+    bool IsValid() {
+        // Count the number of occurances of the format specifier
+        uint32_t count = 0;
+        std::string::size_type pos = source_.find(IndexFormatSpecifier);
+
+        while (pos != std::string::npos) {
+            ++count;
+            pos = source_.find(IndexFormatSpecifier, pos + 1);
+        }
+
+        return (count == args_.size());
+    }
+
+  private:
+    std::string source_; ///< Format string.
+    IndexVector args_;   ///< Array index values for formatting.
+};
+
+#endif // PARAMETER_NAME_H

--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -47,6 +47,7 @@
 #include "vk_layer_extension_utils.h"
 #include "vk_layer_utils.h"
 
+#include "parameter_name.h"
 #include "parameter_validation.h"
 
 namespace parameter_validation {
@@ -1221,10 +1222,9 @@ static std::string EnumeratorString(VkQueryControlFlagBits const &enumerator) {
 
 static const int MaxParamCheckerStringLength = 256;
 
-static bool validate_string(debug_report_data *report_data, const char *apiName, const char *stringName,
+static bool validate_string(debug_report_data *report_data, const char *apiName, const ParameterName &stringName,
                             const char *validateString) {
     assert(apiName != nullptr);
-    assert(stringName != nullptr);
     assert(validateString != nullptr);
 
     bool skipCall = false;
@@ -1234,13 +1234,13 @@ static bool validate_string(debug_report_data *report_data, const char *apiName,
     if (result == VK_STRING_ERROR_NONE) {
         return skipCall;
     } else if (result & VK_STRING_ERROR_LENGTH) {
-        skipCall =
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__, INVALID_USAGE,
-                    LayerName, "%s: string %s exceeds max length %d", apiName, stringName, MaxParamCheckerStringLength);
+        skipCall = log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
+                           INVALID_USAGE, LayerName, "%s: string %s exceeds max length %d", apiName, stringName.get_name().c_str(),
+                           MaxParamCheckerStringLength);
     } else if (result & VK_STRING_ERROR_BAD_DATA) {
-        skipCall =
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__, INVALID_USAGE,
-                    LayerName, "%s: string %s contains invalid characters or is badly formed", apiName, stringName);
+        skipCall = log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
+                           INVALID_USAGE, LayerName, "%s: string %s contains invalid characters or is badly formed", apiName,
+                           stringName.get_name().c_str());
     }
     return skipCall;
 }
@@ -2749,9 +2749,10 @@ bool PreCreateGraphicsPipelines(VkDevice device, const VkGraphicsPipelineCreateI
             }
         }
 
-        int i = 0;
+        size_t i = 0;
         for (size_t j = 0; j < pCreateInfos[i].stageCount; j++) {
-            validate_string(data->report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pStages[j].pName",
+            validate_string(data->report_data, "vkCreateGraphicsPipelines",
+                            ParameterName("pCreateInfos[%i].pStages[%i].pName", ParameterName::IndexVector{i, j}),
                             pCreateInfos[i].pStages[j].pName);
         }
     }
@@ -2800,13 +2801,15 @@ CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t
                     }
                 }
             } else {
-                skip_call |=
-                    validate_struct_pnext(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pTessellationState->pNext",
-                                          NULL, pCreateInfos[i].pTessellationState->pNext, 0, NULL, GeneratedHeaderVersion);
+                skip_call |= validate_struct_pnext(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pTessellationState->pNext", ParameterName::IndexVector{i}), NULL,
+                    pCreateInfos[i].pTessellationState->pNext, 0, NULL, GeneratedHeaderVersion);
 
-                skip_call |=
-                    validate_reserved_flags(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pTessellationState->flags",
-                                            pCreateInfos[i].pTessellationState->flags);
+                skip_call |= validate_reserved_flags(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pTessellationState->flags", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pTessellationState->flags);
 
                 if (pCreateInfos[i].pTessellationState->sType != VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO) {
                     skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
@@ -2831,11 +2834,13 @@ CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t
                 }
             } else {
                 skip_call |=
-                    validate_struct_pnext(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pViewportState->pNext", NULL,
-                                          pCreateInfos[i].pViewportState->pNext, 0, NULL, GeneratedHeaderVersion);
+                    validate_struct_pnext(report_data, "vkCreateGraphicsPipelines",
+                                          ParameterName("pCreateInfos[%i].pViewportState->pNext", ParameterName::IndexVector{i}),
+                                          NULL, pCreateInfos[i].pViewportState->pNext, 0, NULL, GeneratedHeaderVersion);
 
                 skip_call |=
-                    validate_reserved_flags(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pViewportState->flags",
+                    validate_reserved_flags(report_data, "vkCreateGraphicsPipelines",
+                                            ParameterName("pCreateInfos[%i].pViewportState->flags", ParameterName::IndexVector{i}),
                                             pCreateInfos[i].pViewportState->flags);
 
                 if (pCreateInfos[i].pViewportState->sType != VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO) {
@@ -2918,29 +2923,36 @@ CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t
                 }
             } else {
                 skip_call |=
-                    validate_struct_pnext(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pMultisampleState->pNext",
+                    validate_struct_pnext(report_data, "vkCreateGraphicsPipelines",
+                                          ParameterName("pCreateInfos[%i].pMultisampleState->pNext", ParameterName::IndexVector{i}),
                                           NULL, pCreateInfos[i].pMultisampleState->pNext, 0, NULL, GeneratedHeaderVersion);
 
-                skip_call |=
-                    validate_reserved_flags(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pMultisampleState->flags",
-                                            pCreateInfos[i].pMultisampleState->flags);
+                skip_call |= validate_reserved_flags(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pMultisampleState->flags", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pMultisampleState->flags);
 
-                skip_call |= validate_bool32(report_data, "vkCreateGraphicsPipelines",
-                                             "pCreateInfos[i].pMultisampleState->sampleShadingEnable",
-                                             pCreateInfos[i].pMultisampleState->sampleShadingEnable);
+                skip_call |= validate_bool32(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pMultisampleState->sampleShadingEnable", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pMultisampleState->sampleShadingEnable);
 
                 skip_call |= validate_array(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pMultisampleState->rasterizationSamples",
-                    "pCreateInfos[i].pMultisampleState->pSampleMask", pCreateInfos[i].pMultisampleState->rasterizationSamples,
-                    pCreateInfos[i].pMultisampleState->pSampleMask, true, false);
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pMultisampleState->rasterizationSamples", ParameterName::IndexVector{i}),
+                    ParameterName("pCreateInfos[%i].pMultisampleState->pSampleMask", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pMultisampleState->rasterizationSamples, pCreateInfos[i].pMultisampleState->pSampleMask, true,
+                    false);
 
-                skip_call |= validate_bool32(report_data, "vkCreateGraphicsPipelines",
-                                             "pCreateInfos[i].pMultisampleState->alphaToCoverageEnable",
-                                             pCreateInfos[i].pMultisampleState->alphaToCoverageEnable);
+                skip_call |= validate_bool32(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pMultisampleState->alphaToCoverageEnable", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pMultisampleState->alphaToCoverageEnable);
 
-                skip_call |=
-                    validate_bool32(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pMultisampleState->alphaToOneEnable",
-                                    pCreateInfos[i].pMultisampleState->alphaToOneEnable);
+                skip_call |= validate_bool32(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pMultisampleState->alphaToOneEnable", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pMultisampleState->alphaToOneEnable);
 
                 if (pCreateInfos[i].pMultisampleState->sType != VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO) {
                     skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
@@ -2953,66 +2965,87 @@ CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t
 
             // TODO: Conditional NULL check based on rasterizerDiscardEnable and subpass
             if (pCreateInfos[i].pDepthStencilState != nullptr) {
-                skip_call |=
-                    validate_struct_pnext(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->pNext",
-                                          NULL, pCreateInfos[i].pDepthStencilState->pNext, 0, NULL, GeneratedHeaderVersion);
+                skip_call |= validate_struct_pnext(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->pNext", ParameterName::IndexVector{i}), NULL,
+                    pCreateInfos[i].pDepthStencilState->pNext, 0, NULL, GeneratedHeaderVersion);
 
-                skip_call |=
-                    validate_reserved_flags(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->flags",
-                                            pCreateInfos[i].pDepthStencilState->flags);
+                skip_call |= validate_reserved_flags(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->flags", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pDepthStencilState->flags);
 
-                skip_call |=
-                    validate_bool32(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->depthTestEnable",
-                                    pCreateInfos[i].pDepthStencilState->depthTestEnable);
+                skip_call |= validate_bool32(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->depthTestEnable", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pDepthStencilState->depthTestEnable);
 
-                skip_call |= validate_bool32(report_data, "vkCreateGraphicsPipelines",
-                                             "pCreateInfos[i].pDepthStencilState->depthWriteEnable",
-                                             pCreateInfos[i].pDepthStencilState->depthWriteEnable);
-
-                skip_call |= validate_ranged_enum(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->depthCompareOp", "VkCompareOp",
-                    VK_COMPARE_OP_BEGIN_RANGE, VK_COMPARE_OP_END_RANGE, pCreateInfos[i].pDepthStencilState->depthCompareOp);
-
-                skip_call |= validate_bool32(report_data, "vkCreateGraphicsPipelines",
-                                             "pCreateInfos[i].pDepthStencilState->depthBoundsTestEnable",
-                                             pCreateInfos[i].pDepthStencilState->depthBoundsTestEnable);
-
-                skip_call |= validate_bool32(report_data, "vkCreateGraphicsPipelines",
-                                             "pCreateInfos[i].pDepthStencilState->stencilTestEnable",
-                                             pCreateInfos[i].pDepthStencilState->stencilTestEnable);
+                skip_call |= validate_bool32(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->depthWriteEnable", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pDepthStencilState->depthWriteEnable);
 
                 skip_call |= validate_ranged_enum(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->front.failOp", "VkStencilOp",
-                    VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE, pCreateInfos[i].pDepthStencilState->front.failOp);
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->depthCompareOp", ParameterName::IndexVector{i}),
+                    "VkCompareOp", VK_COMPARE_OP_BEGIN_RANGE, VK_COMPARE_OP_END_RANGE,
+                    pCreateInfos[i].pDepthStencilState->depthCompareOp);
+
+                skip_call |= validate_bool32(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->depthBoundsTestEnable", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pDepthStencilState->depthBoundsTestEnable);
+
+                skip_call |= validate_bool32(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->stencilTestEnable", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pDepthStencilState->stencilTestEnable);
 
                 skip_call |= validate_ranged_enum(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->front.passOp", "VkStencilOp",
-                    VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE, pCreateInfos[i].pDepthStencilState->front.passOp);
-
-                skip_call |= validate_ranged_enum(report_data, "vkCreateGraphicsPipelines",
-                                                  "pCreateInfos[i].pDepthStencilState->front.depthFailOp", "VkStencilOp",
-                                                  VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE,
-                                                  pCreateInfos[i].pDepthStencilState->front.depthFailOp);
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->front.failOp", ParameterName::IndexVector{i}),
+                    "VkStencilOp", VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE,
+                    pCreateInfos[i].pDepthStencilState->front.failOp);
 
                 skip_call |= validate_ranged_enum(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->front.compareOp", "VkCompareOp",
-                    VK_COMPARE_OP_BEGIN_RANGE, VK_COMPARE_OP_END_RANGE, pCreateInfos[i].pDepthStencilState->front.compareOp);
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->front.passOp", ParameterName::IndexVector{i}),
+                    "VkStencilOp", VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE,
+                    pCreateInfos[i].pDepthStencilState->front.passOp);
 
                 skip_call |= validate_ranged_enum(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->back.failOp", "VkStencilOp",
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->front.depthFailOp", ParameterName::IndexVector{i}),
+                    "VkStencilOp", VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE,
+                    pCreateInfos[i].pDepthStencilState->front.depthFailOp);
+
+                skip_call |= validate_ranged_enum(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->front.compareOp", ParameterName::IndexVector{i}),
+                    "VkCompareOp", VK_COMPARE_OP_BEGIN_RANGE, VK_COMPARE_OP_END_RANGE,
+                    pCreateInfos[i].pDepthStencilState->front.compareOp);
+
+                skip_call |= validate_ranged_enum(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->back.failOp", ParameterName::IndexVector{i}), "VkStencilOp",
                     VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE, pCreateInfos[i].pDepthStencilState->back.failOp);
 
                 skip_call |= validate_ranged_enum(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->back.passOp", "VkStencilOp",
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->back.passOp", ParameterName::IndexVector{i}), "VkStencilOp",
                     VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE, pCreateInfos[i].pDepthStencilState->back.passOp);
 
                 skip_call |= validate_ranged_enum(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->back.depthFailOp", "VkStencilOp",
-                    VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE, pCreateInfos[i].pDepthStencilState->back.depthFailOp);
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->back.depthFailOp", ParameterName::IndexVector{i}),
+                    "VkStencilOp", VK_STENCIL_OP_BEGIN_RANGE, VK_STENCIL_OP_END_RANGE,
+                    pCreateInfos[i].pDepthStencilState->back.depthFailOp);
 
                 skip_call |= validate_ranged_enum(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pDepthStencilState->back.compareOp", "VkCompareOp",
-                    VK_COMPARE_OP_BEGIN_RANGE, VK_COMPARE_OP_END_RANGE, pCreateInfos[i].pDepthStencilState->back.compareOp);
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pDepthStencilState->back.compareOp", ParameterName::IndexVector{i}),
+                    "VkCompareOp", VK_COMPARE_OP_BEGIN_RANGE, VK_COMPARE_OP_END_RANGE,
+                    pCreateInfos[i].pDepthStencilState->back.compareOp);
 
                 if (pCreateInfos[i].pDepthStencilState->sType != VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO) {
                     skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
@@ -3026,66 +3059,81 @@ CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t
             // TODO: Conditional NULL check based on rasterizerDiscardEnable and subpass
             if (pCreateInfos[i].pColorBlendState != nullptr) {
                 skip_call |=
-                    validate_struct_pnext(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pColorBlendState->pNext", NULL,
-                                          pCreateInfos[i].pColorBlendState->pNext, 0, NULL, GeneratedHeaderVersion);
+                    validate_struct_pnext(report_data, "vkCreateGraphicsPipelines",
+                                          ParameterName("pCreateInfos[%i].pColorBlendState->pNext", ParameterName::IndexVector{i}),
+                                          NULL, pCreateInfos[i].pColorBlendState->pNext, 0, NULL, GeneratedHeaderVersion);
 
-                skip_call |=
-                    validate_reserved_flags(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pColorBlendState->flags",
-                                            pCreateInfos[i].pColorBlendState->flags);
+                skip_call |= validate_reserved_flags(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pColorBlendState->flags", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pColorBlendState->flags);
 
-                skip_call |=
-                    validate_bool32(report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pColorBlendState->logicOpEnable",
-                                    pCreateInfos[i].pColorBlendState->logicOpEnable);
+                skip_call |= validate_bool32(
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pColorBlendState->logicOpEnable", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pColorBlendState->logicOpEnable);
 
                 skip_call |= validate_array(
-                    report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pColorBlendState->attachmentCount",
-                    "pCreateInfos[i].pColorBlendState->pAttachments", pCreateInfos[i].pColorBlendState->attachmentCount,
-                    pCreateInfos[i].pColorBlendState->pAttachments, false, true);
+                    report_data, "vkCreateGraphicsPipelines",
+                    ParameterName("pCreateInfos[%i].pColorBlendState->attachmentCount", ParameterName::IndexVector{i}),
+                    ParameterName("pCreateInfos[%i].pColorBlendState->pAttachments", ParameterName::IndexVector{i}),
+                    pCreateInfos[i].pColorBlendState->attachmentCount, pCreateInfos[i].pColorBlendState->pAttachments, false, true);
 
                 if (pCreateInfos[i].pColorBlendState->pAttachments != NULL) {
                     for (uint32_t attachmentIndex = 0; attachmentIndex < pCreateInfos[i].pColorBlendState->attachmentCount;
                          ++attachmentIndex) {
-                        skip_call |= validate_bool32(report_data, "vkCreateGraphicsPipelines",
-                                                     "pCreateInfos[i].pColorBlendState->pAttachments[i].blendEnable",
-                                                     pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].blendEnable);
+                        skip_call |=
+                            validate_bool32(report_data, "vkCreateGraphicsPipelines",
+                                            ParameterName("pCreateInfos[%i].pColorBlendState->pAttachments[%i].blendEnable",
+                                                          ParameterName::IndexVector{i, attachmentIndex}),
+                                            pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].blendEnable);
 
                         skip_call |= validate_ranged_enum(
                             report_data, "vkCreateGraphicsPipelines",
-                            "pCreateInfos[i].pColorBlendState->pAttachments[i].srcColorBlendFactor", "VkBlendFactor",
-                            VK_BLEND_FACTOR_BEGIN_RANGE, VK_BLEND_FACTOR_END_RANGE,
+                            ParameterName("pCreateInfos[%i].pColorBlendState->pAttachments[%i].srcColorBlendFactor",
+                                          ParameterName::IndexVector{i, attachmentIndex}),
+                            "VkBlendFactor", VK_BLEND_FACTOR_BEGIN_RANGE, VK_BLEND_FACTOR_END_RANGE,
                             pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].srcColorBlendFactor);
 
                         skip_call |= validate_ranged_enum(
                             report_data, "vkCreateGraphicsPipelines",
-                            "pCreateInfos[i].pColorBlendState->pAttachments[i].dstColorBlendFactor", "VkBlendFactor",
-                            VK_BLEND_FACTOR_BEGIN_RANGE, VK_BLEND_FACTOR_END_RANGE,
+                            ParameterName("pCreateInfos[%i].pColorBlendState->pAttachments[%i].dstColorBlendFactor",
+                                          ParameterName::IndexVector{i, attachmentIndex}),
+                            "VkBlendFactor", VK_BLEND_FACTOR_BEGIN_RANGE, VK_BLEND_FACTOR_END_RANGE,
                             pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].dstColorBlendFactor);
 
-                        skip_call |= validate_ranged_enum(
-                            report_data, "vkCreateGraphicsPipelines",
-                            "pCreateInfos[i].pColorBlendState->pAttachments[i].colorBlendOp", "VkBlendOp", VK_BLEND_OP_BEGIN_RANGE,
-                            VK_BLEND_OP_END_RANGE, pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].colorBlendOp);
+                        skip_call |=
+                            validate_ranged_enum(report_data, "vkCreateGraphicsPipelines",
+                                                 ParameterName("pCreateInfos[%i].pColorBlendState->pAttachments[%i].colorBlendOp",
+                                                               ParameterName::IndexVector{i, attachmentIndex}),
+                                                 "VkBlendOp", VK_BLEND_OP_BEGIN_RANGE, VK_BLEND_OP_END_RANGE,
+                                                 pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].colorBlendOp);
 
                         skip_call |= validate_ranged_enum(
                             report_data, "vkCreateGraphicsPipelines",
-                            "pCreateInfos[i].pColorBlendState->pAttachments[i].srcAlphaBlendFactor", "VkBlendFactor",
-                            VK_BLEND_FACTOR_BEGIN_RANGE, VK_BLEND_FACTOR_END_RANGE,
+                            ParameterName("pCreateInfos[%i].pColorBlendState->pAttachments[%i].srcAlphaBlendFactor",
+                                          ParameterName::IndexVector{i, attachmentIndex}),
+                            "VkBlendFactor", VK_BLEND_FACTOR_BEGIN_RANGE, VK_BLEND_FACTOR_END_RANGE,
                             pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].srcAlphaBlendFactor);
 
                         skip_call |= validate_ranged_enum(
                             report_data, "vkCreateGraphicsPipelines",
-                            "pCreateInfos[i].pColorBlendState->pAttachments[i].dstAlphaBlendFactor", "VkBlendFactor",
-                            VK_BLEND_FACTOR_BEGIN_RANGE, VK_BLEND_FACTOR_END_RANGE,
+                            ParameterName("pCreateInfos[%i].pColorBlendState->pAttachments[%i].dstAlphaBlendFactor",
+                                          ParameterName::IndexVector{i, attachmentIndex}),
+                            "VkBlendFactor", VK_BLEND_FACTOR_BEGIN_RANGE, VK_BLEND_FACTOR_END_RANGE,
                             pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].dstAlphaBlendFactor);
 
-                        skip_call |= validate_ranged_enum(
-                            report_data, "vkCreateGraphicsPipelines",
-                            "pCreateInfos[i].pColorBlendState->pAttachments[i].alphaBlendOp", "VkBlendOp", VK_BLEND_OP_BEGIN_RANGE,
-                            VK_BLEND_OP_END_RANGE, pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].alphaBlendOp);
+                        skip_call |=
+                            validate_ranged_enum(report_data, "vkCreateGraphicsPipelines",
+                                                 ParameterName("pCreateInfos[%i].pColorBlendState->pAttachments[%i].alphaBlendOp",
+                                                               ParameterName::IndexVector{i, attachmentIndex}),
+                                                 "VkBlendOp", VK_BLEND_OP_BEGIN_RANGE, VK_BLEND_OP_END_RANGE,
+                                                 pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].alphaBlendOp);
 
                         skip_call |=
                             validate_flags(report_data, "vkCreateGraphicsPipelines",
-                                           "pCreateInfos[i].pColorBlendState->pAttachments[i].colorWriteMask",
+                                           ParameterName("pCreateInfos[%i].pColorBlendState->pAttachments[%i].colorWriteMask",
+                                                         ParameterName::IndexVector{i, attachmentIndex}),
                                            "VkColorComponentFlagBits", AllVkColorComponentFlagBits,
                                            pCreateInfos[i].pColorBlendState->pAttachments[attachmentIndex].colorWriteMask, false);
                     }
@@ -3102,7 +3150,8 @@ CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t
                 // If logicOpEnable is VK_TRUE, logicOp must be a valid VkLogicOp value
                 if (pCreateInfos[i].pColorBlendState->logicOpEnable == VK_TRUE) {
                     skip_call |= validate_ranged_enum(
-                        report_data, "vkCreateGraphicsPipelines", "pCreateInfos[i].pColorBlendState->logicOp", "VkLogicOp",
+                        report_data, "vkCreateGraphicsPipelines",
+                        ParameterName("pCreateInfos[%i].pColorBlendState->logicOp", ParameterName::IndexVector{i}), "VkLogicOp",
                         VK_LOGIC_OP_BEGIN_RANGE, VK_LOGIC_OP_END_RANGE, pCreateInfos[i].pColorBlendState->logicOp);
                 }
             }
@@ -3126,8 +3175,9 @@ bool PreCreateComputePipelines(VkDevice device, const VkComputePipelineCreateInf
 
     if (pCreateInfos != nullptr) {
         // TODO: Handle count!
-        int i = 0;
-        validate_string(data->report_data, "vkCreateComputePipelines", "pCreateInfos[i].stage.pName", pCreateInfos[i].stage.pName);
+        uint32_t i = 0;
+        validate_string(data->report_data, "vkCreateComputePipelines",
+                        ParameterName("pCreateInfos[%i].stage.pName", ParameterName::IndexVector{i}), pCreateInfos[i].stage.pName);
     }
 
     return true;
@@ -3467,11 +3517,13 @@ UpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount, const VkWri
                     for (uint32_t descriptor_index = 0; descriptor_index < pDescriptorWrites[i].descriptorCount;
                          ++descriptor_index) {
                         skip_call |= validate_required_handle(report_data, "vkUpdateDescriptorSets",
-                                                              "pDescriptorWrites[i].pImageInfo[i].imageView",
+                                                              ParameterName("pDescriptorWrites[%i].pImageInfo[%i].imageView",
+                                                                            ParameterName::IndexVector{i, descriptor_index}),
                                                               pDescriptorWrites[i].pImageInfo[descriptor_index].imageView);
                         skip_call |= validate_ranged_enum(report_data, "vkUpdateDescriptorSets",
-                                                          "pDescriptorWrites[i].pImageInfo[i].imageLayout", "VkImageLayout",
-                                                          VK_IMAGE_LAYOUT_BEGIN_RANGE, VK_IMAGE_LAYOUT_END_RANGE,
+                                                          ParameterName("pDescriptorWrites[%i].pImageInfo[%i].imageLayout",
+                                                                        ParameterName::IndexVector{i, descriptor_index}),
+                                                          "VkImageLayout", VK_IMAGE_LAYOUT_BEGIN_RANGE, VK_IMAGE_LAYOUT_END_RANGE,
                                                           pDescriptorWrites[i].pImageInfo[descriptor_index].imageLayout);
                     }
                 }
@@ -3493,7 +3545,8 @@ UpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount, const VkWri
                 } else {
                     for (uint32_t descriptorIndex = 0; descriptorIndex < pDescriptorWrites[i].descriptorCount; ++descriptorIndex) {
                         skip_call |= validate_required_handle(report_data, "vkUpdateDescriptorSets",
-                                                              "pDescriptorWrites[i].pBufferInfo[i].buffer",
+                                                              ParameterName("pDescriptorWrites[%i].pBufferInfo[%i].buffer",
+                                                                            ParameterName::IndexVector{i, descriptorIndex}),
                                                               pDescriptorWrites[i].pBufferInfo[descriptorIndex].buffer);
                     }
                 }
@@ -3512,7 +3565,8 @@ UpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount, const VkWri
                     for (uint32_t descriptor_index = 0; descriptor_index < pDescriptorWrites[i].descriptorCount;
                          ++descriptor_index) {
                         skip_call |= validate_required_handle(report_data, "vkUpdateDescriptorSets",
-                                                              "pDescriptorWrites[i].pTexelBufferView[i]",
+                                                              ParameterName("pDescriptorWrites[%i].pTexelBufferView[%i]",
+                                                                            ParameterName::IndexVector{i, descriptor_index}),
                                                               pDescriptorWrites[i].pTexelBufferView[descriptor_index]);
                     }
                 }

--- a/layers/parameter_validation_utils.h
+++ b/layers/parameter_validation_utils.h
@@ -29,6 +29,8 @@
 #include "vk_enum_string_helper.h"
 #include "vk_layer_logging.h"
 
+#include "parameter_name.h"
+
 namespace parameter_validation {
 
 enum ErrorCode {
@@ -101,14 +103,13 @@ template <> bool is_extension_added_token(VkSamplerAddressMode value) {
 * @return Boolean value indicating that the call should be skipped.
 */
 template <typename T>
-bool ValidateGreaterThan(debug_report_data *report_data, const char *api_name, const char *parameter_name, T value,
-    T lower_bound) {
+bool ValidateGreaterThan(debug_report_data *report_data, const char *api_name, const ParameterName &parameter_name, T value,
+                         T lower_bound) {
     bool skip_call = false;
 
     if (value <= lower_bound) {
-        skip_call |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__, 1,
-            LayerName, "%s: parameter %s must be greater than %d", api_name, parameter_name, lower_bound);
+        skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__, 1, LayerName,
+                             "%s: parameter %s must be greater than %d", api_name, parameter_name.get_name().c_str(), lower_bound);
     }
 
     return skip_call;
@@ -125,13 +126,14 @@ bool ValidateGreaterThan(debug_report_data *report_data, const char *api_name, c
  * @param value Pointer to validate.
  * @return Boolean value indicating that the call should be skipped.
  */
-static bool validate_required_pointer(debug_report_data *report_data, const char *apiName, const char *parameterName,
+static bool validate_required_pointer(debug_report_data *report_data, const char *apiName, const ParameterName &parameterName,
                                       const void *value) {
     bool skipCall = false;
 
     if (value == NULL) {
         skipCall |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                            REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName, parameterName);
+                            REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName,
+                            parameterName.get_name().c_str());
     }
 
     return skipCall;
@@ -155,20 +157,22 @@ static bool validate_required_pointer(debug_report_data *report_data, const char
  * @return Boolean value indicating that the call should be skipped.
  */
 template <typename T>
-bool validate_array(debug_report_data *report_data, const char *apiName, const char *countName, const char *arrayName, T count,
-                    const void *array, bool countRequired, bool arrayRequired) {
+bool validate_array(debug_report_data *report_data, const char *apiName, const ParameterName &countName,
+                    const ParameterName &arrayName, T count, const void *array, bool countRequired, bool arrayRequired) {
     bool skipCall = false;
 
     // Count parameters not tagged as optional cannot be 0
     if ((count == 0) && countRequired) {
         skipCall |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                            REQUIRED_PARAMETER, LayerName, "%s: parameter %s must be greater than 0", apiName, countName);
+                            REQUIRED_PARAMETER, LayerName, "%s: parameter %s must be greater than 0", apiName,
+                            countName.get_name().c_str());
     }
 
     // Array parameters not tagged as optional cannot be NULL, unless the count is 0
     if ((array == NULL) && arrayRequired && (count != 0)) {
         skipCall |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                            REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName, arrayName);
+                            REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName,
+                            arrayName.get_name().c_str());
     }
 
     return skipCall;
@@ -195,14 +199,16 @@ bool validate_array(debug_report_data *report_data, const char *apiName, const c
 * @return Boolean value indicating that the call should be skipped.
 */
 template <typename T>
-bool validate_array(debug_report_data *report_data, const char *apiName, const char *countName, const char *arrayName,
-    const T *count, const void *array, bool countPtrRequired, bool countValueRequired, bool arrayRequired) {
+bool validate_array(debug_report_data *report_data, const char *apiName, const ParameterName &countName,
+                    const ParameterName &arrayName, const T *count, const void *array, bool countPtrRequired,
+                    bool countValueRequired, bool arrayRequired) {
     bool skipCall = false;
 
     if (count == NULL) {
         if (countPtrRequired) {
             skipCall |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName, countName);
+                                REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName,
+                                countName.get_name().c_str());
         }
     }
     else {
@@ -229,20 +235,20 @@ bool validate_array(debug_report_data *report_data, const char *apiName, const c
  * @return Boolean value indicating that the call should be skipped.
  */
 template <typename T>
-bool validate_struct_type(debug_report_data *report_data, const char *apiName, const char *parameterName, const char *sTypeName,
-                          const T *value, VkStructureType sType, bool required) {
+bool validate_struct_type(debug_report_data *report_data, const char *apiName, const ParameterName &parameterName,
+                          const char *sTypeName, const T *value, VkStructureType sType, bool required) {
     bool skipCall = false;
 
     if (value == NULL) {
         if (required) {
-            skipCall |=
-                log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                        REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName, parameterName);
+            skipCall |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
+                                REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName,
+                                parameterName.get_name().c_str());
         }
     } else if (value->sType != sType) {
-        skipCall |=
-            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                    INVALID_STRUCT_STYPE, LayerName, "%s: parameter %s->sType must be %s", apiName, parameterName, sTypeName);
+        skipCall |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
+                            INVALID_STRUCT_STYPE, LayerName, "%s: parameter %s->sType must be %s", apiName,
+                            parameterName.get_name().c_str(), sTypeName);
     }
 
     return skipCall;
@@ -270,15 +276,16 @@ bool validate_struct_type(debug_report_data *report_data, const char *apiName, c
  * @return Boolean value indicating that the call should be skipped.
  */
 template <typename T>
-bool validate_struct_type_array(debug_report_data *report_data, const char *apiName, const char *countName, const char *arrayName,
-                                const char *sTypeName, const uint32_t *count, const T *array, VkStructureType sType,
-                                bool countPtrRequired, bool countValueRequired, bool arrayRequired) {
+bool validate_struct_type_array(debug_report_data *report_data, const char *apiName, const ParameterName &countName,
+                                const ParameterName &arrayName, const char *sTypeName, const uint32_t *count, const T *array,
+                                VkStructureType sType, bool countPtrRequired, bool countValueRequired, bool arrayRequired) {
     bool skipCall = false;
 
     if (count == NULL) {
         if (countPtrRequired) {
             skipCall |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                                REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName, countName);
+                                REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as NULL", apiName,
+                                countName.get_name().c_str());
         }
     } else {
         skipCall |= validate_struct_type_array(report_data, apiName, countName, arrayName, sTypeName, (*count), array, sType,
@@ -308,9 +315,9 @@ bool validate_struct_type_array(debug_report_data *report_data, const char *apiN
  * @return Boolean value indicating that the call should be skipped.
  */
 template <typename T>
-bool validate_struct_type_array(debug_report_data *report_data, const char *apiName, const char *countName, const char *arrayName,
-                                const char *sTypeName, uint32_t count, const T *array, VkStructureType sType, bool countRequired,
-                                bool arrayRequired) {
+bool validate_struct_type_array(debug_report_data *report_data, const char *apiName, const ParameterName &countName,
+                                const ParameterName &arrayName, const char *sTypeName, uint32_t count, const T *array,
+                                VkStructureType sType, bool countRequired, bool arrayRequired) {
     bool skipCall = false;
 
     if ((count == 0) || (array == NULL)) {
@@ -321,7 +328,7 @@ bool validate_struct_type_array(debug_report_data *report_data, const char *apiN
             if (array[i].sType != sType) {
                 skipCall |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                                     __LINE__, INVALID_STRUCT_STYPE, LayerName, "%s: parameter %s[%d].sType must be %s", apiName,
-                                    arrayName, i, sTypeName);
+                                    arrayName.get_name().c_str(), i, sTypeName);
             }
         }
     }
@@ -341,13 +348,13 @@ bool validate_struct_type_array(debug_report_data *report_data, const char *apiN
 * @return Boolean value indicating that the call should be skipped.
 */
 template <typename T>
-bool validate_required_handle(debug_report_data *report_data, const char *api_name, const char *parameter_name, T value) {
+bool validate_required_handle(debug_report_data *report_data, const char *api_name, const ParameterName &parameter_name, T value) {
     bool skip_call = false;
 
     if (value == VK_NULL_HANDLE) {
         skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
                              REQUIRED_PARAMETER, LayerName, "%s: required parameter %s specified as VK_NULL_HANDLE", api_name,
-                             parameter_name);
+                             parameter_name.get_name().c_str());
     }
 
     return skip_call;
@@ -376,8 +383,9 @@ bool validate_required_handle(debug_report_data *report_data, const char *api_na
 * @return Boolean value indicating that the call should be skipped.
 */
 template <typename T>
-bool validate_handle_array(debug_report_data *report_data, const char *api_name, const char *count_name, const char *array_name,
-                           uint32_t count, const T *array, bool count_required, bool array_required) {
+bool validate_handle_array(debug_report_data *report_data, const char *api_name, const ParameterName &count_name,
+                           const ParameterName &array_name, uint32_t count, const T *array, bool count_required,
+                           bool array_required) {
     bool skip_call = false;
 
     if ((count == 0) || (array == NULL)) {
@@ -386,9 +394,10 @@ bool validate_handle_array(debug_report_data *report_data, const char *api_name,
         // Verify that no handles in the array are VK_NULL_HANDLE
         for (uint32_t i = 0; i < count; ++i) {
             if (array[i] == VK_NULL_HANDLE) {
-                skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                     __LINE__, REQUIRED_PARAMETER, LayerName,
-                                     "%s: required parameter %s[%d] specified as VK_NULL_HANDLE", api_name, array_name, i);
+                skip_call |=
+                    log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
+                            REQUIRED_PARAMETER, LayerName, "%s: required parameter %s[%d] specified as VK_NULL_HANDLE", api_name,
+                            array_name.get_name().c_str(), i);
             }
         }
     }
@@ -414,8 +423,9 @@ bool validate_handle_array(debug_report_data *report_data, const char *api_name,
  * @param arrayRequired The 'array' parameter may not be NULL when true.
  * @return Boolean value indicating that the call should be skipped.
  */
-static bool validate_string_array(debug_report_data *report_data, const char *apiName, const char *countName, const char *arrayName,
-                                  uint32_t count, const char *const *array, bool countRequired, bool arrayRequired) {
+static bool validate_string_array(debug_report_data *report_data, const char *apiName, const ParameterName &countName,
+                                  const ParameterName &arrayName, uint32_t count, const char *const *array, bool countRequired,
+                                  bool arrayRequired) {
     bool skipCall = false;
 
     if ((count == 0) || (array == NULL)) {
@@ -426,7 +436,7 @@ static bool validate_string_array(debug_report_data *report_data, const char *ap
             if (array[i] == NULL) {
                 skipCall |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                                     __LINE__, REQUIRED_PARAMETER, LayerName, "%s: required parameter %s[%d] specified as NULL",
-                                    apiName, arrayName, i);
+                                    apiName, arrayName.get_name().c_str(), i);
             }
         }
     }
@@ -451,7 +461,7 @@ static bool validate_string_array(debug_report_data *report_data, const char *ap
  * @param header_version Version of header defining the pNext validation rules.
  * @return Boolean value indicating that the call should be skipped.
  */
-static bool validate_struct_pnext(debug_report_data *report_data, const char *api_name, const char *parameter_name,
+static bool validate_struct_pnext(debug_report_data *report_data, const char *api_name, const ParameterName &parameter_name,
                                   const char *allowed_struct_names, const void *next, size_t allowed_type_count,
                                   const VkStructureType *allowed_types, uint32_t header_version) {
     bool skip_call = false;
@@ -464,9 +474,9 @@ static bool validate_struct_pnext(debug_report_data *report_data, const char *ap
         if (allowed_type_count == 0) {
             std::string message = "%s: value of %s must be NULL.  ";
             message += disclaimer;
-            skip_call |=
-                log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                        INVALID_STRUCT_PNEXT, LayerName, message.c_str(), api_name, parameter_name, header_version, parameter_name);
+            skip_call |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
+                                 INVALID_STRUCT_PNEXT, LayerName, message.c_str(), api_name, parameter_name.get_name().c_str(),
+                                 header_version, parameter_name.get_name().c_str());
         } else {
             const VkStructureType *start = allowed_types;
             const VkStructureType *end = allowed_types + allowed_type_count;
@@ -482,15 +492,16 @@ static bool validate_struct_pnext(debug_report_data *report_data, const char *ap
                         message += disclaimer;
                         skip_call |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
                                              0, __LINE__, INVALID_STRUCT_PNEXT, LayerName, message.c_str(), api_name,
-                                             parameter_name, current->sType, allowed_struct_names, header_version, parameter_name);
+                                             parameter_name.get_name().c_str(), current->sType, allowed_struct_names,
+                                             header_version, parameter_name.get_name().c_str());
                     } else {
                         std::string message =
                             "%s: %s chain includes a structure with unexpected VkStructureType %s; Allowed structures are [%s].  ";
                         message += disclaimer;
-                        skip_call |=
-                            log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
-                                    __LINE__, INVALID_STRUCT_PNEXT, LayerName, message.c_str(), api_name, parameter_name,
-                                    type_name.c_str(), allowed_struct_names, header_version, parameter_name);
+                        skip_call |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
+                                             0, __LINE__, INVALID_STRUCT_PNEXT, LayerName, message.c_str(), api_name,
+                                             parameter_name.get_name().c_str(), type_name.c_str(), allowed_struct_names,
+                                             header_version, parameter_name.get_name().c_str());
                     }
                 }
 
@@ -513,13 +524,14 @@ static bool validate_struct_pnext(debug_report_data *report_data, const char *ap
 * @param value Boolean value to validate.
 * @return Boolean value indicating that the call should be skipped.
 */
-static bool validate_bool32(debug_report_data *report_data, const char *apiName, const char *parameterName, VkBool32 value) {
+static bool validate_bool32(debug_report_data *report_data, const char *apiName, const ParameterName &parameterName,
+                            VkBool32 value) {
     bool skipCall = false;
 
     if ((value != VK_TRUE) && (value != VK_FALSE)) {
         skipCall |= log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
                             UNRECOGNIZED_VALUE, LayerName, "%s: value of %s (%d) is neither VK_TRUE nor VK_FALSE", apiName,
-                            parameterName, value);
+                            parameterName.get_name().c_str(), value);
     }
 
     return skipCall;
@@ -545,8 +557,8 @@ static bool validate_bool32(debug_report_data *report_data, const char *apiName,
 * @return Boolean value indicating that the call should be skipped.
 */
 template <typename T>
-bool validate_ranged_enum(debug_report_data *report_data, const char *apiName, const char *parameterName, const char *enumName,
-                          T begin, T end, T value) {
+bool validate_ranged_enum(debug_report_data *report_data, const char *apiName, const ParameterName &parameterName,
+                          const char *enumName, T begin, T end, T value) {
     bool skipCall = false;
 
     if (((value < begin) || (value > end)) && !is_extension_added_token(value)) {
@@ -554,7 +566,7 @@ bool validate_ranged_enum(debug_report_data *report_data, const char *apiName, c
             log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
                     UNRECOGNIZED_VALUE, LayerName, "%s: value of %s (%d) does not fall within the begin..end range of the core %s "
                                                    "enumeration tokens and is not an extension added token",
-                    apiName, parameterName, value, enumName);
+                    apiName, parameterName.get_name().c_str(), value, enumName);
     }
 
     return skipCall;
@@ -584,9 +596,9 @@ bool validate_ranged_enum(debug_report_data *report_data, const char *apiName, c
 * @return Boolean value indicating that the call should be skipped.
 */
 template <typename T>
-static bool validate_ranged_enum_array(debug_report_data *report_data, const char *apiName, const char *countName,
-                                       const char *arrayName, const char *enumName, T begin, T end, uint32_t count, const T *array,
-                                       bool countRequired, bool arrayRequired) {
+static bool validate_ranged_enum_array(debug_report_data *report_data, const char *apiName, const ParameterName &countName,
+                                       const ParameterName &arrayName, const char *enumName, T begin, T end, uint32_t count,
+                                       const T *array, bool countRequired, bool arrayRequired) {
     bool skipCall = false;
 
     if ((count == 0) || (array == NULL)) {
@@ -598,7 +610,7 @@ static bool validate_ranged_enum_array(debug_report_data *report_data, const cha
                                     __LINE__, UNRECOGNIZED_VALUE, LayerName,
                                     "%s: value of %s[%d] (%d) does not fall within the begin..end range of the core %s "
                                     "enumeration tokens and is not an extension added token",
-                                    apiName, arrayName, i, array[i], enumName);
+                                    apiName, arrayName.get_name().c_str(), i, array[i], enumName);
             }
         }
     }
@@ -618,13 +630,14 @@ static bool validate_ranged_enum_array(debug_report_data *report_data, const cha
 * @param value Value to validate.
 * @return Boolean value indicating that the call should be skipped.
 */
-static bool validate_reserved_flags(debug_report_data *report_data, const char *api_name, const char *parameter_name,
+static bool validate_reserved_flags(debug_report_data *report_data, const char *api_name, const ParameterName &parameter_name,
                                     VkFlags value) {
     bool skip_call = false;
 
     if (value != 0) {
-        skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                             RESERVED_PARAMETER, LayerName, "%s: parameter %s must be 0", api_name, parameter_name);
+        skip_call |=
+            log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
+                    RESERVED_PARAMETER, LayerName, "%s: parameter %s must be 0", api_name, parameter_name.get_name().c_str());
     }
 
     return skip_call;
@@ -645,20 +658,21 @@ static bool validate_reserved_flags(debug_report_data *report_data, const char *
 * @param flags_required The 'value' parameter may not be 0 when true.
 * @return Boolean value indicating that the call should be skipped.
 */
-static bool validate_flags(debug_report_data *report_data, const char *api_name, const char *parameter_name,
+static bool validate_flags(debug_report_data *report_data, const char *api_name, const ParameterName &parameter_name,
                            const char *flag_bits_name, VkFlags all_flags, VkFlags value, bool flags_required) {
     bool skip_call = false;
 
     if (value == 0) {
         if (flags_required) {
             skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                                 REQUIRED_PARAMETER, LayerName, "%s: value of %s must not be 0", api_name, parameter_name);
+                                 REQUIRED_PARAMETER, LayerName, "%s: value of %s must not be 0", api_name,
+                                 parameter_name.get_name().c_str());
         }
     } else if ((value & (~all_flags)) != 0) {
         skip_call |=
             log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
                     UNRECOGNIZED_VALUE, LayerName, "%s: value of %s contains flag bits that are not recognized members of %s",
-                    api_name, parameter_name, flag_bits_name);
+                    api_name, parameter_name.get_name().c_str(), flag_bits_name);
     }
 
     return skip_call;
@@ -682,8 +696,8 @@ static bool validate_flags(debug_report_data *report_data, const char *api_name,
 * @param array_required The 'array' parameter may not be NULL when true.
 * @return Boolean value indicating that the call should be skipped.
 */
-static bool validate_flags_array(debug_report_data *report_data, const char *api_name, const char *count_name,
-                                 const char *array_name, const char *flag_bits_name, VkFlags all_flags, uint32_t count,
+static bool validate_flags_array(debug_report_data *report_data, const char *api_name, const ParameterName &count_name,
+                                 const ParameterName &array_name, const char *flag_bits_name, VkFlags all_flags, uint32_t count,
                                  const VkFlags *array, bool count_required, bool array_required) {
     bool skip_call = false;
 
@@ -696,15 +710,15 @@ static bool validate_flags_array(debug_report_data *report_data, const char *api
                 // Current XML registry logic for validity generation uses the array parameter's optional tag to determine if
                 // elements in the array are allowed be 0
                 if (array_required) {
-                    skip_call |=
-                        log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
-                                REQUIRED_PARAMETER, LayerName, "%s: value of %s[%d] must not be 0", api_name, array_name, i);
+                    skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                                         __LINE__, REQUIRED_PARAMETER, LayerName, "%s: value of %s[%d] must not be 0", api_name,
+                                         array_name.get_name().c_str(), i);
                 }
             } else if ((array[i] & (~all_flags)) != 0) {
                 skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
                                      __LINE__, UNRECOGNIZED_VALUE, LayerName,
                                      "%s: value of %s[%d] contains flag bits that are not recognized members of %s", api_name,
-                                     array_name, i, flag_bits_name);
+                                     array_name.get_name().c_str(), i, flag_bits_name);
             }
         }
     }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -903,7 +903,7 @@ TEST_F(VkLayerTest, RequiredParameter) {
 
     m_errorMonitor->SetDesiredFailureMsg(
         VK_DEBUG_REPORT_ERROR_BIT_EXT,
-        "value of pSubmits[i].pWaitDstStageMask[0] must not be 0");
+        "value of pSubmits[0].pWaitDstStageMask[0] must not be 0");
     // Specify 0 for a required VkFlags array entry
     // Expected to trigger an error with
     // parameter_validation::validate_flags_array
@@ -9662,7 +9662,7 @@ TEST_F(VkLayerTest, BufferMemoryBarrierNoBuffer) {
     // Try to add a buffer memory barrier with no buffer.
     m_errorMonitor->SetDesiredFailureMsg(
         VK_DEBUG_REPORT_ERROR_BIT_EXT,
-        "required parameter pBufferMemoryBarriers[i].buffer specified as VK_NULL_HANDLE");
+        "required parameter pBufferMemoryBarriers[0].buffer specified as VK_NULL_HANDLE");
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     BeginCommandBuffer();


### PR DESCRIPTION
Fix the error messages produced by the parameter_validation layer to report the actual array subscript value in array parameter names instead of the letter i.  

Addresses issue #462.