### PR TITLE
Generate vk_dispatch_table_helper.h files using vk.xml

### DIFF
--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -19,12 +19,11 @@ if exist generated (
 )
 mkdir generated\include generated\common
 
-python ../scripts/vk-generate.py Android dispatch-table-ops layer > generated/include/vk_dispatch_table_helper.h
-
 python ../scripts/vk_helper.py --gen_enum_string_helper ../include/vulkan/vulkan.h --abs_out_dir generated/include
 python ../scripts/vk_helper.py --gen_struct_wrappers ../include/vulkan/vulkan.h --abs_out_dir generated/include
 
 cd generated/include
+python ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_dispatch_table_helper.h
 python ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml thread_check.h
 python ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml parameter_validation.h
 python ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml unique_objects_wrappers.h

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -21,11 +21,10 @@ cd $dir
 rm -rf generated
 mkdir -p generated/include generated/common
 
-python ../scripts/vk-generate.py Android dispatch-table-ops layer > generated/include/vk_dispatch_table_helper.h
-
 python ../scripts/vk_helper.py --gen_enum_string_helper ../include/vulkan/vulkan.h --abs_out_dir generated/include
 python ../scripts/vk_helper.py --gen_struct_wrappers ../include/vulkan/vulkan.h --abs_out_dir generated/include
 
+( cd generated/include; python ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_dispatch_table_helper.h )
 ( cd generated/include; python ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml thread_check.h )
 ( cd generated/include; python ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml parameter_validation.h )
 ( cd generated/include; python ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml unique_objects_wrappers.h )

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -113,10 +113,6 @@ else()
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Wno-unused-function -Wno-sign-compare")
 endif()
 
