### PR TITLE
layers:Warn on cmd buffer invalidate

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -656,7 +656,7 @@ SAMPLER_STATE *getSamplerState(const layer_data *, VkSampler);
 IMAGE_VIEW_STATE *getImageViewState(const layer_data *, VkImageView);
 VkSwapchainKHR getSwapchainFromImage(const layer_data *, VkImage);
 SWAPCHAIN_NODE *getSwapchainNode(const layer_data *, VkSwapchainKHR);
-void invalidateCommandBuffers(std::unordered_set<GLOBAL_CB_NODE *>, VK_OBJECT);
+void invalidateCommandBuffers(const layer_data *, std::unordered_set<GLOBAL_CB_NODE *>, VK_OBJECT);
 bool ValidateMemoryIsBoundToBuffer(const layer_data *, const BUFFER_STATE *, const char *);
 bool ValidateMemoryIsBoundToImage(const layer_data *, const IMAGE_STATE *, const char *);
 void AddCommandBufferBindingSampler(GLOBAL_CB_NODE *, SAMPLER_STATE *);

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -541,7 +541,7 @@ uint32_t cvdescriptorset::DescriptorSet::GetStorageUpdates(const std::map<uint32
 }
 // Set is being deleted or updates so invalidate all bound cmd buffers
 void cvdescriptorset::DescriptorSet::InvalidateBoundCmdBuffers() {
-    core_validation::invalidateCommandBuffers(cb_bindings,
+    core_validation::invalidateCommandBuffers(device_data_, cb_bindings,
                                               {reinterpret_cast<uint64_t &>(set_), VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT});
 }
 // Perform write update in given update struct


### PR DESCRIPTION
From Mikko Strandborg

When a resource gets deleted, any command buffer that references it
gets invalidated, and an error gets thrown whenever that command buffer
is submitted. However, for a developer, it's quite hard to deduce what
exactly caused that to happen. This patch emits a warning whenever a
command buffer that's in CB_RECORDING state (meaning that it has had
its vkBeginCommandBuffer called but not End). This way the developer
can set a breakpoint on that to see exactly what causes the buffer to
be invalidated.

Destroying a resource that's being used in an open command buffer is
almost certainly a bug, but there might still be cases where it might
be valid behavior (for example, when the application decides to abort
an operation), therefore it's not an error but a warning instead.