### PR TITLE
tests: Complain about unexpected errors

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -152,6 +152,7 @@ class ErrorMonitor {
             m_msgFound = VK_TRUE;
             result = VK_TRUE;
         } else {
+            printf("Unexpected: %s\n", msgString);
             m_otherMsgs.push_back(errorString);
         }
         test_platform_thread_unlock_mutex(&m_mutex);


### PR DESCRIPTION
This won't give us test failures yet, but does make the spurious errors
visible.