### PR TITLE
Android demo layers

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -189,6 +189,16 @@ adb install ./tri/bin/NativeActivity-debug.apk
 adb shell am start com.example.Cube/android.app.NativeActivity
 adb shell am start com.example.Tri/android.app.NativeActivity
 ```
+To build, install, and run Cube with validation layers, first build layers using steps above, then run:
+```
+cd demos/android
+android update project -s -p . -t "android-23"
+ndk-build -j
+ant -buildfile cube-with-layers debug
+adb install ./cube-with-layers/bin/NativeActivity-debug.apk
+adb shell am start -a android.intent.action.MAIN -c android-intent.category.LAUNCH -n com.example.CubeWithLayers/android.app.NativeActivity --es args "--validate"
+```
+
 To build, install, and run the Smoke demo for Android, run the following, and any
 prompts that come back from the script:
 ```

--- a/common/android_util.cpp
+++ b/common/android_util.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Relicensed from the WTFPL (http://www.wtfpl.net/faq/).
+ */
+
+#include "android_util.h"
+#include <android_native_app_glue.h>
+#include <cassert>
+#include <vector>
+#include <string>
+#include <sstream>
+
+extern "C" {
+
+// Convert Intents to arg list, returning argc and argv
+// Note that this C routine mallocs memory that the caller must free
+char** get_args(struct android_app* app, const char* intent_extra_data_key, const char* appTag, int* count)
+{
+    std::vector<std::string> args;
+    JavaVM &vm = *app->activity->vm;
+    JNIEnv *p_env;
+    if (vm.AttachCurrentThread(&p_env, nullptr) != JNI_OK)
+        return nullptr;
+
+    JNIEnv &env = *p_env;
+    jobject activity = app->activity->clazz;
+    jmethodID get_intent_method = env.GetMethodID(env.GetObjectClass(activity),
+            "getIntent", "()Landroid/content/Intent;");
+    jobject intent = env.CallObjectMethod(activity, get_intent_method);
+    jmethodID get_string_extra_method = env.GetMethodID(env.GetObjectClass(intent),
+            "getStringExtra", "(Ljava/lang/String;)Ljava/lang/String;");
+    jvalue get_string_extra_args;
+    get_string_extra_args.l = env.NewStringUTF(intent_extra_data_key);
+    jstring extra_str = static_cast<jstring>(env.CallObjectMethodA(intent,
+            get_string_extra_method, &get_string_extra_args));
+
+    std::string args_str;
+    if (extra_str) {
+        const char *extra_utf = env.GetStringUTFChars(extra_str, nullptr);
+        args_str = extra_utf;
+        env.ReleaseStringUTFChars(extra_str, extra_utf);
+        env.DeleteLocalRef(extra_str);
+    }
+
+    env.DeleteLocalRef(get_string_extra_args.l);
+    env.DeleteLocalRef(intent);
+    vm.DetachCurrentThread();
+
+    // split args_str
+    std::stringstream ss(args_str);
+    std::string arg;
+    while (std::getline(ss, arg, ' ')) {
+        if (!arg.empty())
+            args.push_back(arg);
+    }
+
+    // Convert our STL results to C friendly constructs
+    assert(count != nullptr);
+    *count = args.size() + 1;
+    char** vector = (char**) malloc(*count * sizeof(char*));
+    const char* appName = appTag ? appTag : (const char*) "appTag";
+
+   vector[0] = (char*) malloc(strlen(appName) * sizeof(char));
+   strcpy(vector[0], appName);
+
+    for (uint32_t i = 0; i < args.size(); i++) {
+        vector[i + 1] = (char*) malloc(strlen(args[i].c_str()) * sizeof(char));
+        strcpy(vector[i + 1], args[i].c_str());
+    }
+
+    return vector;
+}
+
+} // extern "C"

--- a/common/android_util.h
+++ b/common/android_util.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Relicensed from the WTFPL (http://www.wtfpl.net/faq/).
+ */
+
+#ifndef ANDROID_UTIL_H
+#define ANDROID_UTIL_H
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+char** get_args(struct android_app* app, const char* intent_extra_data_key, const char* appTag, int* count);
+
+#ifdef __cplusplus
+    }
+#endif
+
+#endif

--- a/demos/android/cube-with-layers/AndroidManifest.xml
+++ b/demos/android/cube-with-layers/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.CubeWithLayers" android:versionCode="1" android:versionName="1.0">
+
+    <!-- Allow this app to read and write files (for use by tracing libraries). -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+
+    <!-- This is the platform API where NativeActivity was introduced. -->
+    <uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23"/>
+
+    <!-- This .apk has no Java code itself, so set hasCode to false. -->
+    <application android:label="@string/app_name" android:hasCode="false" android:debuggable='true'>
+
+        <!-- Our activity is the built-in NativeActivity framework class.
+             This will take care of integrating with our NDK code. -->
+        <activity android:name="android.app.NativeActivity" android:label="@string/app_name" android:exported="true">
+            <!-- Tell NativeActivity the name of or .so -->
+            <meta-data android:name="android.app.lib_name" android:value="Cube"/>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/demos/android/cube-with-layers/custom_rules.xml
+++ b/demos/android/cube-with-layers/custom_rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="NativeActivity" default="help">
+
+<property name="cubeWithLayersDir" location="../libs-with-layers" />
+<property name="cubeDir" location="../libs" />
+<property name="layersDir" location="../../../build-android/libs" />
+
+<echo>CubeWithLayers: Creating libs-with-layers</echo>
+<mkdir dir="${cubeWithLayersDir}"/>
+
+<echo>CubeWithLayers: Copying libs from demos/android</echo>
+<copy todir="${cubeWithLayersDir}">
+<fileset dir="${cubeDir}"/>
+</copy>
+
+<echo>CubeWithLayers: Copying layers from build-android</echo>
+<copy todir="${cubeWithLayersDir}">
+<fileset dir="${layersDir}"/>
+</copy>
+
+<!-- Point ndk-build at the libs-with-layers common dir -->
+<echo>CubeWithLayers: Overriding native.libs.absolute.dir with ${cubeWithLayersDir}</echo>
+<property name="native.libs.absolute.dir" location="${cubeWithLayersDir}" />
+
+</project>

--- a/demos/android/cube-with-layers/res/values/strings.xml
+++ b/demos/android/cube-with-layers/res/values/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2013 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- This file contains resource definitions for displayed strings, allowing
+     them to be changed based on the locale and options. -->
+
+<resources>
+    <!-- Simple strings. -->
+    <string name="app_name">CubeWithLayers</string>
+
+</resources>

--- a/demos/android/jni/Android.mk
+++ b/demos/android/jni/Android.mk
@@ -33,7 +33,8 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := Cube
 LOCAL_SRC_FILES += $(DEMO_DIR)/cube.c \
-                   $(SRC_DIR)/common/vulkan_wrapper.cpp
+                   $(SRC_DIR)/common/vulkan_wrapper.cpp \
+                   $(SRC_DIR)/common/android_util.cpp
 LOCAL_C_INCLUDES += $(SRC_DIR)/include \
                     $(DEMO_DIR)/android/include \
                     $(SRC_DIR)/libs \

--- a/demos/cube.c
+++ b/demos/cube.c
@@ -422,54 +422,70 @@ VKAPI_ATTR VkBool32 VKAPI_CALL
 dbgFunc(VkFlags msgFlags, VkDebugReportObjectTypeEXT objType,
     uint64_t srcObject, size_t location, int32_t msgCode,
     const char *pLayerPrefix, const char *pMsg, void *pUserData) {
+
+    // clang-format off
     char *message = (char *)malloc(strlen(pMsg) + 100);
 
     assert(message);
 
-    if (msgFlags & VK_DEBUG_REPORT_ERROR_BIT_EXT) {
-        sprintf(message, "ERROR: [%s] Code %d : %s", pLayerPrefix, msgCode,
-            pMsg);
+    // We know we're submitting queues without fences, ignore this
+    if (strstr(pMsg, "vkQueueSubmit parameter, VkFence fence, is null pointer"))
+        return false;
+
+    if (msgFlags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT) {
+        sprintf(message, "INFORMATION: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
         validation_error = 1;
     } else if (msgFlags & VK_DEBUG_REPORT_WARNING_BIT_EXT) {
-        // We know that we're submitting queues without fences, ignore this
-        // warning
-        if (strstr(pMsg,
-            "vkQueueSubmit parameter, VkFence fence, is null pointer")) {
-            return false;
-        }
-        sprintf(message, "WARNING: [%s] Code %d : %s", pLayerPrefix, msgCode,
-            pMsg);
+        sprintf(message, "WARNING: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
+        validation_error = 1;
+    } else if (msgFlags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT) {
+        sprintf(message, "PERFOERMANCE WARNING: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
+        validation_error = 1;
+    } else if (msgFlags & VK_DEBUG_REPORT_ERROR_BIT_EXT) {
+        sprintf(message, "ERROR: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
+        validation_error = 1;
+    } else if (msgFlags & VK_DEBUG_REPORT_DEBUG_BIT_EXT) {
+        sprintf(message, "DEBUG: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
         validation_error = 1;
     } else {
+        sprintf(message, "INFORMATION: [%s] Code %d : %s", pLayerPrefix, msgCode, pMsg);
         validation_error = 1;
-        return false;
     }
 
 #ifdef _WIN32
+
     in_callback = true;
     struct demo *demo = (struct demo*) pUserData;
     if (!demo->suppress_popups)
         MessageBox(NULL, message, "Alert", MB_OK);
     in_callback = false;
+
 #elif defined(ANDROID)
+
     if (msgFlags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT) {
-        __android_log_print(ANDROID_LOG_INFO,  "Cube", "%s", message);
+        __android_log_print(ANDROID_LOG_INFO,  APP_SHORT_NAME, "%s", message);
     } else if (msgFlags & VK_DEBUG_REPORT_WARNING_BIT_EXT) {
-        __android_log_print(ANDROID_LOG_WARN,  "Cube", "%s", message);
+        __android_log_print(ANDROID_LOG_WARN,  APP_SHORT_NAME, "%s", message);
     } else if (msgFlags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT) {
-        __android_log_print(ANDROID_LOG_WARN,  "Cube", "%s", message);
+        __android_log_print(ANDROID_LOG_WARN,  APP_SHORT_NAME, "%s", message);
     } else if (msgFlags & VK_DEBUG_REPORT_ERROR_BIT_EXT) {
-        __android_log_print(ANDROID_LOG_ERROR, "Cube", "%s", message);
+        __android_log_print(ANDROID_LOG_ERROR, APP_SHORT_NAME, "%s", message);
     } else if (msgFlags & VK_DEBUG_REPORT_DEBUG_BIT_EXT) {
-        __android_log_print(ANDROID_LOG_DEBUG, "Cube", "%s", message);
+        __android_log_print(ANDROID_LOG_DEBUG, APP_SHORT_NAME, "%s", message);
     } else {
-        __android_log_print(ANDROID_LOG_INFO,  "Cube", "%s", message);
+        __android_log_print(ANDROID_LOG_INFO,  APP_SHORT_NAME, "%s", message);
     }
+
 #else
+
     printf("%s\n", message);
     fflush(stdout);
+
 #endif
+
     free(message);
+
+    //clang-format on
 
     /*
     * false indicates that layer should not bail-out of an
@@ -3209,6 +3225,9 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
             continue;
         }
 
+#if defined(ANDROID)
+        ERR_EXIT("Usage: cube [--validate]\n";
+#else
         fprintf(stderr, "Usage:\n  %s [--use_staging] [--validate] [--break] "
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
                         "[--xlib] "
@@ -3217,6 +3236,7 @@ static void demo_init(struct demo *demo, int argc, char **argv) {
                 APP_SHORT_NAME);
         fflush(stderr);
         exit(1);
+#endif
     }
 
     if (!demo->use_xlib)
@@ -3355,7 +3375,7 @@ static void processCommand(struct android_app* app, int32_t cmd) {
                 // Use the following key to send arguments, i.e.
                 // --es args "--validate"
                 const char key[] = "args";
-                char* appTag = (char*) "Cube";
+                char* appTag = (char*) APP_SHORT_NAME;
                 int argc = 0;
                 char** argv = get_args(app, key, appTag, &argc);
 


### PR DESCRIPTION
This series adds another APK setup that pulls in validation layers with Cube, and also adds Android Intent parsing to argv to support "--validate".  The end result is you can run CubeWithLayers on a non-rooted phone and see validation output in logcat.