### PR TITLE
WIP - loader: gh851 wrap debug report callbacks

### DIFF
--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -418,8 +418,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(
          * if enabled.
          */
         loader_activate_instance_layer_extensions(ptr_instance, *pInstance);
-    } else {
-        // TODO: cleanup here.
     }
 
 out:


### PR DESCRIPTION
Allow layers to wrap the debug report callbacks so they can
enable more messaging than the application, but also filter
the items returned.

Change-Id: I3fe8feecfa1838869de8a7338ff610e5ebca2e61