### PR TITLE
tests: Insert missing vkQueueWaitIdle()

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -4142,6 +4142,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferDestroyed) {
     vkQueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
 
     m_errorMonitor->VerifyFound();
+    vkQueueWaitIdle(m_device->m_queue);
     vkFreeMemory(m_device->handle(), mem, NULL);
 }
 


### PR DESCRIPTION
This does not actually fix the Unexpected error message, 
since the real problem is in the validation layers... 
The call to vkQueueSubmit is triggering 2 error messages.
Is one redundant?

Change-Id: I4e28cc778dff7581c83cbe53240d1706f60253a7