### PR TITLE
layers:Handle NULL DebugMarker function ptrs

### DIFF
--- a/layers/object_tracker.cpp
+++ b/layers/object_tracker.cpp
@@ -3216,6 +3216,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevice, con
 
     layer_data *device_data = get_my_data_ptr(get_dispatch_key(*pDevice), layer_data_map);
     device_data->report_data = layer_debug_report_create_device(phy_dev_data->report_data, *pDevice);
+    layer_init_device_dispatch_table(*pDevice, &device_data->dispatch_table, fpGetDeviceProcAddr);
 
     // Add link back to physDev
     device_data->physical_device = physicalDevice;
@@ -3690,7 +3691,11 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(VkDevice device, VkDeb
     if (skip_call) {
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
-    VkResult result = get_dispatch_table(ot_device_table_map, device)->DebugMarkerSetObjectTagEXT(device, pTagInfo);
+    layer_data *dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
+    VkResult result = VK_SUCCESS;
+    if (dev_data->dispatch_table.DebugMarkerSetObjectTagEXT) {
+        result = dev_data->dispatch_table.DebugMarkerSetObjectTagEXT(device, pTagInfo);
+    }
     return result;
 }
 
@@ -3702,7 +3707,11 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(VkDevice device, VkDe
     if (skip_call) {
         return VK_ERROR_VALIDATION_FAILED_EXT;
     }
-    VkResult result = get_dispatch_table(ot_device_table_map, device)->DebugMarkerSetObjectNameEXT(device, pNameInfo);
+    layer_data *dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
+    VkResult result = VK_SUCCESS;
+    if (dev_data->dispatch_table.DebugMarkerSetObjectNameEXT) {
+        result = dev_data->dispatch_table.DebugMarkerSetObjectNameEXT(device, pNameInfo);
+    }
     return result;
 }
 
@@ -3712,8 +3721,9 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer,
     skip_call |=
         ValidateObject(commandBuffer, commandBuffer, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, false, VALIDATION_ERROR_02014);
     lock.unlock();
-    if (!skip_call) {
-        get_dispatch_table(ot_device_table_map, commandBuffer)->CmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
+    layer_data *dev_data = get_my_data_ptr(get_dispatch_key(commandBuffer), layer_data_map);
+    if (!skip_call && dev_data->dispatch_table.CmdDebugMarkerBeginEXT) {
+        dev_data->dispatch_table.CmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
     }
 }
 
@@ -3723,8 +3733,9 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer) {
     skip_call |=
         ValidateObject(commandBuffer, commandBuffer, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, false, VALIDATION_ERROR_02022);
     lock.unlock();
-    if (!skip_call) {
-        get_dispatch_table(ot_device_table_map, commandBuffer)->CmdDebugMarkerEndEXT(commandBuffer);
+    layer_data *dev_data = get_my_data_ptr(get_dispatch_key(commandBuffer), layer_data_map);
+    if (!skip_call && dev_data->dispatch_table.CmdDebugMarkerEndEXT) {
+        dev_data->dispatch_table.CmdDebugMarkerEndEXT(commandBuffer);
     }
 }
 
@@ -3734,8 +3745,9 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer
     skip_call |=
         ValidateObject(commandBuffer, commandBuffer, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, false, VALIDATION_ERROR_02025);
     lock.unlock();
-    if (!skip_call) {
-        get_dispatch_table(ot_device_table_map, commandBuffer)->CmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
+    layer_data *dev_data = get_my_data_ptr(get_dispatch_key(commandBuffer), layer_data_map);
+    if (!skip_call && dev_data->dispatch_table.CmdDebugMarkerInsertEXT) {
+        dev_data->dispatch_table.CmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
     }
 }
 

--- a/layers/object_tracker.h
+++ b/layers/object_tracker.h
@@ -113,11 +113,12 @@ struct layer_data {
     // Map of queue information structures, one per queue
     std::unordered_map<VkQueue, OT_QUEUE_INFO *> queue_info_map;
 
+    VkLayerDispatchTable dispatch_table;
     // Default constructor
     layer_data()
         : instance(nullptr), physical_device(nullptr), num_objects{}, num_total_objects(0), report_data(nullptr),
           wsi_enabled(false), wsi_display_swapchain_enabled(false), objtrack_extensions_enabled(false), num_tmp_callbacks(0),
-          tmp_dbg_create_infos(nullptr), tmp_callbacks(nullptr), object_map{} {
+          tmp_dbg_create_infos(nullptr), tmp_callbacks(nullptr), object_map{}, dispatch_table{} {
         object_map.resize(VK_DEBUG_REPORT_OBJECT_TYPE_RANGE_SIZE_EXT + 1);
     }
 };

--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -5421,9 +5421,12 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(VkDevice device, VkDeb
     skip |= parameter_validation_vkDebugMarkerSetObjectTagEXT(my_data->report_data, pTagInfo);
 
     if (!skip) {
-        result = my_data->dispatch_table.DebugMarkerSetObjectTagEXT(device, pTagInfo);
-
-        validate_result(my_data->report_data, "vkDebugMarkerSetObjectTagEXT", result);
+        if (my_data->dispatch_table.DebugMarkerSetObjectTagEXT) {
+            result = my_data->dispatch_table.DebugMarkerSetObjectTagEXT(device, pTagInfo);
+            validate_result(my_data->report_data, "vkDebugMarkerSetObjectTagEXT", result);
+        } else {
+            result = VK_SUCCESS;
+        }
     }
 
     return result;
@@ -5438,9 +5441,12 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(VkDevice device, VkDe
     skip |= parameter_validation_vkDebugMarkerSetObjectNameEXT(my_data->report_data, pNameInfo);
 
     if (!skip) {
-        VkResult result = my_data->dispatch_table.DebugMarkerSetObjectNameEXT(device, pNameInfo);
-
-        validate_result(my_data->report_data, "vkDebugMarkerSetObjectNameEXT", result);
+        if (my_data->dispatch_table.DebugMarkerSetObjectNameEXT) {
+            result = my_data->dispatch_table.DebugMarkerSetObjectNameEXT(device, pNameInfo);
+            validate_result(my_data->report_data, "vkDebugMarkerSetObjectNameEXT", result);
+        } else {
+            result = VK_SUCCESS;
+        }
     }
 
     return result;
@@ -5453,7 +5459,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(VkCommandBuffer commandBuffer,
 
     skip |= parameter_validation_vkCmdDebugMarkerBeginEXT(my_data->report_data, pMarkerInfo);
 
-    if (!skip) {
+    if (!skip && my_data->dispatch_table.CmdDebugMarkerBeginEXT) {
         my_data->dispatch_table.CmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
     }
 }
@@ -5465,7 +5471,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(VkCommandBuffer commandBuffer
 
     skip |= parameter_validation_vkCmdDebugMarkerInsertEXT(my_data->report_data, pMarkerInfo);
 
-    if (!skip) {
+    if (!skip && my_data->dispatch_table.CmdDebugMarkerInsertEXT) {
         my_data->dispatch_table.CmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
     }
 }


### PR DESCRIPTION
Fixes #1074

Object_tracker and parameter_checker intercept DebugMarker extension
functions which may not be supported by underlying device and
therefore could terminate with a NULL function call.
Updating these layers to handle this case by making sure that their
downstream function ptr is not null before calling down the chain.
If the downstream function ptr is null, considering that VK_SUCCESS
in the layers for functions with VkResult return code.