### PR TITLE
WIP: loader: Add checks for usage of wsi extensions

### DIFF
--- a/layers/object_tracker.h
+++ b/layers/object_tracker.h
@@ -92,6 +92,7 @@ struct layer_data {
     debug_report_data *report_data;
     std::vector<VkDebugReportCallbackEXT> logging_callback;
     bool wsi_enabled;
+    bool wsi_display_swapchain_enabled;
     bool objtrack_extensions_enabled;
 
     // The following are for keeping track of the temporary callbacks that can

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4324,6 +4324,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(
         }
     }
 
+    wsi_create_device(dev, pCreateInfo);
     extensions_create_device(dev, pCreateInfo);
 
     // TODO: Why does fpCreateDevice behave differently than

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -160,6 +160,7 @@ struct loader_dev_ext_dispatch_table {
 
 union loader_device_extension_enables {
     struct {
+        uint8_t khr_display_swapchain       : 1;
         uint8_t ext_debug_marker            : 1;
         uint8_t amd_draw_indirect_count     : 1;
         uint8_t nv_external_memory_win32    : 1;

--- a/loader/wsi.h
+++ b/loader/wsi.h
@@ -27,6 +27,8 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *ptr_instance,
 
 void wsi_create_instance(struct loader_instance *ptr_instance,
                          const VkInstanceCreateInfo *pCreateInfo);
+void wsi_create_device(struct loader_device *dev,
+                       const VkDeviceCreateInfo *pCreateInfo);
 bool wsi_unsupported_instance_extension(const VkExtensionProperties *ext_prop);
 
 VKAPI_ATTR void VKAPI_CALL


### PR DESCRIPTION
The loader really should validate that the WSI extensions are
enabled before being called.  Additionally, I needed to add
more checks for the KHR_display_swapchain extension in the
parameter_validation and object_tracker layers.

Change-Id: I3d07d46baf551be6f5f07e5374d6c683e3f52e7e