### PR TITLE
Tobin gh605 mem valid per range

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5353,6 +5353,7 @@ static bool InsertMemoryRange(layer_data const *dev_data, uint64_t handle, DEVIC
     range.image = is_image;
     range.handle = handle;
     range.linear = is_linear;
+    range.valid = mem_info->global_valid;
     range.memory = mem_info->mem;
     range.start = memoryOffset;
     range.size = memRequirements.size;
@@ -10230,6 +10231,8 @@ MapMemory(VkDevice device, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize
     std::unique_lock<std::mutex> lock(global_lock);
     DEVICE_MEM_INFO *mem_info = getMemObjInfo(dev_data, mem);
     if (mem_info) {
+        // TODO : This could me more fine-grained to track just region that is valid
+        mem_info->global_valid = true;
         auto end_address = (VK_WHOLE_SIZE == size) ? mem_info->alloc_info.allocationSize - 1 : offset + size - 1;
         skip_call |= ValidateMapImageLayouts(device, mem_info, offset, end_address);
         // TODO : Do we need to create new "bound_range" for the mapped range?

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -208,9 +208,14 @@ struct MemRange {
 
 struct MEMORY_RANGE {
     uint64_t handle;
+    bool image; // True for image, false for buffer
+    bool linear; // True for buffers and linear images
     VkDeviceMemory memory;
     VkDeviceSize start;
-    VkDeviceSize end;
+    VkDeviceSize size;
+    VkDeviceSize end; // Store this pre-computed for simplicity
+    // Set of ptrs to every range aliased with this one
+    std::unordered_set<MEMORY_RANGE *> aliases;
 };
 
 // Data struct for tracking memory object
@@ -223,8 +228,10 @@ struct DEVICE_MEM_INFO {
     VkMemoryAllocateInfo alloc_info;
     std::unordered_set<MT_OBJ_HANDLE_TYPE> obj_bindings;         // objects bound to this memory
     std::unordered_set<VkCommandBuffer> command_buffer_bindings; // cmd buffers referencing this memory
-    std::vector<MEMORY_RANGE> buffer_ranges;
-    std::vector<MEMORY_RANGE> image_ranges;
+    std::unordered_map<uint64_t, MEMORY_RANGE> bound_ranges;     // Map of object to its binding range
+    // Convenience vectors image/buff handles to speed up iterating over images or buffers independently
+    std::unordered_set<uint64_t> bound_images;
+    std::unordered_set<uint64_t> bound_buffers;
 
     MemRange mem_range;
     void *p_data, *p_driver_data;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -222,10 +222,7 @@ struct MEMORY_RANGE {
 // Data struct for tracking memory object
 struct DEVICE_MEM_INFO {
     void *object; // Dispatchable object used to create this memory (device of swapchain)
-    // bool valid; // Stores if the color/depth/buffer memory has valid data or not
-    // TODO : What to do with this guy in migrating valid to range?
-    bool stencil_valid; // TODO: Stores if the stencil memory has valid data or not. The validity of this memory may ultimately need
-                        // to be tracked separately from the depth/stencil/buffer memory
+    bool global_valid; // If allocation is mapped, set to "true" to be picked up by subsequently bound ranges
     VkDeviceMemory mem;
     VkMemoryAllocateInfo alloc_info;
     std::unordered_set<MT_OBJ_HANDLE_TYPE> obj_bindings;         // objects bound to this memory
@@ -238,7 +235,7 @@ struct DEVICE_MEM_INFO {
     MemRange mem_range;
     void *p_data, *p_driver_data;
     DEVICE_MEM_INFO(void *disp_object, const VkDeviceMemory in_mem, const VkMemoryAllocateInfo *p_alloc_info)
-        : object(disp_object), stencil_valid(false), mem(in_mem), alloc_info(*p_alloc_info), mem_range{}, p_data(0),
+        : object(disp_object), global_valid(false), mem(in_mem), alloc_info(*p_alloc_info), mem_range{}, p_data(0),
           p_driver_data(0){};
 };
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -210,6 +210,7 @@ struct MEMORY_RANGE {
     uint64_t handle;
     bool image; // True for image, false for buffer
     bool linear; // True for buffers and linear images
+    bool valid;  // True if this range is know to be valid
     VkDeviceMemory memory;
     VkDeviceSize start;
     VkDeviceSize size;
@@ -221,7 +222,8 @@ struct MEMORY_RANGE {
 // Data struct for tracking memory object
 struct DEVICE_MEM_INFO {
     void *object; // Dispatchable object used to create this memory (device of swapchain)
-    bool valid; // Stores if the color/depth/buffer memory has valid data or not
+    // bool valid; // Stores if the color/depth/buffer memory has valid data or not
+    // TODO : What to do with this guy in migrating valid to range?
     bool stencil_valid; // TODO: Stores if the stencil memory has valid data or not. The validity of this memory may ultimately need
                         // to be tracked separately from the depth/stencil/buffer memory
     VkDeviceMemory mem;
@@ -236,7 +238,7 @@ struct DEVICE_MEM_INFO {
     MemRange mem_range;
     void *p_data, *p_driver_data;
     DEVICE_MEM_INFO(void *disp_object, const VkDeviceMemory in_mem, const VkMemoryAllocateInfo *p_alloc_info)
-        : object(disp_object), valid(false), stencil_valid(false), mem(in_mem), alloc_info(*p_alloc_info), mem_range{}, p_data(0),
+        : object(disp_object), stencil_valid(false), mem(in_mem), alloc_info(*p_alloc_info), mem_range{}, p_data(0),
           p_driver_data(0){};
 };
 


### PR DESCRIPTION
This moves memory allocation valid tracking to be per-range instead of per allocation. Also improves alias tracking but lots more work to do in that department. It does fix a couple of errors in how invalid alias cases were being flagged.
This should fix #605 with current changes, but still need to fix the failing test.
Noted various holes with TODOs.