### PR TITLE
use "exit /b", not "exit"

### DIFF
--- a/build_windows_targets.bat
+++ b/build_windows_targets.bat
@@ -34,7 +34,7 @@ if %do_cmake%==0 (
     if %do_32%==0 (
         if %do_64%==0 (
             echo No valid parameters specified.
-            exit 1
+            exit /b 1
         )
     )
 )
@@ -76,7 +76,7 @@ if %do_64%==1 (
        echo.
        echo 64-bit Debug build failed!
        popd
-       exit 1
+       exit /b 1
     )   
    
     echo Building 64-bit Release 
@@ -85,7 +85,7 @@ if %do_64%==1 (
        echo.
        echo 64-bit Release build failed!
        popd
-       exit 1
+       exit /b 1
     )   
     popd
 )
@@ -106,7 +106,7 @@ if %do_32%==1 (
        echo.
        echo 32-bit Debug build failed!
        popd
-       exit 1
+       exit /b 1
     )   
        
     echo Building 32-bit Release 
@@ -115,8 +115,8 @@ if %do_32%==1 (
        echo.
        echo 32-bit Release build failed!
        popd
-       exit 1
+       exit /b 1
     )   
     popd
 )
-exit 0
+exit /b 0


### PR DESCRIPTION
"exit" terminates the cmd shell that invoked this script.

"exit /b" terminates only this bat script.