### PR TITLE
toolchain: Fix SPIRV-Headers update script

### DIFF
--- a/update_external_sources.sh
+++ b/update_external_sources.sh
@@ -60,6 +60,7 @@ function update_spirv-tools () {
    else
       cd $BASEDIR/spirv-tools/external/spirv-headers
       git fetch --all
+      git checkout master
       git pull
    fi
 }


### PR DESCRIPTION
Without specifying a branch, git pull fails.

You may also want to specify a revision.  The android script introduced one in 662666d0. 
