### PR TITLE
layers: Require VkGraphicsPipelineCreateInfo::pDepthStencilState

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3425,6 +3425,20 @@ static bool verifyPipelineCreateState(layer_data *my_data, const VkDevice device
                 }
             }
         }
+
+        // If rasterization is not disabled, and subpass uses a depth/stencil
+        // attachment, pDepthStencilState must be a pointer to a valid structure
+        auto subpass_desc = renderPass ? &renderPass->pCreateInfo->pSubpasses[pPipeline->graphicsPipelineCI.subpass] : nullptr;
+        if (subpass_desc && subpass_desc->pDepthStencilAttachment &&
+            subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
+            if (!pPipeline->graphicsPipelineCI.pDepthStencilState) {
+                skip_call |= log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                                     __LINE__, DRAWSTATE_INVALID_PIPELINE_CREATE_STATE, "DS",
+                                     "Invalid Pipeline CreateInfo State: "
+                                     "pDepthStencilState is NULL when rasterization is enabled and subpass uses a "
+                                     "depth/stencil attachment");
+            }
+        }
     }
     return skip_call;
 }

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1171,24 +1171,7 @@ VkPipelineObj::VkPipelineObj(VkDeviceObj *device) {
     m_vp_state.pViewports = NULL;
     m_vp_state.pScissors = NULL;
 
-    m_ds_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-    m_ds_state.pNext = VK_NULL_HANDLE, m_ds_state.depthTestEnable = VK_FALSE;
-    m_ds_state.flags = 0;
-    m_ds_state.depthWriteEnable = VK_FALSE;
-    m_ds_state.depthBoundsTestEnable = VK_FALSE;
-    m_ds_state.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
-    m_ds_state.back.depthFailOp = VK_STENCIL_OP_KEEP;
-    m_ds_state.back.failOp = VK_STENCIL_OP_KEEP;
-    m_ds_state.back.passOp = VK_STENCIL_OP_KEEP;
-    m_ds_state.back.compareOp = VK_COMPARE_OP_ALWAYS;
-    m_ds_state.stencilTestEnable = VK_FALSE;
-    m_ds_state.back.compareMask = 0xff;
-    m_ds_state.back.writeMask = 0xff;
-    m_ds_state.back.reference = 0;
-    m_ds_state.minDepthBounds = 0.f;
-    m_ds_state.maxDepthBounds = 1.f;
-
-    m_ds_state.front = m_ds_state.back;
+    m_ds_state = nullptr;
 };
 
 void VkPipelineObj::AddShader(VkShaderObj *shader) { m_shaderObjs.push_back(shader); }
@@ -1211,13 +1194,7 @@ void VkPipelineObj::AddColorAttachment(uint32_t binding, const VkPipelineColorBl
 }
 
 void VkPipelineObj::SetDepthStencil(const VkPipelineDepthStencilStateCreateInfo *ds_state) {
-    m_ds_state.depthTestEnable = ds_state->depthTestEnable;
-    m_ds_state.depthWriteEnable = ds_state->depthWriteEnable;
-    m_ds_state.depthBoundsTestEnable = ds_state->depthBoundsTestEnable;
-    m_ds_state.depthCompareOp = ds_state->depthCompareOp;
-    m_ds_state.stencilTestEnable = ds_state->stencilTestEnable;
-    m_ds_state.back = ds_state->back;
-    m_ds_state.front = ds_state->front;
+    m_ds_state = ds_state;
 }
 
 void VkPipelineObj::SetViewport(const vector<VkViewport> viewports) {
@@ -1306,7 +1283,7 @@ VkResult VkPipelineObj::CreateVKPipeline(VkPipelineLayout layout, VkRenderPass r
     info.pViewportState = &m_vp_state;
     info.pRasterizationState = &m_rs_state;
     info.pMultisampleState = &m_ms_state;
-    info.pDepthStencilState = &m_ds_state;
+    info.pDepthStencilState = m_ds_state;
     info.pColorBlendState = &m_cb_state;
 
     if (m_ia_state.topology == VK_PRIMITIVE_TOPOLOGY_PATCH_LIST) {

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -413,7 +413,7 @@ class VkPipelineObj : public vk_testing::Pipeline {
     VkPipelineInputAssemblyStateCreateInfo m_ia_state;
     VkPipelineRasterizationStateCreateInfo m_rs_state;
     VkPipelineColorBlendStateCreateInfo m_cb_state;
-    VkPipelineDepthStencilStateCreateInfo m_ds_state;
+    VkPipelineDepthStencilStateCreateInfo const *m_ds_state;
     VkPipelineViewportStateCreateInfo m_vp_state;
     VkPipelineMultisampleStateCreateInfo m_ms_state;
     VkPipelineTessellationStateCreateInfo m_te_state;


### PR DESCRIPTION
If the subpass uses a depth/stencil attachment and rasterization is not
disabled, then this structure must be present.