### PR TITLE
LX581, Warn if CmdBlitImage Extents are NULL

### DIFF
--- a/layers/image.cpp
+++ b/layers/image.cpp
@@ -1033,6 +1033,28 @@ CmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcI
     bool skipCall = false;
     layer_data *device_data = get_my_data_ptr(get_dispatch_key(commandBuffer), layer_data_map);
 
+    // Warn for zero-sized regions
+    for (uint32_t i = 0; i < regionCount; i++) {
+        if ((pRegions[i].srcOffsets[0].x == pRegions[i].srcOffsets[1].x) ||
+            (pRegions[i].srcOffsets[0].y == pRegions[i].srcOffsets[1].y) ||
+            (pRegions[i].srcOffsets[0].z == pRegions[i].srcOffsets[1].z)) {
+            std::stringstream ss;
+            ss << "vkCmdBlitImage: pRegions[" << i << "].srcOffsets specify a zero-volume area.";
+            skipCall |= log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT,
+                VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, reinterpret_cast<uint64_t>(commandBuffer),
+                __LINE__, IMAGE_INVALID_EXTENTS, "IMAGE", "%s", ss.str().c_str());
+        }
+        if ((pRegions[i].dstOffsets[0].x == pRegions[i].dstOffsets[1].x) ||
+            (pRegions[i].dstOffsets[0].y == pRegions[i].dstOffsets[1].y) ||
+            (pRegions[i].dstOffsets[0].z == pRegions[i].dstOffsets[1].z)) {
+            std::stringstream ss;
+            ss << "vkCmdBlitImage: pRegions[" << i << "].dstOffsets specify a zero-volume area.";
+            skipCall |= log_msg(device_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT,
+                VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, reinterpret_cast<uint64_t>(commandBuffer),
+                __LINE__, IMAGE_INVALID_EXTENTS, "IMAGE", "%s", ss.str().c_str());
+        }
+    }
+
     auto srcImageEntry = getImageState(device_data, srcImage);
     auto dstImageEntry = getImageState(device_data, dstImage);
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -15537,6 +15537,14 @@ TEST_F(VkLayerTest, MiscImageLayerTests) {
                    16, &blitRegion, VK_FILTER_LINEAR);
     m_errorMonitor->VerifyFound();
 
+    // Look for NULL-blit warning
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_WARNING_BIT_EXT,
+                                         "Offsets specify a zero-volume area.");
+    vkCmdBlitImage(m_commandBuffer->GetBufferHandle(), intImage1.handle(),
+                   intImage1.layout(), intImage2.handle(), intImage2.layout(),
+                   1, &blitRegion, VK_FILTER_LINEAR);
+    m_errorMonitor->VerifyFound();
+
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                          "called with 0 in ppMemoryBarriers");
     VkImageMemoryBarrier img_barrier;


### PR DESCRIPTION
Extents work differently for this API than others, Id says it bit them and they see it in other places in the wild (apparently, setting the z_extent to zero on Nvidia works while AMD respects the coordinates).