### PR TITLE
Remove redundant image layer checks, remove enum/struct_validator_helpers

### DIFF
--- a/layers/image.cpp
+++ b/layers/image.cpp
@@ -40,7 +40,6 @@
 #include "vk_loader_platform.h"
 #include "vk_dispatch_table_helper.h"
 #include "vk_struct_string_helper_cpp.h"
-#include "vk_enum_validate_helper.h"
 #include "image.h"
 #include "vk_layer_config.h"
 #include "vk_layer_extension_utils.h"
@@ -216,10 +215,6 @@ static const VkLayerProperties global_layer = {
 };
 
 // Start of the Image layer proper
-
-static inline uint32_t validate_VkImageLayoutKHR(VkImageLayout input_value) {
-    return ((validate_VkImageLayout(input_value) == 1) || (input_value == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR));
-}
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
                                            const VkAllocationCallbacks *pAllocator, VkImage *pImage) {
@@ -410,31 +405,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(VkDevice device, const VkRenderP
         if (pCreateInfo->pAttachments[i].format == VK_FORMAT_UNDEFINED) {
             std::stringstream ss;
             ss << "vkCreateRenderPass: pCreateInfo->pAttachments[" << i << "].format is VK_FORMAT_UNDEFINED";
-            skip_call |= log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
-                                 IMAGE_RENDERPASS_INVALID_ATTACHMENT, "IMAGE", "%s", ss.str().c_str());
-        }
-
-        if (!validate_VkImageLayoutKHR(pCreateInfo->pAttachments[i].initialLayout) ||
-            !validate_VkImageLayoutKHR(pCreateInfo->pAttachments[i].finalLayout)) {
-            std::stringstream ss;
-            ss << "vkCreateRenderPass parameter, VkImageLayout in pCreateInfo->pAttachments[" << i << "], is unrecognized";
-            // TODO: Verify against Valid Use section of spec. Generally if something yield an undefined result, it's invalid
-            skip_call |= log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
-                                 IMAGE_RENDERPASS_INVALID_ATTACHMENT, "IMAGE", "%s", ss.str().c_str());
-        }
-
-        if (!validate_VkAttachmentLoadOp(pCreateInfo->pAttachments[i].loadOp)) {
-            std::stringstream ss;
-            ss << "vkCreateRenderPass parameter, VkAttachmentLoadOp in pCreateInfo->pAttachments[" << i << "], is unrecognized";
-            // TODO: Verify against Valid Use section of spec. Generally if something yield an undefined result, it's invalid
-            skip_call |= log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
-                                 IMAGE_RENDERPASS_INVALID_ATTACHMENT, "IMAGE", "%s", ss.str().c_str());
-        }
-
-        if (!validate_VkAttachmentStoreOp(pCreateInfo->pAttachments[i].storeOp)) {
-            std::stringstream ss;
-            ss << "vkCreateRenderPass parameter, VkAttachmentStoreOp in pCreateInfo->pAttachments[" << i << "], is unrecognized";
-            // TODO: Verify against Valid Use section of spec. Generally if something yield an undefined result, it's invalid
             skip_call |= log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, (VkDebugReportObjectTypeEXT)0, 0, __LINE__,
                                  IMAGE_RENDERPASS_INVALID_ATTACHMENT, "IMAGE", "%s", ss.str().c_str());
         }

--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -41,7 +41,6 @@
 #include "vulkan/vk_layer.h"
 #include "vk_layer_config.h"
 #include "vk_dispatch_table_helper.h"
-#include "vk_struct_validate_helper.h"
 
 #include "vk_layer_table.h"
 #include "vk_layer_data.h"

--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -41,7 +41,6 @@
 #include "vulkan/vk_layer.h"
 #include "vk_layer_config.h"
 #include "vk_dispatch_table_helper.h"
-#include "vk_enum_validate_helper.h"
 #include "vk_struct_validate_helper.h"
 
 #include "vk_layer_table.h"
@@ -3843,15 +3842,10 @@ bool PreBeginCommandBuffer(layer_data *dev_data, VkCommandBuffer commandBuffer, 
                         "Cannot set inherited occlusionQueryEnable in vkBeginCommandBuffer() when device does not support "
                         "inheritedQueries.");
         }
-
-        if ((dev_data->physical_device_features.inheritedQueries != VK_FALSE) && (pInfo->occlusionQueryEnable != VK_FALSE) &&
-            (!validate_VkQueryControlFlagBits(VkQueryControlFlagBits(pInfo->queryFlags)))) {
-            skip |=
-                log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
-                        reinterpret_cast<uint64_t>(commandBuffer), __LINE__, DEVICE_FEATURE, LayerName,
-                        "Cannot enable in occlusion queries in vkBeginCommandBuffer() and set queryFlags to %d which is not a "
-                        "valid combination of VkQueryControlFlagBits.",
-                        pInfo->queryFlags);
+        // VALIDATION_ERROR_00117 check
+        if ((dev_data->physical_device_features.inheritedQueries != VK_FALSE) && (pInfo->occlusionQueryEnable != VK_FALSE)) {
+            skip |= validate_flags(dev_data->report_data, "vkBeginCommandBuffer", "pBeginInfo->pInheritanceInfo->queryFlags",
+                                   "VkQueryControlFlagBits", AllVkQueryControlFlagBits, pInfo->queryFlags, false);
         }
     }
     return skip;

--- a/layers/threading.cpp
+++ b/layers/threading.cpp
@@ -27,7 +27,6 @@
 #include "vk_layer_config.h"
 #include "vk_layer_extension_utils.h"
 #include "vk_layer_utils.h"
-#include "vk_struct_validate_helper.h"
 #include "vk_layer_table.h"
 #include "vk_layer_logging.h"
 #include "threading.h"

--- a/layers/threading.cpp
+++ b/layers/threading.cpp
@@ -27,7 +27,6 @@
 #include "vk_layer_config.h"
 #include "vk_layer_extension_utils.h"
 #include "vk_layer_utils.h"
-#include "vk_enum_validate_helper.h"
 #include "vk_struct_validate_helper.h"
 #include "vk_layer_table.h"
 #include "vk_layer_logging.h"


### PR DESCRIPTION
struct_validate_helper was unused, enum_validate_helper was only used for redundant checks that have been removed/replaced.  Part of switching vk-helper stuff over to being vk.xml-based.