### PR TITLE
 Validate Image/Buffer Copy Parameters

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -7512,6 +7512,108 @@ static bool VerifyDestImageLayout(layer_data *dev_data, GLOBAL_CB_NODE *cb_node,
     return skip_call;
 }
 
+static inline bool ValidImageTransferGranularity(layer_data *dev_data, const GLOBAL_CB_NODE *cb_node, const VkExtent3D *extent,
+                                                    VkExtent3D *granularity) {
+    bool valid = true;
+    auto pPool = getCommandPoolNode(dev_data, cb_node->createInfo.commandPool);
+    if (pPool) {
+        granularity = &dev_data->phys_dev_properties.queue_family_properties[pPool->queueFamilyIndex].minImageTransferGranularity;
+        if ((vk_safe_modulo(extent->depth, granularity->depth) != 0) || (vk_safe_modulo(extent->width, granularity->width) != 0) ||
+            (vk_safe_modulo(extent->height, granularity->height) != 0)) {
+            valid = false;
+        }
+    }
+    return valid;
+}
+
+static inline bool CheckItgOffset(layer_data *dev_data, const GLOBAL_CB_NODE *cb_node, const VkOffset3D *offset, const uint32_t i,
+                                  const char *function, const char *member) {
+    bool skip = false;
+    VkExtent3D granularity = {};
+    VkExtent3D extent = {};
+    extent.width = static_cast<uint32_t>(abs(offset->x));
+    extent.height = static_cast<uint32_t>(abs(offset->y));
+    extent.depth = static_cast<uint32_t>(abs(offset->z));
+    if (ValidImageTransferGranularity(dev_data, cb_node, &extent, &granularity) == false) {
+        skip |= log_msg(
+            dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
+            DRAWSTATE_IMAGE_TRANSFER_GRANULARITY, "DS", "%s: pRegion[%d].%s (x=%d, y=%d, z=%d) must respect this command buffer's "
+                                                        "queue family image transfer granularity (w=%d, h=%d, d=%d).",
+            function, i, member, offset->x, offset->y, offset->z, granularity.width, granularity.height, granularity.depth);
+    }
+    return skip;
+}
+
+static inline bool CheckItgExtent(layer_data *dev_data, const GLOBAL_CB_NODE *cb_node, const VkExtent3D *extent, const uint32_t i,
+                                  const char *function, const char *member) {
+    bool skip = false;
+    VkExtent3D granularity = {};
+    if (ValidImageTransferGranularity(dev_data, cb_node, extent, &granularity) == false) {
+        skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
+                        DRAWSTATE_IMAGE_TRANSFER_GRANULARITY, "DS",
+                        "%s: pRegion[%d].%s (w=%d, h=%d, d=%d) must respect this command buffer's "
+                        "queue family image transfer granularity (w=%d, h=%d, z=%d).",
+                        function, i, member, extent->width, extent->height, extent->depth, granularity.width, granularity.height,
+                        granularity.depth);
+    }
+    return skip;
+}
+
+static inline bool CheckItgInt(layer_data *dev_data, const GLOBAL_CB_NODE *cb_node, const uint32_t value, const uint32_t i,
+                               const char *function, const char *member) {
+    bool skip = false;
+    VkExtent3D granularity = {};
+    VkExtent3D extent = {};
+    extent.width = value;
+    if (ValidImageTransferGranularity(dev_data, cb_node, &extent, &granularity) == false) {
+        skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
+                        DRAWSTATE_IMAGE_TRANSFER_GRANULARITY, "DS",
+                        "%s: pRegion[%d].%s (%d) must respect this command buffer's queue family image transfer granularity %d).",
+                        function, i, member, extent.width, granularity.width);
+    }
+    return skip;
+}
+
+static inline bool CheckItgSize(layer_data *dev_data, const GLOBAL_CB_NODE *cb_node, const VkDeviceSize value, const uint32_t i,
+                                const char *function, const char *member) {
+    bool skip = false;
+    VkExtent3D *granularity;
+    auto pPool = getCommandPoolNode(dev_data, cb_node->createInfo.commandPool);
+    if (pPool) {
+        granularity = &dev_data->phys_dev_properties.queue_family_properties[pPool->queueFamilyIndex].minImageTransferGranularity;
+        if (vk_safe_modulo(value, granularity->width) != 0) {
+            skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
+                            DRAWSTATE_IMAGE_TRANSFER_GRANULARITY, "DS",
+                            "%s: pRegion[%d].%s (%" PRIdLEAST64
+                            ") must respect this command buffer's queue family image transfer granularity %d).",
+                            function, i, member, value, granularity->width);
+        }
+    }
+    return skip;
+}
+
+static inline bool ValidateCopyImageTransferGranularityRequirements(layer_data *dev_data, const GLOBAL_CB_NODE *cb_node,
+                                                                    const VkImageCopy *region, const uint32_t i,
+                                                                    const char *function) {
+    bool skip = false;
+    skip |= CheckItgOffset(dev_data, cb_node, &region->srcOffset, i, function, "srcOffset");
+    skip |= CheckItgOffset(dev_data, cb_node, &region->dstOffset, i, function, "dstOffset");
+    skip |= CheckItgExtent(dev_data, cb_node, &region->extent, i, function, "extent");
+    return skip;
+}
+
+static inline bool ValidateCopyBufferImageTransferGranularityRequirements(layer_data *dev_data, const GLOBAL_CB_NODE *cb_node,
+                                                                          const VkBufferImageCopy *region, const uint32_t i,
+                                                                          const char *function) {
+    bool skip = false;
+    skip |= CheckItgSize(dev_data, cb_node, region->bufferOffset, i, function, "bufferOffset");
+    skip |= CheckItgInt(dev_data, cb_node, region->bufferRowLength, i, function, "bufferRowLength");
+    skip |= CheckItgInt(dev_data, cb_node, region->bufferImageHeight, i, function, "bufferImageHeight");
+    skip |= CheckItgOffset(dev_data, cb_node, &region->imageOffset, i, function, "imageOffset");
+    skip |= CheckItgExtent(dev_data, cb_node, &region->imageExtent, i, function, "imageExtent");
+    return skip;
+}
+
 VKAPI_ATTR void VKAPI_CALL
 CmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
              VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageCopy *pRegions) {
@@ -7546,6 +7648,7 @@ CmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcI
         for (uint32_t i = 0; i < regionCount; ++i) {
             skip_call |= VerifySourceImageLayout(dev_data, cb_node, srcImage, pRegions[i].srcSubresource, srcImageLayout);
             skip_call |= VerifyDestImageLayout(dev_data, cb_node, dstImage, pRegions[i].dstSubresource, dstImageLayout);
+            skip_call |= ValidateCopyImageTransferGranularityRequirements(dev_data, cb_node, &pRegions[i], i, "vkCmdCopyImage()");
         }
     } else {
         assert(0);
@@ -7627,6 +7730,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage(VkCommandBuffer commandBuffer, V
         skip_call |= insideRenderPass(dev_data, cb_node, "vkCmdCopyBufferToImage()");
         for (uint32_t i = 0; i < regionCount; ++i) {
             skip_call |= VerifyDestImageLayout(dev_data, cb_node, dstImage, pRegions[i].imageSubresource, dstImageLayout);
+            skip_call |=
+                ValidateCopyBufferImageTransferGranularityRequirements(dev_data, cb_node, &pRegions[i], i, "vkCmdCopyBufferToImage()");
         }
     } else {
         assert(0);
@@ -7672,6 +7777,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer(VkCommandBuffer commandBuffer, V
         skip_call |= insideRenderPass(dev_data, cb_node, "vkCmdCopyImageToBuffer()");
         for (uint32_t i = 0; i < regionCount; ++i) {
             skip_call |= VerifySourceImageLayout(dev_data, cb_node, srcImage, pRegions[i].imageSubresource, srcImageLayout);
+            skip_call |=
+                ValidateCopyBufferImageTransferGranularityRequirements(dev_data, cb_node, &pRegions[i], i, "CmdCopyImageToBuffer");
         }
     } else {
         assert(0);

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -221,6 +221,8 @@ enum DRAW_STATE_ERROR {
                                              // of queried queue families
     DRAWSTATE_INVALID_QUEUE_FAMILY,          // Command buffer submitted on queue is from
                                              // a different queue family
+    DRAWSTATE_IMAGE_TRANSFER_GRANULARITY,    // Violation of queue family's image transfer
+                                             // granularity
     DRAWSTATE_PUSH_CONSTANTS_ERROR,          // Push constants exceed maxPushConstantSize
 };
 

--- a/layers/vk_validation_layer_details.md
+++ b/layers/vk_validation_layer_details.md
@@ -106,6 +106,7 @@ The Draw State portion of the core validation layer tracks state leading into Dr
 | Push Constants | Validate that the size of push constant ranges and updates does not exceed maxPushConstantSize | PUSH_CONSTANTS_ERROR | vkCreatePipelineLayout vkCmdPushConstants | InvalidPushConstants | NA |
 | Attachment Image Usage | Validate that Image attachment location does not conflict with the image's USAGE flags | INVALID_IMAGE_USAGE | vkCreateFramebuffer | FramebufferCreateErrors | NA |
 | Attachment Image Index | Validate that Image attachment references are appropriate and not out-of-bounds | INVALID_ATTACHMENT_INDEX | vkCreateRenderPass vkCreateFramebuffer | UnusedPreserveAttachment | NA |
+| Image Transfer Granularity | Validate that Image Transfer Granularity property settings are respected for image transfers | IMAGE_TRANSFER_GRANULARITY | vkCmdCopyImage vkCmdCopyImageToBuffer vkCmdCopyBufferToImage | DSImageTransferGranularityTests | NA |
 | NA | Enum used for informational messages | NONE | | TODO | None |
 | NA | Enum used for errors in the layer itself. This does not indicate an app issue, but instead a bug in the layer. | INTERNAL_ERROR | | TODO | None |
 | NA | Enum used when VK_LAYER_LUNARG_core_validation attempts to allocate memory for its own internal use and is unable to. | OUT_OF_MEMORY | | TODO | None |

--- a/layers/vk_validation_layer_details.md
+++ b/layers/vk_validation_layer_details.md
@@ -237,7 +237,7 @@ DETAILS TABLE PENDING
 | Verify Correct Image Settings | Verifies that values are valid for a given resource or subresource | INVALID_IMAGE_RESOURCE | vkCmdPipelineBarrier | MiscImageLayerTests | NA |
 | Verify Image Format Limits | Verifies that image creation parameters are with the device format limits | INVALID_FORMAT_LIMITS_VIOLATION | vkCreateImage | ImageFormatLimits | NA |
 | Verify Layout | Verifies the layouts are valid for this image operation | INVALID_LAYOUT | vkCreateImage vkCmdClearColorImage | TODO | ImageFormatLimits |
-| Verify Image Extents | Validates that image extent limits are not invalid | INVALID_EXTENTS | vkCmdCopyImage | CopyImageLayerCountMismatch | NA |
+| Verify Image Extents | Validates that image extent limits are not invalid | INVALID_EXTENTS | vkCmdCopyImage vkCmdCopyBufferToImage vkCmdCopyImageToBuffer | MiscImageLayerTests CopyImageLayerCountMismatch | NA |
 | Verify Usage | Verifies the image was created with usage valid for this image operation | INVALID_USAGE | vkCmdClearColorImage | TODO | ClearImageErrors |
 | NA | Enum used for informational messages | NONE | | TODO | None |
 

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -16110,6 +16110,55 @@ TEST_F(VkLayerTest, MiscImageLayerTests) {
     m_errorMonitor->VerifyFound();
     region.imageSubresource.layerCount = 1;
 
+    // BufferOffset must be a multiple of the calling command's VkImage parameter's texel size
+    // Introduce failure by setting bufferOffset to 1 and 1/2 texels
+    region.bufferOffset = 6;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "must be a multiple of this format's texel size");
+    vkCmdCopyBufferToImage(m_commandBuffer->GetBufferHandle(), buffer.handle(),
+                           image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                           1, &region);
+    m_errorMonitor->VerifyFound();
+
+    // BufferOffset must be a multiple of 4
+    // Introduce failure by setting bufferOffset to a value not divisible by 4
+    region.bufferOffset = 6;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "must be a multiple of 4");
+    vkCmdCopyBufferToImage(m_commandBuffer->GetBufferHandle(), buffer.handle(),
+                           image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                           1, &region);
+    m_errorMonitor->VerifyFound();
+
+    // BufferRowLength must be 0, or greater than or equal to the width member of imageExtent
+    region.bufferOffset = 0;
+    region.imageExtent.height = 128;
+    region.imageExtent.width = 128;
+    // Introduce failure by setting bufferRowLength > 0 but less than width
+    region.bufferRowLength = 64;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "must be zero or greater-than-or-equal-to imageExtent.width");
+    vkCmdCopyBufferToImage(m_commandBuffer->GetBufferHandle(), buffer.handle(),
+                           image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                           1, &region);
+    m_errorMonitor->VerifyFound();
+
+    // BufferImageHeight must be 0, or greater than or equal to the height member of imageExtent
+    region.bufferRowLength = 128;
+    // Introduce failure by setting bufferRowHeight > 0 but less than height
+    region.bufferImageHeight = 64;
+    m_errorMonitor->SetDesiredFailureMsg(
+        VK_DEBUG_REPORT_ERROR_BIT_EXT,
+        "must be zero or greater-than-or-equal-to imageExtent.height");
+    vkCmdCopyBufferToImage(m_commandBuffer->GetBufferHandle(), buffer.handle(),
+                           image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                           1, &region);
+    m_errorMonitor->VerifyFound();
+
+    region.bufferImageHeight = 128;
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                          "aspectMasks for each region must "
                                          "specify only COLOR or DEPTH or "


### PR DESCRIPTION
Github issue #763.  Added validation to image layer for buffer-image copy parameters, along with tests and doc updates.  Further added image transfer granularity checks for image copies to core_validation along with tests and doc updates.