### PR TITLE
Fix Dota2 crash in Windows

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4601,7 +4601,9 @@ static void DecrementBoundResources(layer_data const *dev_data, GLOBAL_CB_NODE c
         }
         case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT: {
             auto sampler_node = getSamplerNode(dev_data, reinterpret_cast<VkSampler &>(obj.handle));
-            sampler_node->in_use.fetch_sub(1);
+            if (sampler_node) {
+                sampler_node->in_use.fetch_sub(1);
+            }
             break;
         }
         default:

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -164,7 +164,9 @@ struct SAMPLER_NODE : public BASE_NODE {
     VkSampler sampler;
     VkSamplerCreateInfo createInfo;
 
-    SAMPLER_NODE(const VkSampler *ps, const VkSamplerCreateInfo *pci) : sampler(*ps), createInfo(*pci){};
+    SAMPLER_NODE(const VkSampler *ps, const VkSamplerCreateInfo *pci) : sampler(*ps), createInfo(*pci){
+        in_use.store(0);
+    };
 };
 
 class IMAGE_NODE : public BASE_NODE {


### PR DESCRIPTION
Two issues, in_use was not initialized in SAMPLER_NODE and an invalid access during resource tracking for same. This occurs during GetFenceStatus after a call to DestroySampler.