-add_custom_command(OUTPUT vk_dispatch_table_helper.h
-    COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/vk-generate.py AllPlatforms dispatch-table-ops layer > vk_dispatch_table_helper.h
-    DEPENDS ${SCRIPTS_DIR}/vk-generate.py ${SCRIPTS_DIR}/vulkan.py)
-
 run_vk_helper(gen_enum_string_helper vk_enum_string_helper.h)
 run_vk_helper(gen_struct_wrappers
     vk_struct_string_helper.h
@@ -168,6 +164,7 @@ add_custom_target(generate_vk_layer_helpers DEPENDS
 run_vk_layer_xml_generate(threading_generator.py thread_check.h)
 run_vk_layer_xml_generate(parameter_validation_generator.py parameter_validation.h)
 run_vk_layer_xml_generate(unique_objects_generator.py unique_objects_wrappers.h)
+run_vk_layer_xml_generate(dispatch_table_generator.py vk_dispatch_table_helper.h)
 
 # Layer Utils Library
 # For Windows, we use a static lib because the Windows loader has a fairly restrictive loader search

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -7,7 +7,7 @@ macro(run_vk_helper subcmd)
     )
 endmacro()
 
-macro(run_vk_layer_xml_generate dependency output)
+macro(run_vk_xml_generate dependency output)
     add_custom_command(OUTPUT ${output}
         COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml ${output}
         DEPENDS ${SCRIPTS_DIR}/vk.xml ${SCRIPTS_DIR}/generator.py ${SCRIPTS_DIR}/${dependency} ${SCRIPTS_DIR}/lvl_genvk.py ${SCRIPTS_DIR}/reg.py
@@ -161,10 +161,10 @@ add_custom_target(generate_vk_layer_helpers DEPENDS
     vk_safe_struct.cpp
 )
 
-run_vk_layer_xml_generate(threading_generator.py thread_check.h)
-run_vk_layer_xml_generate(parameter_validation_generator.py parameter_validation.h)
-run_vk_layer_xml_generate(unique_objects_generator.py unique_objects_wrappers.h)
-run_vk_layer_xml_generate(dispatch_table_generator.py vk_dispatch_table_helper.h)
+run_vk_xml_generate(threading_generator.py thread_check.h)
+run_vk_xml_generate(parameter_validation_generator.py parameter_validation.h)
+run_vk_xml_generate(unique_objects_generator.py unique_objects_wrappers.h)
+run_vk_xml_generate(dispatch_table_generator.py vk_dispatch_table_helper.h)
 
 # Layer Utils Library
 # For Windows, we use a static lib because the Windows loader has a fairly restrictive loader search

--- a/scripts/dispatch_table_generator.py
+++ b/scripts/dispatch_table_generator.py
@@ -1,0 +1,196 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2015-2016 The Khronos Group Inc.
+# Copyright (c) 2015-2016 Valve Corporation
+# Copyright (c) 2015-2016 LunarG, Inc.
+# Copyright (c) 2015-2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Mark Lobodzinski <mark@lunarg.com>
+
+import os,re,sys
+import xml.etree.ElementTree as etree
+from generator import *
+from collections import namedtuple
+
+#
+# DispatchTableOutputGeneratorOptions - subclass of GeneratorOptions.
+class DispatchTableOutputGeneratorOptions(GeneratorOptions):
+    def __init__(self,
+                 filename = None,
+                 directory = '.',
+                 apiname = None,
+                 profile = None,
+                 versions = '.*',
+                 emitversions = '.*',
+                 defaultExtensions = None,
+                 addExtensions = None,
+                 removeExtensions = None,
+                 sortProcedure = regSortFeatures,
+                 prefixText = "",
+                 genFuncPointers = True,
+                 protectFile = True,
+                 protectFeature = True,
+                 protectProto = None,
+                 protectProtoStr = None,
+                 apicall = '',
+                 apientry = '',
+                 apientryp = '',
+                 alignFuncParam = 0):
+        GeneratorOptions.__init__(self, filename, directory, apiname, profile,
+                                  versions, emitversions, defaultExtensions,
+                                  addExtensions, removeExtensions, sortProcedure)
+        self.prefixText      = prefixText
+        self.genFuncPointers = genFuncPointers
+        self.prefixText      = None
+        self.protectFile     = protectFile
+        self.protectFeature  = protectFeature
+        self.protectProto    = protectProto
+        self.protectProtoStr = protectProtoStr
+        self.apicall         = apicall
+        self.apientry        = apientry
+        self.apientryp       = apientryp
+        self.alignFuncParam  = alignFuncParam
+#
+# DispatchTableOutputGenerator - subclass of OutputGenerator.
+# Generates dispatch table helper header files for LVL
+class DispatchTableOutputGenerator(OutputGenerator):
+    """Generate dispatch table helper header based on XML element attributes"""
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        OutputGenerator.__init__(self, errFile, warnFile, diagFile)
+        # Internal state - accumulators for different inner block text
+        self.instance_dispatch_list = []      # List of entries for instance dispatch list
+        self.device_dispatch_list = []        # List of entries for device dispatch list
+    #
+    # Called once at the beginning of each run
+    def beginFile(self, genOpts):
+        OutputGenerator.beginFile(self, genOpts)
+        # User-supplied prefix text, if any (list of strings)
+        if (genOpts.prefixText):
+            for s in genOpts.prefixText:
+                write(s, file=self.outFile)
+        # File Comment
+        file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
+        file_comment += '// See dispatch_table_generator.py for modifications\n'
+        write(file_comment, file=self.outFile)
+        # Copyright Notice
+        copyright =  '/*\n'
+        copyright += ' * Copyright (c) 2015-2016 The Khronos Group Inc.\n'
+        copyright += ' * Copyright (c) 2015-2016 Valve Corporation\n'
+        copyright += ' * Copyright (c) 2015-2016 LunarG, Inc.\n'
+        copyright += ' *\n'
+        copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
+        copyright += ' * you may not use this file except in compliance with the License.\n'
+        copyright += ' * You may obtain a copy of the License at\n'
+        copyright += ' *\n'
+        copyright += ' *     http://www.apache.org/licenses/LICENSE-2.0\n'
+        copyright += ' *\n'
+        copyright += ' * Unless required by applicable law or agreed to in writing, software\n'
+        copyright += ' * distributed under the License is distributed on an "AS IS" BASIS,\n'
+        copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
+        copyright += ' * See the License for the specific language governing permissions and\n'
+        copyright += ' * limitations under the License.\n'
+        copyright += ' *\n'
+        copyright += ' * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>\n'
+        copyright += ' * Author: Jon Ashburn <jon@lunarg.com>\n'
+        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
+        copyright += ' */\n'
+
+        preamble = ''
+        preamble += '#include <vulkan/vulkan.h>\n'
+        preamble += '#include <vulkan/vk_layer.h>\n'
+        preamble += '#include <string.h>\n'
+
+        write(copyright, file=self.outFile)
+        write(preamble, file=self.outFile)
+    #
+    # Write generate and write dispatch tables to output file
+    def endFile(self):
+        device_table = ''
+        instance_table = ''
+
+        device_table += self.OutputDispatchTable('device')
+        instance_table += self.OutputDispatchTable('instance')
+
+        write(device_table, file=self.outFile);
+        write(instance_table, file=self.outFile);
+
+        # Finish processing in superclass
+        OutputGenerator.endFile(self)
+    #
+    # Process commands, adding to appropriate dispatch tables
+    def genCmd(self, cmdinfo, name):
+        OutputGenerator.genCmd(self, cmdinfo, name)
+
+        avoid_entries = ['vkCreateInstance',
+                         'vkCreateDevice']
+        # Get first param type
+        params = cmdinfo.elem.findall('param')
+        info = self.getTypeNameTuple(params[0])
+
+        if name not in avoid_entries:
+            self.AddCommandToDispatchList(name, info[0], self.featureExtraProtect)
+
+    #
+    # Determine if this API should be ignored or added to the instance or device dispatch table
+    def AddCommandToDispatchList(self, name, handle_type, protect):
+        handle = self.registry.tree.find("types/type/[name='" + handle_type + "'][@category='handle']")
+        if handle == None:
+            return
+        if handle_type != 'VkInstance' and handle_type != 'VkPhysicalDevice' and name != 'vkGetInstanceProcAddr':
+            self.device_dispatch_list.append((name, self.featureExtraProtect))
+        else:
+            self.instance_dispatch_list.append((name, self.featureExtraProtect))
+        return
+    #
+    # Retrieve the type and name for a parameter
+    def getTypeNameTuple(self, param):
+        type = ''
+        name = ''
+        for elem in param:
+            if elem.tag == 'type':
+                type = noneStr(elem.text)
+            elif elem.tag == 'name':
+                name = noneStr(elem.text)
+        return (type, name)
+    #
+    # Create a dispatch table from the appropriate list and return it as a string
+    def OutputDispatchTable(self, table_type):
+        entries = []
+        table = ''
+        if table_type == 'device':
+            entries = self.device_dispatch_list
+            table += 'static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDispatchTable *table, PFN_vkGetDeviceProcAddr gpa) {\n'
+            table += '    memset(table, 0, sizeof(*table));\n'
+            table += '    // Device function pointers\n'
+        else:
+            entries = self.instance_dispatch_list
+            table += 'static inline void layer_init_instance_dispatch_table(VkInstance instance, VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa) {\n'
+            table += '    memset(table, 0, sizeof(*table));\n'
+            table += '    // Instance function pointers\n'
+
+        for item in entries:
+            # Remove 'vk' from proto name
+            base_name = item[0][2:]
+
+            if item[1] is not None:
+                table += '#ifdef %s\n' % item[1]
+            table += '    table->%s = (PFN_%s) gpa(%s, "%s");\n' % (base_name, item[0], table_type, item[0])
+            if item[1] is not None:
+                table += '#endif // %s\n' % item[1]
+        table += '}\n\n'
+        return table

--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -23,6 +23,7 @@ from generator import write
 from threading_generator import  ThreadGeneratorOptions, ThreadOutputGenerator
 from parameter_validation_generator import ParamCheckerGeneratorOptions, ParamCheckerOutputGenerator
 from unique_objects_generator import UniqueObjectsGeneratorOptions, UniqueObjectsOutputGenerator
+from dispatch_table_generator import DispatchTableOutputGenerator, DispatchTableOutputGeneratorOptions
 
 # Simple timer functions
 startTime = None
@@ -159,6 +160,30 @@ def makeGenOpts(extensions = [], protect = True, directory = '.'):
             apientryp         = 'VKAPI_PTR *',
             alignFuncParam    = 48)
         ]
