### PR TITLE
layers: Remove old/unnecessary FIXME from swapchain layer

### DIFF
--- a/layers/swapchain.cpp
+++ b/layers/swapchain.cpp
@@ -1389,7 +1389,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysica
         if ((result == VK_SUCCESS) && pPhysicalDevice) {
             // Record the result of this query:
             pPhysicalDevice->gotSurfaceCapabilities = true;
-            // FIXME: NEED TO COPY THIS DATA, BECAUSE pSurfaceCapabilities POINTS TO APP-ALLOCATED DATA
             pPhysicalDevice->surfaceCapabilities = *pSurfaceCapabilities;
         }
         lock.unlock();


### PR DESCRIPTION
This FIXME comment does not apply.  It may have applied, if the line being
referred to once copied a pointer to user data, but at this point, the actual
data is being copied into a struct owned by the swapchain layer, which is what
the comment was about.