### PR TITLE
Swapchain layer: Change query count errors to warnings

### DIFF
--- a/layers/swapchain.cpp
+++ b/layers/swapchain.cpp
@@ -1419,7 +1419,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevi
             // Since we haven't recorded a preliminary value of *pSurfaceFormatCount, that likely means that the application didn't
             // previously call this function with a NULL value of pSurfaceFormats:
             skip_call |= log_msg(
-                my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
+                my_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
                 reinterpret_cast<uint64_t>(pPhysicalDevice->physicalDevice), __LINE__, SWAPCHAIN_PRIOR_COUNT, swapchain_layer_name,
                 "vkGetPhysicalDeviceSurfaceFormatsKHR() called with non-NULL pSurfaceFormatCount; but no prior positive "
                 "value has been seen for pSurfaceFormats.");
@@ -1497,7 +1497,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModesKHR(VkPhysica
             // Since we haven't recorded a preliminary value of *pPresentModeCount, that likely means that the application didn't
             // previously call this function with a NULL value of pPresentModes:
             skip_call |= log_msg(
-                my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
+                my_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,
                 reinterpret_cast<uint64_t>(pPhysicalDevice->physicalDevice), __LINE__, SWAPCHAIN_PRIOR_COUNT, swapchain_layer_name,
                 "vkGetPhysicalDeviceSurfacePresentModesKHR() called with non-NULL pPresentModeCount; but no prior positive "
                 "value has been seen for pPresentModes.");
@@ -1995,7 +1995,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(VkDevice device, VkSwapchai
         if (pSwapchain->imageCount == 0) {
             // Since we haven't recorded a preliminary value of *pSwapchainImageCount, that likely means that the application didn't
             // previously call this function with a NULL value of pSwapchainImages:
-            skip_call |= log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT,
+            skip_call |= log_msg(my_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT,
                                  reinterpret_cast<uint64_t>(device), __LINE__, SWAPCHAIN_PRIOR_COUNT, swapchain_layer_name,
                                  "vkGetSwapchainImagesKHR() called with non-NULL pSwapchainImageCount; but no prior positive "
                                  "value has been seen for pSwapchainImages.");

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2650,7 +2650,7 @@ TEST_F(VkWsiEnabledLayerTest, TestEnabledWsi) {
     // Next, call with a non-NULL pSurfaceFormats, even though we haven't
     // correctly done a 1st try (to get the count):
     m_errorMonitor->SetDesiredFailureMsg(
-        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        VK_DEBUG_REPORT_WARNING_BIT_EXT,
         "but no prior positive value has been seen for");
     surface_format_count = 0;
     vkGetPhysicalDeviceSurfaceFormatsKHR(
@@ -2706,7 +2706,7 @@ TEST_F(VkWsiEnabledLayerTest, TestEnabledWsi) {
     // Next, call with a non-NULL VkPresentModeKHR, even though we haven't
     // correctly done a 1st try (to get the count):
     m_errorMonitor->SetDesiredFailureMsg(
-        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        VK_DEBUG_REPORT_WARNING_BIT_EXT,
         "but no prior positive value has been seen for");
     surface_present_mode_count = 0;
     vkGetPhysicalDeviceSurfacePresentModesKHR(


### PR DESCRIPTION
Changed errors for requesting variable-sized structures without first querying for a size into warnings -- this is a result of the conclusion reached in VulkanTools Issue 59.