+
+
+    # Options for dispatch table helper generator
+    genOpts['vk_dispatch_table_helper.h'] = [
+          DispatchTableOutputGenerator,
+          DispatchTableOutputGeneratorOptions(
+            filename          = 'vk_dispatch_table_helper.h',
+            directory         = directory,
+            apiname           = 'vulkan',
+            profile           = None,
+            versions          = allVersions,
+            emitversions      = allVersions,
+            defaultExtensions = 'vulkan',
+            addExtensions     = addExtensions,
+            removeExtensions  = removeExtensions,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            protectFeature    = False,
+            apicall           = 'VKAPI_ATTR ',
+            apientry          = 'VKAPI_CALL ',
+            apientryp         = 'VKAPI_PTR *',
+            alignFuncParam    = 48)
+        ]
+
+
 
 # Generate a target based on the options in the matching genOpts{} object.
 # This is encapsulated in a function so it can be profiled and/or timed.

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -87,16 +87,14 @@ run_vk_xml_generate(dispatch_table_generator.py vk_dispatch_table_helper.h)
 
 set (WRAP_SRCS
        wrap_objects.cpp
-	   ${CMAKE_CURRENT_SOURCE_DIR}/../../layers/vk_layer_table.cpp
-	   ${CMAKE_CURRENT_SOURCE_DIR}/../../layers/vk_layer_extension_utils.cpp
-	   )
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../layers/vk_layer_table.cpp
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../layers/vk_layer_extension_utils.cpp
+       )
 add_vk_layer(wrap_objects ${WRAP_SRCS})
 
 set (TEST_SRCS
        test.cpp
-	   ${CMAKE_CURRENT_SOURCE_DIR}/../../layers/vk_layer_table.cpp
-	   ${CMAKE_CURRENT_SOURCE_DIR}/../../layers/vk_layer_extension_utils.cpp
-	   )
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../layers/vk_layer_table.cpp
+       ${CMAKE_CURRENT_SOURCE_DIR}/../../layers/vk_layer_extension_utils.cpp
+       )
 add_vk_layer(test ${TEST_SRCS})
