### PR TITLE
Tobin gh1030 refinement

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9257,7 +9257,7 @@ static bool ValidateBarriers(const char *funcName, VkCommandBuffer cmdBuffer, ui
 
         auto buffer_node = getBufferNode(dev_data, mem_barrier->buffer);
         if (buffer_node) {
-            auto buffer_size = buffer_node->binding.size;
+            auto buffer_size = buffer_node->requirements.size;
             if (mem_barrier->offset >= buffer_size) {
                 skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
                                 DRAWSTATE_INVALID_BARRIER, "DS", "%s: Buffer Barrier 0x%" PRIx64 " has offset 0x%" PRIx64

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5957,18 +5957,22 @@ BindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory mem, VkDeviceS
 
 VKAPI_ATTR void VKAPI_CALL
 GetBufferMemoryRequirements(VkDevice device, VkBuffer buffer, VkMemoryRequirements *pMemoryRequirements) {
-    layer_data *my_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
-    // TODO : What to track here?
-    //   Could potentially save returned mem requirements and validate values passed into BindBufferMemory
-    my_data->dispatch_table.GetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
+    layer_data *dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
+    dev_data->dispatch_table.GetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
+    auto buffer_state = getBufferNode(dev_data, buffer);
+    if (buffer_state) {
+        buffer_state->requirements = *pMemoryRequirements;
+    }
 }
 
 VKAPI_ATTR void VKAPI_CALL
 GetImageMemoryRequirements(VkDevice device, VkImage image, VkMemoryRequirements *pMemoryRequirements) {
-    layer_data *my_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
-    // TODO : What to track here?
-    //   Could potentially save returned mem requirements and validate values passed into BindImageMemory
-    my_data->dispatch_table.GetImageMemoryRequirements(device, image, pMemoryRequirements);
+    layer_data *dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
+    dev_data->dispatch_table.GetImageMemoryRequirements(device, image, pMemoryRequirements);
+    auto image_state = getImageState(dev_data, image);
+    if (image_state) {
+        image_state->requirements = *pMemoryRequirements;
+    }
 }
 
 static bool PreCallValidateDestroyImageView(layer_data *dev_data, VkImageView image_view, IMAGE_VIEW_STATE **image_view_state,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -177,6 +177,18 @@ class BINDABLE : public BASE_NODE {
     // TODO : Need to update solution to track all sparse binding data
     std::unordered_set<MEM_BINDING> sparse_bindings;
     BINDABLE() : sparse(false), binding{}, requirements{}, sparse_bindings{} {};
+    // Return unordered set of memory objects that are bound
+    std::unordered_set<VkDeviceMemory> GetBoundMemory() {
+        std::unordered_set<VkDeviceMemory> mem_set;
+        if (!sparse) {
+            mem_set.insert(binding.mem);
+        } else {
+            for (auto sb : sparse_bindings) {
+                mem_set.insert(sb.mem);
+            }
+        }
+        return mem_set;
+    }
 };
 
 class BUFFER_NODE : public BINDABLE {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -164,17 +164,19 @@ template <> struct hash<MEM_BINDING> {
 };
 }
 
-// Superclass for bindable object state (currently imagesa and buffers)
+// Superclass for bindable object state (currently images and buffers)
 class BINDABLE : public BASE_NODE {
   public:
     bool sparse; // Is this object being bound with sparse memory or not?
     // Non-sparse binding data
     MEM_BINDING binding;
+    // Memory requirements for this BINDABLE
+    VkMemoryRequirements requirements;
     // Sparse binding data, initially just tracking MEM_BINDING per mem object
     //  There's more data for sparse bindings so need better long-term solution
     // TODO : Need to update solution to track all sparse binding data
     std::unordered_set<MEM_BINDING> sparse_bindings;
-    BINDABLE() : sparse(false), binding{}, sparse_bindings{}{};
+    BINDABLE() : sparse(false), binding{}, requirements{}, sparse_bindings{} {};
 };
 
 class BUFFER_NODE : public BINDABLE {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -191,17 +191,17 @@ class BINDABLE : public BASE_NODE {
     }
 };
 
-class BUFFER_NODE : public BINDABLE {
+class BUFFER_STATE : public BINDABLE {
   public:
     VkBuffer buffer;
     VkBufferCreateInfo createInfo;
-    BUFFER_NODE(VkBuffer buff, const VkBufferCreateInfo *pCreateInfo) : buffer(buff), createInfo(*pCreateInfo) {
+    BUFFER_STATE(VkBuffer buff, const VkBufferCreateInfo *pCreateInfo) : buffer(buff), createInfo(*pCreateInfo) {
         if (createInfo.flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
             sparse = true;
         }
     };
 
-    BUFFER_NODE(BUFFER_NODE const &rh_obj) = delete;
+    BUFFER_STATE(BUFFER_STATE const &rh_obj) = delete;
 };
 
 class BUFFER_VIEW_STATE : public BASE_NODE {
@@ -646,7 +646,7 @@ struct layer_data;
 cvdescriptorset::DescriptorSet *getSetNode(const layer_data *, VkDescriptorSet);
 cvdescriptorset::DescriptorSetLayout const *getDescriptorSetLayout(layer_data const *, VkDescriptorSetLayout);
 DESCRIPTOR_POOL_STATE *getDescriptorPoolState(const layer_data *, const VkDescriptorPool);
-BUFFER_NODE *getBufferNode(const layer_data *, VkBuffer);
+BUFFER_STATE *getBufferState(const layer_data *, VkBuffer);
 IMAGE_STATE *getImageState(const layer_data *, VkImage);
 DEVICE_MEM_INFO *getMemObjInfo(const layer_data *, VkDeviceMemory);
 BUFFER_VIEW_STATE *getBufferViewState(const layer_data *, VkBufferView);
@@ -655,12 +655,12 @@ IMAGE_VIEW_STATE *getImageViewState(const layer_data *, VkImageView);
 VkSwapchainKHR getSwapchainFromImage(const layer_data *, VkImage);
 SWAPCHAIN_NODE *getSwapchainNode(const layer_data *, VkSwapchainKHR);
 void invalidateCommandBuffers(std::unordered_set<GLOBAL_CB_NODE *>, VK_OBJECT);
-bool ValidateMemoryIsBoundToBuffer(const layer_data *, const BUFFER_NODE *, const char *);
+bool ValidateMemoryIsBoundToBuffer(const layer_data *, const BUFFER_STATE *, const char *);
 bool ValidateMemoryIsBoundToImage(const layer_data *, const IMAGE_STATE *, const char *);
 void AddCommandBufferBindingSampler(GLOBAL_CB_NODE *, SAMPLER_STATE *);
 void AddCommandBufferBindingImage(const layer_data *, GLOBAL_CB_NODE *, IMAGE_STATE *);
 void AddCommandBufferBindingImageView(const layer_data *, GLOBAL_CB_NODE *, IMAGE_VIEW_STATE *);
-void AddCommandBufferBindingBuffer(const layer_data *, GLOBAL_CB_NODE *, BUFFER_NODE *);
+void AddCommandBufferBindingBuffer(const layer_data *, GLOBAL_CB_NODE *, BUFFER_STATE *);
 void AddCommandBufferBindingBufferView(const layer_data *, GLOBAL_CB_NODE *, BUFFER_VIEW_STATE *);
 }
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -172,11 +172,13 @@ class BINDABLE : public BASE_NODE {
     MEM_BINDING binding;
     // Memory requirements for this BINDABLE
     VkMemoryRequirements requirements;
+    // bool to track if memory requirements were checked
+    bool memory_requirements_checked;
     // Sparse binding data, initially just tracking MEM_BINDING per mem object
     //  There's more data for sparse bindings so need better long-term solution
     // TODO : Need to update solution to track all sparse binding data
     std::unordered_set<MEM_BINDING> sparse_bindings;
-    BINDABLE() : sparse(false), binding{}, requirements{}, sparse_bindings{} {};
+    BINDABLE() : sparse(false), binding{}, requirements{}, memory_requirements_checked(false), sparse_bindings{} {};
     // Return unordered set of memory objects that are bound
     std::unordered_set<VkDeviceMemory> GetBoundMemory() {
         std::unordered_set<VkDeviceMemory> mem_set;

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -406,14 +406,15 @@ bool cvdescriptorset::DescriptorSet::ValidateDrawState(const std::map<uint32_t, 
                             *error = error_str.str();
                             return false;
                         } else {
-                            auto mem_entry = getMemObjInfo(device_data_, buffer_node->binding.mem);
-                            if (!mem_entry) {
-                                std::stringstream error_str;
-                                error_str << "Descriptor in binding #" << binding << " at global descriptor index " << i
-                                          << " uses buffer " << buffer << " that references invalid memory "
-                                          << buffer_node->binding.mem << ".";
-                                *error = error_str.str();
-                                return false;
+                            for (auto mem_binding : buffer_node->GetBoundMemory()) {
+                                if (!getMemObjInfo(device_data_, mem_binding)) {
+                                    std::stringstream error_str;
+                                    error_str << "Descriptor in binding #" << binding << " at global descriptor index " << i
+                                              << " uses buffer " << buffer << " that references invalid memory " << mem_binding
+                                              << ".";
+                                    *error = error_str.str();
+                                    return false;
+                                }
                             }
                         }
                         if (descriptors_[i]->IsDynamic()) {

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -383,7 +383,7 @@ class DescriptorSet : public BASE_NODE {
                                    std::string *) const;
     bool VerifyCopyUpdateContents(const VkCopyDescriptorSet *, const DescriptorSet *, VkDescriptorType, uint32_t,
                                   UNIQUE_VALIDATION_ERROR_CODE *, std::string *) const;
-    bool ValidateBufferUsage(BUFFER_NODE const *, VkDescriptorType, UNIQUE_VALIDATION_ERROR_CODE *, std::string *) const;
+    bool ValidateBufferUsage(BUFFER_STATE const *, VkDescriptorType, UNIQUE_VALIDATION_ERROR_CODE *, std::string *) const;
     bool ValidateBufferUpdate(VkDescriptorBufferInfo const *, VkDescriptorType, UNIQUE_VALIDATION_ERROR_CODE *,
                               std::string *) const;
     // Private helper to set all bound cmd buffers to INVALID state


### PR DESCRIPTION
Replaces #1159 

Fixes #1030 

I found that those initial changes were causing new errors on smoketest. Upon further investigation, smoketest binds memory to a buffer without ever calling vkGetBufferMemoryRequirements().
There's an implication in the spec that this is invalid, although I don't see that it's explicitly stated anywhere.
To deal with this issue initially, I've added warnings in the case where memory is bound to a buffer/image without first checking the requirements and then validation will make the requirements call itself to fill its state.

There is still more work to be done to refactor BindImage/BufferMemory functions to Pre/Post and add proper checks for all of the VUs along with tests. Also need to fix smoketest. I'll open separate issues for these, but this PR is focused on getting the fix in for 1030.