### PR TITLE
layers: Change to including vk_safe_struct code.

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -33,7 +33,6 @@ LOCAL_MODULE := VkLayer_core_validation
 LOCAL_SRC_FILES += $(LAYER_DIR)/layer-src/core_validation/core_validation.cpp
 LOCAL_SRC_FILES += $(LAYER_DIR)/layer-src/core_validation/descriptor_sets.cpp
 LOCAL_SRC_FILES += $(LAYER_DIR)/common/vk_layer_table.cpp
-LOCAL_SRC_FILES += $(LAYER_DIR)/layer-src/unique_objects/vk_safe_struct.cpp
 LOCAL_C_INCLUDES += $(SRC_DIR)/include \
                     $(SRC_DIR)/layers \
                     $(LAYER_DIR)/include \
@@ -110,7 +109,6 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_unique_objects
 LOCAL_SRC_FILES += $(LAYER_DIR)/layer-src/unique_objects/unique_objects.cpp
-LOCAL_SRC_FILES += $(LAYER_DIR)/layer-src/unique_objects/vk_safe_struct.cpp
 LOCAL_SRC_FILES += $(LAYER_DIR)/common/vk_layer_table.cpp
 LOCAL_C_INCLUDES += $(SRC_DIR)/include \
                     $(SRC_DIR)/layers \

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -128,16 +128,7 @@ run_vk_helper(gen_struct_wrappers
     vk_struct_wrappers.h
     vk_struct_wrappers.cpp
     vk_safe_struct.h
-# Don't list vk_safe_struct.cpp as OUTPUT to avoid duplicate builds.
-# If listed here use of it for add_library will cause it to be created
-# independently of custom target generate_vk_layer_helpers .
-# That breaks parallel builds.
-#   vk_safe_struct.cpp
-)
-
-# Let gen_struct_wrappers really create vk_safe_struct.cpp
-add_custom_command(OUTPUT vk_safe_struct.cpp
-    COMMAND echo defer making vk_safe_struct.cpp
+    vk_safe_struct.cpp
 )
 
 set_source_files_properties(
@@ -188,13 +179,13 @@ else()
     install(TARGETS VkLayer_utils DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
-add_vk_layer(core_validation core_validation.cpp vk_layer_table.cpp vk_safe_struct.cpp descriptor_sets.cpp)
+add_vk_layer(core_validation core_validation.cpp vk_layer_table.cpp descriptor_sets.cpp)
 add_vk_layer(object_tracker object_tracker.cpp vk_layer_table.cpp)
 add_vk_layer(image image.cpp vk_layer_table.cpp)
 add_vk_layer(swapchain swapchain.cpp vk_layer_table.cpp)
 # generated
 add_vk_layer(threading threading.cpp thread_check.h vk_layer_table.cpp)
-add_vk_layer(unique_objects unique_objects.cpp unique_objects_wrappers.h vk_layer_table.cpp vk_safe_struct.cpp)
+add_vk_layer(unique_objects unique_objects.cpp unique_objects_wrappers.h vk_layer_table.cpp)
 add_vk_layer(parameter_validation parameter_validation.cpp parameter_validation.h vk_layer_table.cpp)
 
 # Core validation has additional dependencies

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -70,6 +70,9 @@
     }
 #endif
 
+// This intentionally includes a cpp file
+#include "vk_safe_struct.cpp"
+
 using namespace std;
 
 namespace core_validation {

--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -41,6 +41,9 @@
 #include "vk_layer_data.h"
 #include "vk_layer_utils.h"
 
+// This intentionally includes a cpp file
+#include "vk_safe_struct.cpp"
+
 #include "unique_objects_wrappers.h"
 
 namespace unique_objects {


### PR DESCRIPTION
Cmake on windows cannot handle multiple projects using generated library code.
This happens with vk_safe_struct.cpp between core_validation and unique_objects.
Having both layers list it in add_vk_layer and the resulting add_library operation causes
their vcxproj files to create vk_safe_struct.cpp for build and remove vk_safe_struct.cpp for rebuild.
That breaks parallel builds when the creation collides.
It breaks rebuild when the recently created file is removed by another project.
Changing to using #include of the cpp file avoids that bad build behavior.