-
-

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -8,6 +8,13 @@ set(LAYER_JSON_FILES
 set(VK_LAYER_RPATH /usr/lib/x86_64-linux-gnu/vulkan/layer:/usr/lib/i386-linux-gnu/vulkan/layer)
 set(CMAKE_INSTALL_RPATH ${VK_LAYER_RPATH})
 
+macro(run_vk_xml_generate dependency output)
+    add_custom_command(OUTPUT ${output}
+        COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/lvl_genvk.py -registry ${SCRIPTS_DIR}/vk.xml ${output}
+        DEPENDS ${SCRIPTS_DIR}/vk.xml ${SCRIPTS_DIR}/generator.py ${SCRIPTS_DIR}/${dependency} ${SCRIPTS_DIR}/lvl_genvk.py ${SCRIPTS_DIR}/reg.py
+    )
+endmacro()
+
 if (WIN32)
     if (NOT (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR))
         foreach (config_file ${LAYER_JSON_FILES})
@@ -72,13 +79,11 @@ else()
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Wno-unused-function")
 endif()
 
-add_custom_command(OUTPUT vk_dispatch_table_helper.h
-    COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/vk-generate.py AllPlatforms dispatch-table-ops layer > vk_dispatch_table_helper.h
-    DEPENDS ${SCRIPTS_DIR}/vk-generate.py ${SCRIPTS_DIR}/vulkan.py)
-
 add_custom_target(generate_tests_dispatch_table_helper DEPENDS
     vk_dispatch_table_helper.h
 )
+
+run_vk_xml_generate(dispatch_table_generator.py vk_dispatch_table_helper.h)
 
 set (WRAP_SRCS
        wrap_objects.cpp


### PR DESCRIPTION
Generating these header files was done via vk-generate.py based on parsing the header or hand-edited API metadata scripts.  Moved to using standard codegen.  Def files are next (will remove the vk-generate script after all functionality is migrated and trunk merges are complete).