### PR TITLE
cmake: speed up the build

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -146,8 +146,6 @@ run_vk_helper(gen_struct_wrappers
     vk_struct_string_helper_cpp.h
     vk_struct_size_helper.h
     vk_struct_size_helper.c
-    vk_struct_wrappers.h
-    vk_struct_wrappers.cpp
     vk_safe_struct.h
     vk_safe_struct.cpp
 )
@@ -157,8 +155,6 @@ set_source_files_properties(
     vk_struct_string_helper_cpp.h
     vk_struct_size_helper.h
     vk_struct_size_helper.c
-    vk_struct_wrappers.h
-    vk_struct_wrappers.cpp
     vk_safe_struct.h
     vk_safe_struct.cpp
     PROPERTIES GENERATED TRUE)
@@ -176,8 +172,6 @@ add_custom_target(generate_vk_layer_helpers DEPENDS
     vk_struct_string_helper_cpp.h
     vk_struct_size_helper.h
     vk_struct_size_helper.c
-    vk_struct_wrappers.h
-    vk_struct_wrappers.cpp
     vk_safe_struct.h
     vk_safe_struct.cpp
 )


### PR DESCRIPTION
Remove old dependencies from cmake, which was causing long build times
even when nothing had changed.

Change-Id: Ie162606b54352306ae6400aa18e942d8cffb7782