### PR TITLE
Tobin gh915 invalid cb fb image bindings

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -453,7 +453,7 @@ static const char *object_type_to_string(VkDebugReportObjectTypeEXT type) {
     case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT:
         return "descriptor set";
     case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT:
-        return "buffer";
+        return "framebuffer";
     case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT:
         return "event";
     case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT:


### PR DESCRIPTION
Fixes #915 and includes some other minor clean-up as well as a test

Main fix is to bind images that are in framebuffer attachments to command buffers along with the framebuffer itself. Test hits this case and verifies that command buffer goes invalid.

Added early exit case for invalid command buffer at QueueSubmit time as null objects can then crash on subsequent queued function calls for memory set/validate if objects were destroyed and ptrs are null.
