### PR TITLE
Fix incorrect array index in inner loop of instance extension validation

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4035,7 +4035,7 @@ VkResult loader_validate_instance_extensions(
         /* Not in global list, search layer extension lists */
         for (uint32_t j = 0; j < pCreateInfo->enabledLayerCount; j++) {
             layer_prop = loader_get_layer_property(
-                pCreateInfo->ppEnabledLayerNames[i], instance_layer);
+                pCreateInfo->ppEnabledLayerNames[j], instance_layer);
             if (!layer_prop) {
                 /* Should NOT get here, loader_validate_layers
                  * should have already filtered this case out.


### PR DESCRIPTION
Change-Id: I27606fb32049bb531131ca29357d79491e3f96a7

The loop counter of the enabled layers is "j" but the array indexing is done using "i".