### PR TITLE
demos: Give Android versions permissions for internet & read/write files

### DIFF
--- a/demos/android/AndroidManifest.xml.cube
+++ b/demos/android/AndroidManifest.xml.cube
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.Cube" android:versionCode="1" android:versionName="1.0">
 
+    <!-- Allow this app to read and write files (for use by tracing libraries). -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <!-- This is the platform API where NativeActivity was introduced. -->
     <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23"/>
 

--- a/demos/android/AndroidManifest.xml.tri
+++ b/demos/android/AndroidManifest.xml.tri
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.Tri" android:versionCode="1" android:versionName="1.0">
 
+    <!-- Allow this app to read and write files (for use by tracing libraries). -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <!-- This is the platform API where NativeActivity was introduced. -->
     <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23"/>
 


### PR DESCRIPTION
This is in support of RenderDoc (and other tracing libraries).  On Android,
these "native" applications must have permission to read/write files on the
Android filesystem so that a trace-capture library can write a trace file.
After building and installing the application, the following commands should be
run from a Linux shell, in order to truly grant those permissions (not normally
required for an Android Java-based app, with a GUI; but is required for these
shell-launched, native apps):

adb shell pm grant com.example.Cube android.permission.READ_EXTERNAL_STORAGE
adb shell pm grant com.example.Cube android.permission.WRITE_EXTERNAL_STORAGE