### PR TITLE
WIP:  loader: gh1120 - Unwrap phys dev handles

### DIFF
--- a/loader/extensions.h
+++ b/loader/extensions.h
@@ -28,6 +28,15 @@ bool extension_instance_gpa(struct loader_instance *ptr_instance,
 void extensions_create_instance(struct loader_instance *ptr_instance,
                                 const VkInstanceCreateInfo *pCreateInfo);
 
+// Definitions for the VK_EXT_debug_marker extension
+
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_DebugMarkerSetObjectTagEXT(
+    VkDevice device, VkDebugMarkerObjectTagInfoEXT *pTagInfo);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_DebugMarkerSetObjectNameEXT(
+    VkDevice device, VkDebugMarkerObjectNameInfoEXT *pNameInfo);
+
 // Definitions for the VK_NV_external_memory_capabilities extension
 
 VKAPI_ATTR VkResult VKAPI_CALL

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1644,6 +1644,8 @@ static bool loader_icd_init_entrys(struct loader_icd_term *icd_term,
     LOOKUP_GIPA(GetPhysicalDeviceSparseImageFormatProperties, true);
     LOOKUP_GIPA(CreateDebugReportCallbackEXT, false);
     LOOKUP_GIPA(DestroyDebugReportCallbackEXT, false);
+    LOOKUP_GIPA(DebugMarkerSetObjectTagEXT, false);
+    LOOKUP_GIPA(DebugMarkerSetObjectNameEXT, false);
     LOOKUP_GIPA(GetPhysicalDeviceSurfaceSupportKHR, false);
     LOOKUP_GIPA(GetPhysicalDeviceSurfaceCapabilitiesKHR, false);
     LOOKUP_GIPA(GetPhysicalDeviceSurfaceFormatsKHR, false);
@@ -3274,15 +3276,28 @@ void loader_override_terminating_device_proc(
     struct loader_icd_term *icd_term =
         loader_get_icd_and_device(device, &dev, NULL);
 
-    // Certain device entry-points still need to go through a terminator before
-    // hitting the ICD.  This could be for several reasons, but the main one
-    // is currently unwrapping an object before passing the appropriate info
-    // along to the ICD.
+    // Overrides for device functions needing a trampoline and
+    // a terminatorbecause ertain device entry-points still need to go
+    // through a terminator before hitting the ICD.  This could be for
+    // several reasons, but the main one is currently unwrapping an
+    // object before passing the appropriate info along to the ICD.
     if ((PFN_vkVoidFunction)disp_table->core_dispatch.CreateSwapchainKHR ==
         (PFN_vkVoidFunction)icd_term->GetDeviceProcAddr(
             device, "vkCreateSwapchainKHR")) {
         disp_table->core_dispatch.CreateSwapchainKHR =
             terminator_vkCreateSwapchainKHR;
+    }
+    if ((PFN_vkVoidFunction)disp_table->core_dispatch.DebugMarkerSetObjectTagEXT ==
+        (PFN_vkVoidFunction)icd_term->GetDeviceProcAddr(
+            device, "vkDebugMarkerSetObjectTagEXT")) {
+        disp_table->core_dispatch.DebugMarkerSetObjectTagEXT =
+            terminator_DebugMarkerSetObjectTagEXT;
+    }
+    if ((PFN_vkVoidFunction)disp_table->core_dispatch.DebugMarkerSetObjectNameEXT ==
+        (PFN_vkVoidFunction)icd_term->GetDeviceProcAddr(
+            device, "vkDebugMarkerSetObjectNameEXT")) {
+        disp_table->core_dispatch.DebugMarkerSetObjectNameEXT =
+            terminator_DebugMarkerSetObjectNameEXT;
     }
 }
 
@@ -3292,12 +3307,17 @@ loader_gpa_device_internal(VkDevice device, const char *pName) {
     struct loader_icd_term *icd_term =
         loader_get_icd_and_device(device, &dev, NULL);
 
-    // Certain device entry-points still need to go through a terminator before
-    // hitting the ICD.  This could be for several reasons, but the main one
-    // is currently unwrapping an object before passing the appropriate info
-    // along to the ICD.
+    // Overrides for device functions needing a trampoline and
+    // a terminatorbecause ertain device entry-points still need to go
+    // through a terminator before hitting the ICD.  This could be for
+    // several reasons, but the main one is currently unwrapping an
+    // object before passing the appropriate info along to the ICD.
     if (!strcmp(pName, "vkCreateSwapchainKHR")) {
         return (PFN_vkVoidFunction)terminator_vkCreateSwapchainKHR;
+    } else if (!strcmp(pName, "vkDebugMarkerSetObjectTagEXT")) {
+        return (PFN_vkVoidFunction)terminator_DebugMarkerSetObjectTagEXT;
+    } else if (!strcmp(pName, "vkDebugMarkerSetObjectNameEXT")) {
+        return (PFN_vkVoidFunction)terminator_DebugMarkerSetObjectNameEXT;
     }
 
     return icd_term->GetDeviceProcAddr(device, pName);

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -200,6 +200,8 @@ struct loader_icd_term {
     PFN_vkCreateDebugReportCallbackEXT CreateDebugReportCallbackEXT;
     PFN_vkDestroyDebugReportCallbackEXT DestroyDebugReportCallbackEXT;
     PFN_vkDebugReportMessageEXT DebugReportMessageEXT;
+    PFN_vkDebugMarkerSetObjectTagEXT DebugMarkerSetObjectTagEXT;
+    PFN_vkDebugMarkerSetObjectNameEXT DebugMarkerSetObjectNameEXT;
     PFN_vkGetPhysicalDeviceSurfaceSupportKHR GetPhysicalDeviceSurfaceSupportKHR;
     PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR
         GetPhysicalDeviceSurfaceCapabilitiesKHR;

--- a/loader/table_ops.h
+++ b/loader/table_ops.h
@@ -541,11 +541,6 @@ loader_lookup_device_dispatch_table(const VkLayerDispatchTable *table,
     if (!strcmp(name, "CmdExecuteCommands"))
         return (void *)table->CmdExecuteCommands;
 
-    if (!strcmp(name, "CreateSwapchainKHR")) {
-        // For CreateSwapChainKHR we need to use trampoline and terminator
-        // functions to properly unwrap the SurfaceKHR object.
-        return (void *)vkCreateSwapchainKHR;
-    }
     if (!strcmp(name, "DestroySwapchainKHR"))
         return (void *)table->DestroySwapchainKHR;
     if (!strcmp(name, "GetSwapchainImagesKHR"))
@@ -554,6 +549,19 @@ loader_lookup_device_dispatch_table(const VkLayerDispatchTable *table,
         return (void *)table->AcquireNextImageKHR;
     if (!strcmp(name, "QueuePresentKHR"))
         return (void *)table->QueuePresentKHR;
+
+    // Overrides for device functions needing a trampoline and
+    // a terminatorbecause ertain device entry-points still need to go
+    // through a terminator before hitting the ICD.  This could be for
+    // several reasons, but the main one is currently unwrapping an
+    // object before passing the appropriate info along to the ICD.
+    if (!strcmp(name, "CreateSwapchainKHR")) {
+        return (void *)vkCreateSwapchainKHR;
+    } else if (!strcmp(name, "DebugMarkerSetObjectTagEXT")) {
+        return (void *)vkDebugMarkerSetObjectTagEXT;
+    } else if (!strcmp(name, "DebugMarkerSetObjectNameEXT")) {
+        return (void *)vkDebugMarkerSetObjectNameEXT;
+    }
 
     return NULL;
 }


### PR DESCRIPTION
Unwrap both the physical device handles and the KHR_surface handles
in the loader during both the trampoline and terminator calls for
DebugMarker commands.  This has to be done since the values given
to a application are the loader trampoline versions, and the values
given to the layers are the loader terminator versions.

Thanks to Baldur (Mr. Renderdoc) for discovering this, testing my
fixes, and resolving a bug.

Change-Id: I7618d71ffee6c53d9842758210a9261f6b3a1797