### PR TITLE
Smoke Android layers

### DIFF
--- a/demos/smoke/Main.cpp
+++ b/demos/smoke/Main.cpp
@@ -21,6 +21,11 @@
 
 namespace {
 
+Game *create_game(const std::vector<std::string> &args)
+{
+    return new Smoke(args);
+}
+
 Game *create_game(int argc, char **argv)
 {
     std::vector<std::string> args(argv, argv + argc);
@@ -67,7 +72,7 @@ int main(int argc, char **argv) {
 
 void android_main(android_app *app)
 {
-    Game *game = create_game(0, nullptr);
+    Game *game = create_game(ShellAndroid::get_args(*app));
 
     try {
         ShellAndroid shell(*app, *game);

--- a/demos/smoke/Shell.cpp
+++ b/demos/smoke/Shell.cpp
@@ -32,9 +32,7 @@ Shell::Shell(Game &game)
     instance_extensions_.push_back(VK_KHR_SURFACE_EXTENSION_NAME);
     device_extensions_.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
-    // require "standard" validation layers
     if (settings_.validate) {
-        instance_layers_.push_back("VK_LAYER_LUNARG_standard_validation");
         instance_extensions_.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
     }
 }

--- a/demos/smoke/ShellAndroid.cpp
+++ b/demos/smoke/ShellAndroid.cpp
@@ -67,6 +67,14 @@ private:
 
 ShellAndroid::ShellAndroid(android_app &app, Game &game) : Shell(game), app_(app)
 {
+    instance_layers_.push_back("VK_LAYER_GOOGLE_threading");
+    instance_layers_.push_back("VK_LAYER_LUNARG_parameter_validation");
+    instance_layers_.push_back("VK_LAYER_LUNARG_object_tracker");
+    instance_layers_.push_back("VK_LAYER_LUNARG_image");
+    instance_layers_.push_back("VK_LAYER_LUNARG_core_validation");
+    instance_layers_.push_back("VK_LAYER_LUNARG_swapchain");
+    instance_layers_.push_back("VK_LAYER_GOOGLE_unique_objects");
+
     instance_extensions_.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
 
     app_dummy();

--- a/demos/smoke/ShellAndroid.h
+++ b/demos/smoke/ShellAndroid.h
@@ -22,6 +22,8 @@
 
 class ShellAndroid : public Shell {
 public:
+    static std::vector<std::string> get_args(android_app &app);
+
     ShellAndroid(android_app &app, Game &game);
     ~ShellAndroid();
 

--- a/demos/smoke/ShellWayland.cpp
+++ b/demos/smoke/ShellWayland.cpp
@@ -109,6 +109,7 @@ void ShellWayland::handle_popup_done(
     void *data UNUSED, struct wl_shell_surface *shell_surface UNUSED) {}
 
 ShellWayland::ShellWayland(Game &game) : Shell(game) {
+    instance_layers_.push_back("VK_LAYER_LUNARG_standard_validation");
     instance_extensions_.push_back(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
 
     init_connection();

--- a/demos/smoke/ShellWin32.cpp
+++ b/demos/smoke/ShellWin32.cpp
@@ -57,6 +57,7 @@ private:
 
 ShellWin32::ShellWin32(Game &game) : Shell(game), hwnd_(nullptr)
 {
+    instance_layers_.push_back("VK_LAYER_LUNARG_standard_validation");
     instance_extensions_.push_back(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
     init_vk();
 }

--- a/demos/smoke/ShellXcb.cpp
+++ b/demos/smoke/ShellXcb.cpp
@@ -83,6 +83,7 @@ xcb_atom_t intern_atom(xcb_connection_t *c, xcb_intern_atom_cookie_t cookie)
 
 ShellXcb::ShellXcb(Game &game) : Shell(game)
 {
+    instance_layers_.push_back("VK_LAYER_LUNARG_standard_validation");
     instance_extensions_.push_back(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
 
     init_connection();

--- a/demos/smoke/android/build.gradle
+++ b/demos/smoke/android/build.gradle
@@ -14,6 +14,7 @@ def demosDir = "../.."
 def smokeDir = "${demosDir}/smoke"
 def glmDir = "${demosDir}/../libs"
 def vulkanDir = "${demosDir}/../include"
+def layersDir = "${demosDir}/../build-android/libs"
 
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
@@ -66,6 +67,11 @@ model {
                     exclude 'ShellXcb.cpp'
                     exclude 'ShellWin32.cpp'
                     exclude 'ShellWayland.cpp'
+                }
+            }
+            jniLibs {
+                dependencies {
+                    source.srcDir "${layersDir}"
                 }
             }
         }


### PR DESCRIPTION
This series allows us to package validation layers with Smoke and enable them on Android.

Since Smoke only exists in this repo for validating that layers are working correctly, the layers are packaged into the APK unconditionally.

This change is primarily driven by downstream needs for using Smoke to verify that persistently mapped buffer support is working with vktrace.

The biggest change is a direct port of arg parsing from Hologram that didn't make the original cutoff.

There should be no change in desktop functionality.
