### PR TITLE
Fix core validation crashes

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -3501,10 +3501,12 @@ TEST_F(VkLayerTest, CommandBufferTwoSubmits) {
 
     err = vkQueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     ASSERT_VK_SUCCESS(err);
+    vkQueueWaitIdle(m_device->m_queue);
 
     // Cause validation error by re-submitting cmd buffer that should only be
     // submitted once
     err = vkQueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    vkQueueWaitIdle(m_device->m_queue);
 
     m_errorMonitor->VerifyFound();
 }

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -243,6 +243,7 @@ Device::~Device() {
         queues_[i].clear();
     }
 
+    vkDeviceWaitIdle(handle());
     vkDestroyDevice(handle(), NULL);
 }
 


### PR DESCRIPTION
Invalid LVT caused a crash in core-validation (RetireWorkOnQueue).  Fixed the test to prevent the bad result that LVT passed back, and added some null-checks to keep the layer from crashing.  Also reverted Tony's commit that undid a change which uncovered this crash.