### PR TITLE
Disable header-reordering for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,4 +2,5 @@
 # We'll use defaults from the LLVM style, but with 4 columns indentation.
 BasedOnStyle: LLVM
 IndentWidth: 4
+SortIncludes: false
 ...

--- a/layers/.clang-format
+++ b/layers/.clang-format
@@ -3,4 +3,5 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
 ColumnLimit: 132
+SortIncludes: false
 ...

--- a/tests/.clang-format
+++ b/tests/.clang-format
@@ -3,4 +3,5 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
 ColumnLimit: 132
+SortIncludes: false
 ...


### PR DESCRIPTION
By default, clang-format will sort header files when running the tool, which often breaks compilation. Added the option specified below to the main, tests, and layers version of these files to disable header reordering.

`SortIncludes: false`
