### PR TITLE
Fix VK_NV_external_memory_capabilities support

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1651,6 +1651,7 @@ static bool loader_icd_init_entrys(struct loader_icd *icd, VkInstance inst,
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
     LOOKUP_GIPA(GetPhysicalDeviceWaylandPresentationSupportKHR, false);
 #endif
+    LOOKUP_GIPA(GetPhysicalDeviceExternalImageFormatPropertiesNV, false);
 
 #undef LOOKUP_GIPA
 


### PR DESCRIPTION
-Need to init the instance function pointer

-The function should gracefully fall back on
 drivers that don't support it.