### PR TITLE
Stroyan cmake fixes

### DIFF
--- a/build_windows_targets.bat
+++ b/build_windows_targets.bat
@@ -71,7 +71,7 @@ if %do_64%==1 (
     echo Generating 64-bit CMake files for Visual Studio %VS_VERSION%
     cmake -G "Visual Studio %VS_VERSION% Win64" ..
     echo Building 64-bit Debug 
-    msbuild ALL_BUILD.vcxproj /p:Platform=x64 /p:Configuration=Debug /verbosity:quiet
+    msbuild ALL_BUILD.vcxproj /p:Platform=x64 /p:Configuration=Debug /maxcpucount /verbosity:quiet
     if errorlevel 1 (
        echo.
        echo 64-bit Debug build failed!
@@ -80,7 +80,7 @@ if %do_64%==1 (
     )   
    
     echo Building 64-bit Release 
-    msbuild ALL_BUILD.vcxproj /p:Platform=x64 /p:Configuration=Release /verbosity:quiet
+    msbuild ALL_BUILD.vcxproj /p:Platform=x64 /p:Configuration=Release /maxcpucount /verbosity:quiet
     if errorlevel 1 (
        echo.
        echo 64-bit Release build failed!
@@ -101,7 +101,7 @@ if %do_32%==1 (
     echo Generating 32-bit CMake files for Visual Studio %VS_VERSION%
     cmake -G "Visual Studio %VS_VERSION%" ..
     echo Building 32-bit Debug 
-    msbuild ALL_BUILD.vcxproj /p:Platform=x86 /p:Configuration=Debug /verbosity:quiet
+    msbuild ALL_BUILD.vcxproj /p:Platform=x86 /p:Configuration=Debug /maxcpucount /verbosity:quiet
     if errorlevel 1 (
        echo.
        echo 32-bit Debug build failed!
@@ -110,7 +110,7 @@ if %do_32%==1 (
     )   
        
     echo Building 32-bit Release 
-    msbuild ALL_BUILD.vcxproj /p:Platform=x86 /p:Configuration=Release /verbosity:quiet
+    msbuild ALL_BUILD.vcxproj /p:Platform=x86 /p:Configuration=Release /maxcpucount /verbosity:quiet
     if errorlevel 1 (
        echo.
        echo 32-bit Release build failed!

--- a/cmake/FindImageMagick.cmake
+++ b/cmake/FindImageMagick.cmake
@@ -244,7 +244,7 @@ FOREACH(component ${ImageMagick_FIND_COMPONENTS}
             )
         ENDIF()
 
-        IF(NOT ImageMagick_MagickWand_INCLUDE_DIR OR NOT ImageMagick_MagickWand_LIBRARY)
+        IF(NOT ImageMagick_Magick++_INCLUDE_DIR OR NOT ImageMagick_Magick++_LIBRARY)
             # Look for Magick++.h, in the magick sub-folder
             FIND_IMAGEMAGICK_API(Magick++ magick magick/Magick++.h
                 Magick++ CORE_RL_Magick++_ Magick++-6.Q16 Magick++-Q16 Magick++-6.Q8 Magick++-Q8 Magick++-6.Q16HDRI Magick++-Q16HDRI Magick++-6.Q8HDRI Magick++-Q8HDRI

--- a/cmake/FindImageMagick.cmake
+++ b/cmake/FindImageMagick.cmake
@@ -231,6 +231,8 @@ FOREACH(component ${ImageMagick_FIND_COMPONENTS}
     )
 
     IF(component STREQUAL "Magick++")
+        # unset cached variable that assumes header parameter never changes
+        UNSET(ImageMagick_MagickWand_INCLUDE_DIR CACHE)
 
         # Try top folder first
         FIND_IMAGEMAGICK_API(Magick++ <NONE> Magick++.h
@@ -252,6 +254,8 @@ FOREACH(component ${ImageMagick_FIND_COMPONENTS}
         ENDIF()
 
     ELSEIF(component STREQUAL "MagickWand")
+        # unset cached variable that assumes header parameter never changes
+        UNSET(ImageMagick_MagickWand_INCLUDE_DIR CACHE)
 
         # Try top folder first
         FIND_IMAGEMAGICK_API(MagickWand <NONE> MagickWand.h

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -44,23 +44,19 @@ if(WIN32)
     endforeach()
 
     add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/demos/tri-vert.spv
-       COMMAND ${GLSLANG_VALIDATOR} -s -V ${PROJECT_SOURCE_DIR}/demos/tri.vert
-       COMMAND move vert.spv ${CMAKE_BINARY_DIR}/demos/tri-vert.spv
+       COMMAND ${GLSLANG_VALIDATOR} -s -V -o ${CMAKE_BINARY_DIR}/demos/tri-vert.spv ${PROJECT_SOURCE_DIR}/demos/tri.vert
        DEPENDS tri.vert ${GLSLANG_VALIDATOR}
        )
     add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/demos/tri-frag.spv
-       COMMAND ${GLSLANG_VALIDATOR} -s -V ${PROJECT_SOURCE_DIR}/demos/tri.frag
-       COMMAND move frag.spv ${CMAKE_BINARY_DIR}/demos/tri-frag.spv
+       COMMAND ${GLSLANG_VALIDATOR} -s -V -o ${CMAKE_BINARY_DIR}/demos/tri-frag.spv ${PROJECT_SOURCE_DIR}/demos/tri.frag
        DEPENDS tri.frag ${GLSLANG_VALIDATOR}
        )
     add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/demos/cube-vert.spv
-       COMMAND ${GLSLANG_VALIDATOR} -s -V ${PROJECT_SOURCE_DIR}/demos/cube.vert
-       COMMAND move vert.spv ${CMAKE_BINARY_DIR}/demos/cube-vert.spv
+       COMMAND ${GLSLANG_VALIDATOR} -s -V -o ${CMAKE_BINARY_DIR}/demos/cube-vert.spv ${PROJECT_SOURCE_DIR}/demos/cube.vert
        DEPENDS cube.vert ${GLSLANG_VALIDATOR}
        )
     add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/demos/cube-frag.spv
-       COMMAND ${GLSLANG_VALIDATOR} -s -V ${PROJECT_SOURCE_DIR}/demos/cube.frag
-       COMMAND move frag.spv ${CMAKE_BINARY_DIR}/demos/cube-frag.spv
+       COMMAND ${GLSLANG_VALIDATOR} -s -V -o ${CMAKE_BINARY_DIR}/demos/cube-frag.spv ${PROJECT_SOURCE_DIR}/demos/cube.frag
        DEPENDS cube.frag ${GLSLANG_VALIDATOR}
        )
    file(COPY cube.vcxproj.user DESTINATION ${CMAKE_BINARY_DIR}/demos)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -40,6 +40,7 @@ if (WIN32)
                     COMMAND copy ${src_json} ${dst_json}
                     VERBATIM
                     )
+                add_dependencies(${config_file}-json ${config_file})
             endforeach(config_file)
         else()
             foreach (config_file ${LAYER_JSON_FILES})
@@ -49,6 +50,7 @@ if (WIN32)
                     COMMAND copy ${src_json} ${dst_json}
                     VERBATIM
                     )
+                add_dependencies(${config_file}-json ${config_file})
             endforeach(config_file)
         endif()
     endif()
@@ -60,6 +62,7 @@ else()
                 COMMAND ln -sf ${CMAKE_CURRENT_SOURCE_DIR}/linux/${config_file}.json
                 VERBATIM
                 )
+                add_dependencies(${config_file}-json ${config_file})
         endforeach(config_file)
     endif()
 endif()
@@ -72,14 +75,14 @@ if (WIN32)
     )
     add_library(VkLayer_${target} SHARED ${ARGN} VkLayer_${target}.def)
     target_link_Libraries(VkLayer_${target} VkLayer_utils)
-    add_dependencies(VkLayer_${target} generate_vk_layer_helpers)
+    add_dependencies(VkLayer_${target} generate_dispatch_table_helper generate_vk_layer_helpers generate_enum_string_helper VkLayer_utils)
     set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "/DEF:${CMAKE_CURRENT_BINARY_DIR}/VkLayer_${target}.def")
     endmacro()
 else()
     macro(add_vk_layer target)
     add_library(VkLayer_${target} SHARED ${ARGN})
     target_link_Libraries(VkLayer_${target} VkLayer_utils)
-    add_dependencies(VkLayer_${target} generate_vk_layer_helpers)
+    add_dependencies(VkLayer_${target} generate_dispatch_table_helper generate_vk_layer_helpers generate_enum_string_helper VkLayer_utils)
     set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic")
     install(TARGETS VkLayer_${target} DESTINATION ${PROJECT_BINARY_DIR}/install_staging)
     endmacro()
@@ -117,12 +120,40 @@ run_vk_helper(gen_struct_wrappers
     vk_struct_wrappers.h
     vk_struct_wrappers.cpp
     vk_safe_struct.h
+# Don't list vk_safe_struct.cpp as OUTPUT to avoid duplicate builds.
+# If listed here use of it for add_library will cause it to be created
+# independently of custom target generate_vk_layer_helpers .
+# That breaks parallel builds.
+#   vk_safe_struct.cpp
+)
+
+# Let gen_struct_wrappers really create vk_safe_struct.cpp
+add_custom_command(OUTPUT vk_safe_struct.cpp
+    COMMAND echo defer making vk_safe_struct.cpp
+)
+
+set_source_files_properties(
+    vk_struct_string_helper.h
+    vk_struct_string_helper_cpp.h
+    vk_struct_string_helper_no_addr.h
+    vk_struct_string_helper_no_addr_cpp.h
+    vk_struct_size_helper.h
+    vk_struct_size_helper.c
+    vk_struct_wrappers.h
+    vk_struct_wrappers.cpp
+    vk_safe_struct.h
     vk_safe_struct.cpp
+    PROPERTIES GENERATED TRUE)
+
+add_custom_target(generate_enum_string_helper DEPENDS
+    vk_enum_string_helper.h
+)
+
+add_custom_target(generate_dispatch_table_helper DEPENDS
+    vk_dispatch_table_helper.h
 )
 
 add_custom_target(generate_vk_layer_helpers DEPENDS
-    vk_dispatch_table_helper.h
-    vk_enum_string_helper.h
     vk_struct_string_helper.h
     vk_struct_string_helper_no_addr.h
     vk_struct_string_helper_cpp.h

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -21,6 +21,7 @@ if (WIN32)
                 COMMAND copy ${src_json} ${dst_json}
                 VERBATIM
                 )
+                add_dependencies(${config_file}-json ${config_file})
         endforeach(config_file)
     endif()
 else()
@@ -42,13 +43,13 @@ if (WIN32)
         DEPENDS ${PROJECT_SOURCE_DIR}/vk-generate.py ${PROJECT_SOURCE_DIR}/vulkan.py
     )
     add_library(VkLayer_${target} SHARED ${ARGN} VkLayer_${target}.def)
