### PR TITLE
Tobin descriptor layout bindings in order

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -97,18 +97,6 @@ bool cvdescriptorset::DescriptorSetLayout::ValidateCreateInfo(debug_report_data 
     return skip;
 }
 
-// Return the number of descriptors for the given binding and all successive bindings
-uint32_t cvdescriptorset::DescriptorSetLayout::GetConsecutiveDescriptorCountFromBinding(uint32_t binding) const {
-    // If binding is invalid we'll return 0
-    uint32_t binding_count = 0;
-    auto bi_itr = binding_to_index_map_.find(binding);
-    while (bi_itr != binding_to_index_map_.end()) {
-        binding_count += bindings_[bi_itr->second].descriptorCount;
-        bi_itr++;
-    }
-    return binding_count;
-}
-
 // put all bindings into the given set
 void cvdescriptorset::DescriptorSetLayout::FillBindingSet(std::unordered_set<uint32_t> *binding_set) const {
     for (auto binding_index_pair : binding_to_index_map_)
@@ -1215,12 +1203,11 @@ bool cvdescriptorset::DescriptorSet::ValidateWriteUpdate(const debug_report_data
         *error_msg = error_str.str();
         return false;
     }
-    if (update->descriptorCount >
-        (p_layout_->GetConsecutiveDescriptorCountFromBinding(update->dstBinding) - update->dstArrayElement)) {
+    if (update->descriptorCount > (descriptors_.size() - start_idx)) {
         *error_code = VALIDATION_ERROR_00938;
         std::stringstream error_str;
         error_str << "Attempting write update to descriptor set " << set_ << " binding #" << update->dstBinding << " with "
-                  << p_layout_->GetConsecutiveDescriptorCountFromBinding(update->dstBinding)
+                  << descriptors_.size() - start_idx
                   << " descriptors in that binding and all successive bindings of the set, but update of "
                   << update->descriptorCount << " descriptors combined with update array element offset of "
                   << update->dstArrayElement << " oversteps the available number of consecutive descriptors";

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -100,8 +100,6 @@ class DescriptorSetLayout {
     uint32_t GetTotalDescriptorCount() const { return descriptor_count_; };
     uint32_t GetDynamicDescriptorCount() const { return dynamic_descriptor_count_; };
     // For a given binding, return the number of descriptors in that binding and all successive bindings
-    // TODO : I think this can die with the update
-    uint32_t GetConsecutiveDescriptorCountFromBinding(uint32_t) const;
     uint32_t GetBindingCount() const { return binding_count_; };
     // Fill passed-in set with bindings
     void FillBindingSet(std::unordered_set<uint32_t> *) const;


### PR DESCRIPTION
Fixes #1227 

Store bindings in-order in DescriptorSetLayout class.

This simplifies the class a bit and allows easy check for consecutive binding order. I looked at further consolidating the class to unify the *FromIndex & *FromBinding functions but b/c bindings may still have gaps it's friendlier to users of the class to provide both functions.