### PR TITLE
Tobin pre post refactor

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -86,6 +86,10 @@ struct CHECK_DISABLED {
     bool free_descriptor_sets; // Skip validation prior to vkFreeDescriptorSets()
     bool allocate_descriptor_sets; // Skip validation prior to vkAllocateDescriptorSets()
     bool update_descriptor_sets;   // Skip validation prior to vkUpdateDescriptorSets()
+    bool wait_for_fences;
+    bool get_fence_state;
+    bool queue_wait_idle;
+    bool device_wait_idle;
 };
 
 /*


### PR DESCRIPTION
Started to refactor a few functions for Pre/Post pattern and ran into RetireWorkOnQueue which still had a bit of validation mingled with state update so I pulled out the validation and split up related functions to do validation prior to calling down chain and only update state after the call down the chain.

Also added flags to the refactored API functions.