### PR TITLE
vulkaninfo: fix segfault when DISPLAY is not set

### DIFF
--- a/demos/vulkaninfo.c
+++ b/demos/vulkaninfo.c
@@ -911,6 +911,9 @@ static void app_create_xlib_window(struct app_instance *inst) {
     long visualMask = VisualScreenMask;
     int numberOfVisuals;
 
+    if (inst->xlib_display == NULL)
+        return;
+
     XVisualInfo vInfoTemplate={};
     vInfoTemplate.screen = DefaultScreen(inst->xlib_display);
     XVisualInfo *visualInfo = XGetVisualInfo(inst->xlib_display, visualMask,
@@ -1507,6 +1510,12 @@ int main(int argc, char **argv) {
         app_destroy_win32_window(&inst);
     }
 #endif
+#if defined(VK_USE_PLATFORM_XCB_KHR) || defined(VK_USE_PLATFORM_XLIB_KHR)
+    if (getenv("DISPLAY") == NULL) {
+        printf("'DISPLAY' environment variable not set... Exiting!\n");
+        goto out;
+    }
+#endif
 //--XCB--
 #ifdef VK_USE_PLATFORM_XCB_KHR
     if (has_extension(VK_KHR_XCB_SURFACE_EXTENSION_NAME,
@@ -1527,6 +1536,10 @@ int main(int argc, char **argv) {
     if (has_extension(VK_KHR_XLIB_SURFACE_EXTENSION_NAME,
                       inst.global_extension_count, inst.global_extensions)) {
         app_create_xlib_window(&inst);
+        if (inst.xlib_display == NULL) {
+            printf("'DISPLAY' variable not set correctly. Exiting!\n'");
+            goto out;
+        }
         for (i = 0; i < gpu_count; i++) {
             app_create_xlib_surface(&inst);
             printf("GPU id       : %u (%s)\n", i, gpus[i].props.deviceName);
@@ -1547,6 +1560,7 @@ int main(int argc, char **argv) {
         printf("\n\n");
     }
 
+out:
     for (i = 0; i < gpu_count; i++)
         app_gpu_destroy(&gpus[i]);
 


### PR DESCRIPTION
Both xlib and xcb interfaces expect the DISPLAY environment
variable to be set before creation of a window and the
display creation mechanism would segfault if that is
not the case and won't provide the user with details on
what has to be done to correct the problem.
We now handle such scenarios and exit cleanly after
providing the user with some details.

Signed-off-by: Awais Belal <awais_belal@mentor.com>