### PR TITLE
Adding input attachment access as optional for attachment optimal layouts

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8810,12 +8810,12 @@ static bool ValidateMaskBitsFromLayouts(const layer_data *my_data, VkCommandBuff
     switch (layout) {
     case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL: {
         skip_call |= ValidateMaskBits(my_data, cmdBuffer, accessMask, layout, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-                                      VK_ACCESS_COLOR_ATTACHMENT_READ_BIT, type);
+                                      VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_INPUT_ATTACHMENT_READ_BIT, type);
         break;
     }
     case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL: {
         skip_call |= ValidateMaskBits(my_data, cmdBuffer, accessMask, layout, VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
-                                      VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT, type);
+                                      VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_INPUT_ATTACHMENT_READ_BIT, type);
         break;
     }
     case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL: {
@@ -8828,7 +8828,8 @@ static bool ValidateMaskBitsFromLayouts(const layer_data *my_data, VkCommandBuff
     }
     case VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL: {
         skip_call |= ValidateMaskBits(my_data, cmdBuffer, accessMask, layout, 0,
-                                      VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_SHADER_READ_BIT, type);
+                                      VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                                      VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_INPUT_ATTACHMENT_READ_BIT, type);
         break;
     }
     case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL: {


### PR DESCRIPTION
Change-Id: I0ef3d1af2ef38d218f1721e98eb1d98b326cd340

The checks in ValidateMaskBitsFromLayouts try to validate that the access mask provided in an image memory barrier make sense for the (new and old) image layout provided.

For the most part this seems to generate sensible warnings, e.g. if you transition to VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, then you can't use the image for anything other than a transfer destination, so it makes sense to issue a warning if the dstAccess is anything other than VK_ACCESS_TRANSFER_WRITE_BIT.

But for the attachment ATTACHMENT_OPTIMAL / READ_ONLY_OPTIMAL states I think there are more accesses that are sensible, and I don't see why they should produce a warning. For example, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL only accepts VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT, but the spec's description of the this layout says:
>must only be used as a read-only depth/stencil attachment in a VkFramebuffer and/or as a read-only image in a shader (which can be read as a sampled image, combined image/sampler and/or input attachment). 

Based on that it seems reasonable for an application to include VK_ACCESS_SHADER_READ_BIT and VK_ACCESS_INPUT_ATTACHMENT_READ_BIT in the access mask for this layout transition.

Similar arguments apply for the two other layouts modified in this patch.