### PR TITLE
Tobin gh821 multiple img mem mapping

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4885,7 +4885,11 @@ FreeMemory(VkDevice device, VkDeviceMemory mem, const VkAllocationCallbacks *pAl
     }
 }
 
-static bool validateMemRange(layer_data *my_data, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size) {
+// Validate that given Map memory range is valid. This means that the memory should not already be mapped,
+//  and that the size of the map range should be:
+//  1. Not zero
+//  2. Within the size of the memory allocation
+static bool ValidateMapMemRange(layer_data *my_data, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size) {
     bool skip_call = false;
 
     if (size == 0) {
@@ -10080,7 +10084,7 @@ MapMemory(VkDevice device, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize
                         "Mapping Memory without VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT set: mem obj 0x%" PRIxLEAST64, (uint64_t)mem);
         }
     }
-    skip_call |= validateMemRange(dev_data, mem, offset, size);
+    skip_call |= ValidateMapMemRange(dev_data, mem, offset, size);
 #endif
     skip_call |= ValidateMapImageLayouts(device, mem);
     lock.unlock();

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -220,17 +220,17 @@ struct DEVICE_MEM_INFO {
     bool stencil_valid; // TODO: Stores if the stencil memory has valid data or not. The validity of this memory may ultimately need
                         // to be tracked separately from the depth/stencil/buffer memory
     VkDeviceMemory mem;
-    VkMemoryAllocateInfo allocInfo;
-    std::unordered_set<MT_OBJ_HANDLE_TYPE> objBindings;        // objects bound to this memory
-    std::unordered_set<VkCommandBuffer> commandBufferBindings; // cmd buffers referencing this memory
-    std::vector<MEMORY_RANGE> bufferRanges;
-    std::vector<MEMORY_RANGE> imageRanges;
+    VkMemoryAllocateInfo alloc_info;
+    std::unordered_set<MT_OBJ_HANDLE_TYPE> obj_bindings;         // objects bound to this memory
+    std::unordered_set<VkCommandBuffer> command_buffer_bindings; // cmd buffers referencing this memory
+    std::vector<MEMORY_RANGE> buffer_ranges;
+    std::vector<MEMORY_RANGE> image_ranges;
 
-    MemRange memRange;
-    void *pData, *pDriverData;
+    MemRange mem_range;
+    void *p_data, *p_driver_data;
     DEVICE_MEM_INFO(void *disp_object, const VkDeviceMemory in_mem, const VkMemoryAllocateInfo *p_alloc_info)
-        : object(disp_object), valid(false), stencil_valid(false), mem(in_mem), allocInfo(*p_alloc_info), memRange{}, pData(0),
-          pDriverData(0){};
+        : object(disp_object), valid(false), stencil_valid(false), mem(in_mem), alloc_info(*p_alloc_info), mem_range{}, p_data(0),
+          p_driver_data(0){};
 };
 
 class SWAPCHAIN_NODE {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -225,12 +225,12 @@ struct DEVICE_MEM_INFO {
     std::unordered_set<VkCommandBuffer> commandBufferBindings; // cmd buffers referencing this memory
     std::vector<MEMORY_RANGE> bufferRanges;
     std::vector<MEMORY_RANGE> imageRanges;
-    VkImage image; // If memory is bound to image, this will have VkImage handle, else VK_NULL_HANDLE
+
     MemRange memRange;
     void *pData, *pDriverData;
     DEVICE_MEM_INFO(void *disp_object, const VkDeviceMemory in_mem, const VkMemoryAllocateInfo *p_alloc_info)
-        : object(disp_object), valid(false), stencil_valid(false), mem(in_mem), allocInfo(*p_alloc_info),
-          image(VK_NULL_HANDLE), memRange{}, pData(0), pDriverData(0){};
+        : object(disp_object), valid(false), stencil_valid(false), mem(in_mem), allocInfo(*p_alloc_info), memRange{}, pData(0),
+          pDriverData(0){};
 };
 
 class SWAPCHAIN_NODE {


### PR DESCRIPTION
Fixes #821 
The first and last CLs are the important ones. Just some clean-up in-between.
Kill single "image" member from DEVICE_MEM_INFO struct as all bound images are now correctly tracked in object_bindings set.
Update the validation check at MapMemory time to verify that ANY images that overlap the mapped memory are in the correct image layout.