### PR TITLE
Fixes, that validation layers do work for VK_KHR_display under Linux

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -12220,6 +12220,11 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(VkInstance instance, VkSurfaceKHR s
     }
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
+													const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+	return CreateSurface(instance, pCreateInfo, pAllocator, pSurface, &VkLayerInstanceDispatchTable::CreateDisplayPlaneSurfaceKHR);
+}
+
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR *pCreateInfo,
                                                        const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
@@ -12615,6 +12620,8 @@ intercept_khr_surface_command(const char *name, VkInstance instance) {
         PFN_vkVoidFunction proc;
         bool instance_layer_data::*enable;
     } khr_surface_commands[] = {
+        {"vkCreateDisplayPlaneSurfaceKHR", reinterpret_cast<PFN_vkVoidFunction>(CreateDisplayPlaneSurfaceKHR),
+            &instance_layer_data::displayExtensionEnabled},
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         {"vkCreateAndroidSurfaceKHR", reinterpret_cast<PFN_vkVoidFunction>(CreateAndroidSurfaceKHR),
             &instance_layer_data::androidSurfaceExtensionEnabled},

--- a/layers/object_tracker.cpp
+++ b/layers/object_tracker.cpp
@@ -2718,6 +2718,27 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInf
     return result;
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
+													        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface) {
+    bool skip_call = false;
+    {
+        std::lock_guard<std::mutex> lock(global_lock);
+        skip_call |= ValidateObject(instance, instance, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, false);
+    }
+    if (skip_call) {
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+    VkResult result =
+        get_dispatch_table(ot_instance_table_map, instance)->CreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+    {
+        std::lock_guard<std::mutex> lock(global_lock);
+        if (result == VK_SUCCESS) {
+            CreateObject(instance, *pSurface, VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT, pAllocator);
+        }
+    }
+    return result;
+}
+
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR *pCreateInfo,
                                                      const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface) {
@@ -3058,6 +3079,8 @@ static inline PFN_vkVoidFunction InterceptWsiEnabledCommand(const char *name, Vk
     if (!strcmp("vkGetPhysicalDeviceSurfacePresentModesKHR", name))
         return reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceSurfacePresentModesKHR);
 
+    if ((instanceExtMap[pTable].display_enabled == true) && !strcmp("vkCreateDisplayPlaneSurfaceKHR", name))
+        return reinterpret_cast<PFN_vkVoidFunction>(CreateDisplayPlaneSurfaceKHR);
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     if ((instanceExtMap[pTable].win32_enabled == true) && !strcmp("vkCreateWin32SurfaceKHR", name))
         return reinterpret_cast<PFN_vkVoidFunction>(CreateWin32SurfaceKHR);
@@ -3124,6 +3147,9 @@ static void CheckInstanceRegisterExtensions(const VkInstanceCreateInfo *pCreateI
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SURFACE_EXTENSION_NAME) == 0) {
             instanceExtMap[pDisp].wsi_enabled = true;
+        }
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_DISPLAY_EXTENSION_NAME) == 0) {
+        	instanceExtMap[pDisp].display_enabled = true;
         }
 #ifdef VK_USE_PLATFORM_XLIB_KHR
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_XLIB_SURFACE_EXTENSION_NAME) == 0) {

--- a/layers/object_tracker.h
+++ b/layers/object_tracker.h
@@ -81,6 +81,7 @@ struct instance_extension_enables {
     bool mir_enabled;
     bool android_enabled;
     bool win32_enabled;
+    bool display_enabled;
 };
 
 typedef std::unordered_map<uint64_t, OBJTRACK_NODE *> object_map_type;

--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -676,6 +676,30 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(VkPhysicalDevice phys
     }
     return result;
 }
+
+VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkDisplayModeKHR mode,
+															  uint32_t planeIndex, VkDisplayPlaneCapabilitiesKHR* pCapabilities) {
+    layer_data *dev_data = get_my_data_ptr(get_dispatch_key(physicalDevice), layer_data_map);
+    {
+        std::lock_guard<std::mutex> lock(global_lock);
+        auto it = dev_data->unique_id_mapping.find(reinterpret_cast<uint64_t &>(mode));
+        if (it == dev_data->unique_id_mapping.end())
+        {
+            uint64_t unique_id = global_unique_id++;
+            dev_data->unique_id_mapping[unique_id] = reinterpret_cast<uint64_t &>(mode);
+
+            mode = reinterpret_cast<VkDisplayModeKHR &>(unique_id);
+        }
+        else
+        {
+        	mode = reinterpret_cast<VkDisplayModeKHR &>(it->second);
+        }
+    }
+
+    VkResult result = dev_data->instance_dispatch_table->GetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities);
+
+    return result;
+}
 #endif
 
 } // namespace unique_objects

--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -146,6 +146,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             'vkGetPhysicalDeviceDisplayPlanePropertiesKHR',
             'vkGetDisplayPlaneSupportedDisplaysKHR',
             'vkGetDisplayModePropertiesKHR',
+            'vkGetDisplayPlaneCapabilitiesKHR',
             # DebugReport APIs are hooked, but handled separately in the source file
             'vkCreateDebugReportCallbackEXT',
             'vkDestroyDebugReportCallbackEXT',

--- a/scripts/vulkan.py
+++ b/scripts/vulkan.py
@@ -1375,6 +1375,7 @@ win32_wsi_exts = [VK_KHR_win32_surface
 common_exts = [VK_VERSION_1_0,
                VK_KHR_surface,
                VK_KHR_swapchain,
+               VK_KHR_display,
                VK_KHR_display_swapchain,
               ]
 
@@ -1399,6 +1400,7 @@ non_exported_exts = [VK_NV_external_memory_capabilities,
 #                    VK_IMG_format_pvrtc,
                     ]
 non_android_exts = [VK_KHR_display,
+                    VK_KHR_display_swapchain,
                    ]
 extensions = common_exts
 extensions_all = non_exported_exts
@@ -1410,6 +1412,8 @@ elif sys.argv[1] in linux_display_servers:
     extensions += linux_wsi_exts
     extensions_all += extensions + linux_only_exts
 elif sys.argv[1] in android_display_servers:
+    extensions = [x for x in extensions if x not in non_android_exts]
+
     extensions += android_wsi_exts
     extensions_all += extensions + android_only_exts
 else:


### PR DESCRIPTION
At the moment, if VK_KHR_display extension is used, the validation layers do crash.

The fixes in this pull request do solve the problem.
Tested on i.MX8 using Linux OS.