### PR TITLE
Fix codegen issue in dispatch-table-helper

### DIFF
--- a/vk-generate.py
+++ b/vk-generate.py
@@ -155,68 +155,39 @@ class DispatchTableOpsSubcommand(Subcommand):
             stmts.append("    // Core instance function pointers")
             stmts.append("    table->GetInstanceProcAddr = (PFN_vkGetInstanceProcAddr) gpa(instance, \"vkGetInstanceProcAddr\");")
 
-            KHR_printed = False
-            EXT_printed = False
-            Win32_printed = False
-            XLIB_printed = False
-            XCB_printed = False
-            MIR_printed = False
-            WAY_printed = False
-            Android_printed = False
             for proto in self.protos:
                 if proto.params[0].ty != "VkInstance" and proto.params[0].ty != "VkPhysicalDevice" or \
                   proto.name == "CreateDevice" or proto.name == "GetInstanceProcAddr":
                     continue
-                if Win32_printed and 'Win32' not in proto.name:
-                    stmts.append("#endif // VK_USE_PLATFORM_WIN32_KHR")
-                    Win32_printed = False
-                if XLIB_printed and 'Xlib' not in proto.name:
-                    stmts.append("#endif // VK_USE_PLATFORM_XLIB_KHR")
-                    XLIB_printed = False
-                if XCB_printed and 'Xcb' not in proto.name:
-                    stmts.append("#endif // VK_USE_PLATFORM_XCB_KHR")
-                    XCB_printed = False
-                if MIR_printed and 'Mir' not in proto.name:
-                    stmts.append("#endif // VK_USE_PLATFORM_MIR_KHR")
-                    MIR_printed = False
-                if WAY_printed and 'Wayland' not in proto.name:
-                    stmts.append("#endif // VK_USE_PLATFORM_WAYLAND_KHR")
-                    WAY_printed = False
-                if Android_printed and 'Android' not in proto.name:
-                    stmts.append("#endif // VK_USE_PLATFORM_ANDROID_KHR")
-                    Android_printed = False
+                # Protect platform-dependent APIs with #ifdef
                 if 'KHR' in proto.name and 'Win32' in proto.name:
-                    if not Win32_printed:
-                        stmts.append("#ifdef VK_USE_PLATFORM_WIN32_KHR")
-                        Win32_printed = True
+                    stmts.append("#ifdef VK_USE_PLATFORM_WIN32_KHR")
                 if 'KHR' in proto.name and 'Xlib' in proto.name:
-                    if not XLIB_printed:
-                        stmts.append("#ifdef VK_USE_PLATFORM_XLIB_KHR")
-                        XLIB_printed = True
+                    stmts.append("#ifdef VK_USE_PLATFORM_XLIB_KHR")
                 if 'KHR' in proto.name and 'Xcb' in proto.name:
-                    if not XCB_printed:
-                        stmts.append("#ifdef VK_USE_PLATFORM_XCB_KHR")
-                        XCB_printed = True
+                    stmts.append("#ifdef VK_USE_PLATFORM_XCB_KHR")
                 if 'KHR' in proto.name and 'Mir' in proto.name:
-                    if not MIR_printed:
-                        stmts.append("#ifdef VK_USE_PLATFORM_MIR_KHR")
-                        MIR_printed = True
+                    stmts.append("#ifdef VK_USE_PLATFORM_MIR_KHR")
                 if 'KHR' in proto.name and 'Wayland' in proto.name:
-                    if not WAY_printed:
-                        stmts.append("#ifdef VK_USE_PLATFORM_WAYLAND_KHR")
-                        WAY_printed = True
+                    stmts.append("#ifdef VK_USE_PLATFORM_WAYLAND_KHR")
                 if 'KHR' in proto.name and 'Android' in proto.name:
-                    if not Android_printed:
-                        stmts.append("#ifdef VK_USE_PLATFORM_ANDROID_KHR")
-                        Android_printed = True
-                if 'KHR' in proto.name and not KHR_printed:
-                    stmts.append("    // KHR instance extension function pointers")
-                    KHR_printed = True
-                if 'EXT' in proto.name and not EXT_printed:
-                    stmts.append("    // EXT instance extension function pointers")
-                    EXT_printed = True
+                    stmts.append("#ifdef VK_USE_PLATFORM_ANDROID_KHR")
+                # Output dispatch table entry
                 stmts.append("    table->%s = (PFN_vk%s) gpa(instance, \"vk%s\");" %
                       (proto.name, proto.name, proto.name))
+                # If entry was protected by an #ifdef, close with a #endif
+                if 'KHR' in proto.name and 'Win32' in proto.name:
+                    stmts.append("#endif // VK_USE_PLATFORM_WIN32_KHR")
+                if 'KHR' in proto.name and 'Xlib' in proto.name:
+                    stmts.append("#endif // VK_USE_PLATFORM_XLIB_KHR")
+                if 'KHR' in proto.name and 'Xcb' in proto.name:
+                    stmts.append("#endif // VK_USE_PLATFORM_XCB_KHR")
+                if 'KHR' in proto.name and 'Mir' in proto.name:
+                    stmts.append("#endif // VK_USE_PLATFORM_MIR_KHR")
+                if 'KHR' in proto.name and 'Wayland' in proto.name:
+                    stmts.append("#endif // VK_USE_PLATFORM_WAYLAND_KHR")
+                if 'KHR' in proto.name and 'Android' in proto.name:
+                    stmts.append("#endif // VK_USE_PLATFORM_ANDROID_KHR")
             func.append("static inline void %s_init_instance_dispatch_table(" % self.prefix)
             func.append("%s        VkInstance instance," % (" " * len(self.prefix)))
             func.append("%s        VkLayerInstanceDispatchTable *table," % (" " * len(self.prefix)))


### PR DESCRIPTION
If a dispatch table entry needed to be protected by a #ifdef and was
the last prototype in the list, the corresponding #endif was not
generated causing compilation failures.

Change-Id: I8760bf546bc38d6fc7d80cd3a095e52977dc554e