### PR TITLE
layers: Remove cmds vector from GLOBAL_CB_NODE

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -337,6 +337,7 @@ struct RENDER_PASS_STATE : public BASE_NODE {
 
 // Cmd Buffer Tracking
 enum CMD_TYPE {
+    CMD_NONE,
     CMD_BINDPIPELINE,
     CMD_BINDPIPELINEDELTA,
     CMD_SETVIEWPORTSTATE,
@@ -387,12 +388,6 @@ enum CMD_TYPE {
     CMD_ENDRENDERPASS,
     CMD_EXECUTECOMMANDS,
     CMD_END, // Should be last command in any RECORDED cmd buffer
-};
-
-// Data structure for holding sequence of cmds in cmd buffer
-struct CMD_NODE {
-    CMD_TYPE type;
-    uint64_t cmdNumber;
 };
 
 enum CB_STATE {
@@ -581,7 +576,7 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     CB_STATE state;                     // Track cmd buffer update state
     uint64_t submitCount;               // Number of times CB has been submitted
     CBStatusFlags status;               // Track status of various bindings on cmd buffer
-    std::vector<CMD_NODE> cmds;              // vector of commands bound to this command buffer
+    CMD_TYPE last_cmd;                  // Last command written to the CB
     // Currently storing "lastBound" objects on per-CB basis
     //  long-term may want to create caches of "lastBound" states and could have
     //  each individual CMD_NODE referencing its own "lastBound" state


### PR DESCRIPTION
Now that cmd buffer printing has been removed, the only use of this is
to distinguish between cmd buffers invalidated before and after a
complete recording. This should eventually be folded into the state
machine, but removing the vector of cmds is a first step.

Signed-off-by: Chris Forbes <chrisforbes@google.com>