### PR TITLE
layers: Handle partial failure in vkCreate*Pipelines

### DIFF
--- a/layers/object_tracker.cpp
+++ b/layers/object_tracker.cpp
@@ -3589,8 +3589,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice device, VkPipeli
     VkResult result = get_dispatch_table(ot_device_table_map, device)
                           ->CreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     lock.lock();
-    if (result == VK_SUCCESS) {
-        for (uint32_t idx2 = 0; idx2 < createInfoCount; ++idx2) {
+    for (uint32_t idx2 = 0; idx2 < createInfoCount; ++idx2) {
+        if (pPipelines[idx2] != VK_NULL_HANDLE) {
             CreateObject(device, pPipelines[idx2], VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, pAllocator);
         }
     }
@@ -3631,8 +3631,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, VkPipelin
     VkResult result = get_dispatch_table(ot_device_table_map, device)
                           ->CreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     lock.lock();
-    if (result == VK_SUCCESS) {
-        for (uint32_t idx1 = 0; idx1 < createInfoCount; ++idx1) {
+    for (uint32_t idx1 = 0; idx1 < createInfoCount; ++idx1) {
+        if (pPipelines[idx1] != VK_NULL_HANDLE) {
             CreateObject(device, pPipelines[idx1], VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, pAllocator);
         }
     }

--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -428,13 +428,15 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, VkPipelin
     VkResult result = my_device_data->device_dispatch_table->CreateComputePipelines(
         device, pipelineCache, createInfoCount, (const VkComputePipelineCreateInfo *)local_pCreateInfos, pAllocator, pPipelines);
     delete[] local_pCreateInfos;
-    if (VK_SUCCESS == result) {
+    {
         uint64_t unique_id = 0;
         std::lock_guard<std::mutex> lock(global_lock);
         for (uint32_t i = 0; i < createInfoCount; ++i) {
-            unique_id = global_unique_id++;
-            my_device_data->unique_id_mapping[unique_id] = reinterpret_cast<uint64_t &>(pPipelines[i]);
-            pPipelines[i] = reinterpret_cast<VkPipeline &>(unique_id);
+            if (pPipelines[i] != VK_NULL_HANDLE) {
+                unique_id = global_unique_id++;
+                my_device_data->unique_id_mapping[unique_id] = reinterpret_cast<uint64_t &>(pPipelines[i]);
+                pPipelines[i] = reinterpret_cast<VkPipeline &>(unique_id);
+            }
         }
     }
     return result;
@@ -484,13 +486,15 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice device, VkPipeli
     VkResult result = my_device_data->device_dispatch_table->CreateGraphicsPipelines(
         device, pipelineCache, createInfoCount, (const VkGraphicsPipelineCreateInfo *)local_pCreateInfos, pAllocator, pPipelines);
     delete[] local_pCreateInfos;
-    if (VK_SUCCESS == result) {
+    {
         uint64_t unique_id = 0;
         std::lock_guard<std::mutex> lock(global_lock);
         for (uint32_t i = 0; i < createInfoCount; ++i) {
-            unique_id = global_unique_id++;
-            my_device_data->unique_id_mapping[unique_id] = reinterpret_cast<uint64_t &>(pPipelines[i]);
-            pPipelines[i] = reinterpret_cast<VkPipeline &>(unique_id);
+            if (pPipelines[i] != VK_NULL_HANDLE) {
+                unique_id = global_unique_id++;
+                my_device_data->unique_id_mapping[unique_id] = reinterpret_cast<uint64_t &>(pPipelines[i]);
+                pPipelines[i] = reinterpret_cast<VkPipeline &>(unique_id);
+            }
         }
     }
     return result;


### PR DESCRIPTION
Hi, this is driven by CTS and deals with an edge case of creating graphics and compute pipelines in bulk.

As per the spec, it's possible to create multiple pipelines with a single call. In case of a failure invalid handles will be set to VK_NULL_HANDLE and the remaining non-NULL handles are valid and must be dealt with correctly.

Currently layers check for an error code and ignore the result completely if there was an error. As a result returned handles aren't sanitized to global ids and are not known to the layers. Attempting to free them is treated as an error by the layers, leading to a memory leak.