### PR TITLE
loader: Fix validation error

### DIFF
--- a/layers/vk_layer_utils.cpp
+++ b/layers/vk_layer_utils.cpp
@@ -695,9 +695,12 @@ VK_LAYER_EXPORT VkStringErrorFlags vk_string_validate(const int max_length, cons
     int num_char_bytes = 0;
     int i, j;
 
-    for (i = 0; i < max_length; i++) {
+    for (i = 0; i <= max_length; i++) {
         if (utf8[i] == 0) {
             break;
+        } else if (i == max_length) {
+          result = VK_STRING_ERROR_LENGTH;
+          break;
         } else if ((utf8[i] >= 0xa) && (utf8[i] < 0x7f)) {
             num_char_bytes = 0;
         } else if ((utf8[i] & UTF8_ONE_BYTE_MASK) == UTF8_ONE_BYTE_CODE) {

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -4752,8 +4752,11 @@ VkStringErrorFlags vk_string_validate(const int max_length, const char *utf8) {
     int num_char_bytes = 0;
     int i, j;
 
-    for (i = 0; i < max_length; i++) {
+    for (i = 0; i <= max_length; i++) {
         if (utf8[i] == 0) {
+            break;
+        } else if (i == max_length) {
+            result |= VK_STRING_ERROR_LENGTH;
             break;
         } else if ((utf8[i] >= 0x20) && (utf8[i] < 0x7f)) {
             num_char_bytes = 0;


### PR DESCRIPTION
The string length validation will not detect strings
that exceed the max length.
For example, when i = max_length-1 and utf8[i] is a valid
character (>= 0x20 and < 0x7f) no error is thrown and
the next iteration will end the loop.
This change extends the loop and the if check to
catch this issue.

And, BTW, it's not really necessary to put the validation check here as neither issue will cause the loader to crash. That allows this test to be moved to a validation layer where it really should be.