### PR TITLE
header: gh907 fix vulkan.hpp detection of 64-bit arch

### DIFF
--- a/include/vulkan/vulkan.hpp
+++ b/include/vulkan/vulkan.hpp
@@ -44,7 +44,7 @@ static_assert( VK_HEADER_VERSION ==  25 , "Wrong VK_HEADER_VERSION!" );
 
 // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
 // To enable this feature on 32-bit platforms please define VULKAN_HPP_TYPESAFE_CONVERSION
-#if !defined(VK_DEFINE_NON_DISPATCHABLE_HANDLE)
+#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
 #define VULKAN_HPP_TYPESAFE_CONVERSION 1
 #endif
 


### PR DESCRIPTION
The generator that produced vulkan.hpp for 1.0.25 seemed to ignore the 64-bit architecture test, thereby breaking 64-bit builds.
The macro VK_DEFINE_NON_DISPATCHABLE_HANDLE is always defined according to vulkan.h.