### PR TITLE
tests: Remove document validation test

### DIFF
--- a/tests/_run_all_tests.ps1
+++ b/tests/_run_all_tests.ps1
@@ -27,9 +27,5 @@ if ($lastexitcode -ne 0) {
 }
 
 & $dPath\vk_layer_validation_tests --gtest_filter=-$TestExceptions
-if ($lastexitcode -ne 0) {
-   exit 1
-}
 
-.\vkvalidatelayerdoc.ps1
 exit $lastexitcode


### PR DESCRIPTION
This test requires files outside of the build directory, which
doesn't work when distributing build results.  It will soon be
superseded by a new test for valid enums.  It is still covered
by Linux run_all_tests.sh