### PR TITLE
layers:Add undefined validation error enum

### DIFF
--- a/layers/object_tracker.cpp
+++ b/layers/object_tracker.cpp
@@ -316,8 +316,6 @@ static void DestroyObject(T1 dispatchable_object, T2 object, VkDebugReportObject
     }
 }
 
-static const int VALIDATION_ERROR_UNDEFINED = -1;
-
 template <typename T1, typename T2>
 static bool ValidateObject(T1 dispatchable_object, T2 object, VkDebugReportObjectTypeEXT object_type, bool null_allowed,
                            int error_code) {

--- a/layers/spec.py
+++ b/layers/spec.py
@@ -175,7 +175,7 @@ class Specification:
         file_contents.append('//  Corresponding validation error message for each enum is given in the mapping table below')
         file_contents.append('//  When a given error occurs, these enum values should be passed to the as the messageCode')
         file_contents.append('//  parameter to the PFN_vkDebugReportCallbackEXT function')
-        enum_decl = ['enum UNIQUE_VALIDATION_ERROR_CODE {']
+        enum_decl = ['enum UNIQUE_VALIDATION_ERROR_CODE {\n    VALIDATION_ERROR_UNDEFINED = -1,']
         error_string_map = ['static std::unordered_map<int, char const *const> validation_error_map{']
         for enum in sorted(self.val_error_dict):
             #print "Header enum is %s" % (enum)

--- a/layers/vk_validation_error_messages.h
+++ b/layers/vk_validation_error_messages.h
@@ -29,6 +29,7 @@
 //  When a given error occurs, these enum values should be passed to the as the messageCode
 //  parameter to the PFN_vkDebugReportCallbackEXT function
 enum UNIQUE_VALIDATION_ERROR_CODE {
+    VALIDATION_ERROR_UNDEFINED = -1,
     VALIDATION_ERROR_00000 = 0,
     VALIDATION_ERROR_00001 = 1,
     VALIDATION_ERROR_00002 = 2,


### PR DESCRIPTION
Add VALIDATION_ERROR_UNDEFINED to UNIQUE_VALIDATION_ERROR_CODE enum
with a value of "-1". This had been custom-defined in
object_tracker.cpp so removing it from there.