-    add_dependencies(VkLayer_${target} generate_vk_layer_helpers)
+    add_dependencies(VkLayer_${target} generate_tests_dispatch_table_helper VkLayer_utils)
     set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "/DEF:${CMAKE_CURRENT_BINARY_DIR}/VkLayer_${target}.def")
     endmacro()
 else()
     macro(add_vk_layer target)
     add_library(VkLayer_${target} SHARED ${ARGN})
-    add_dependencies(VkLayer_${target} generate_vk_layer_helpers)
+    add_dependencies(VkLayer_${target} generate_tests_dispatch_table_helper VkLayer_utils)
     set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic")
     install(TARGETS VkLayer_${target} DESTINATION ${PROJECT_BINARY_DIR}/install_staging)
     endmacro()
@@ -75,6 +76,10 @@ endif()
 add_custom_command(OUTPUT vk_dispatch_table_helper.h
     COMMAND ${PYTHON_CMD} ${PROJECT_SOURCE_DIR}/vk-generate.py ${DisplayServer} dispatch-table-ops layer > vk_dispatch_table_helper.h
     DEPENDS ${PROJECT_SOURCE_DIR}/vk-generate.py ${PROJECT_SOURCE_DIR}/vulkan.py)
+
+add_custom_target(generate_tests_dispatch_table_helper DEPENDS
+    vk_dispatch_table_helper.h
+)
 
 set (WRAP_SRCS
        wrap_objects.cpp


### PR DESCRIPTION
These changes get windows builds working with recent ImageMagick versiosn and Visual Studio.
I noted that the ImageMagick was not found on my system.  The current use of FIND_PATH for headers
trips over cached variable values and fails on either first cmake or repeated use of cmake.

Using visual studio to build tries to use parallel builds.  That was turned off in the msbuild script.
I tracked down the places that parallel builds failed.  I then enabled them in build_windows_targets.bat.