### PR TITLE
scripts:Make stats script work with python3

### DIFF
--- a/layers/vk_validation_stats.py
+++ b/layers/vk_validation_stats.py
@@ -73,7 +73,7 @@ class ValidationDatabase:
                     continue
                 db_line = line.split(self.delimiter)
                 if len(db_line) != 6:
-                    print "ERROR: Bad database line doesn't have 6 elements: %s" % (line)
+                    print("ERROR: Bad database line doesn't have 6 elements: %s" % (line))
                 error_enum = db_line[0]
                 implemented = db_line[1]
                 testname = db_line[2]


### PR DESCRIPTION
Just needed parens around the single print so that the
vk_validation_stats.py script will run with python3.

@mark-lunarg this should allow #1242 to run on Windows systems w/ python3 default.