### PR TITLE
layers:Mark latest buffers and images as written

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -8022,8 +8022,8 @@ static void UpdateStateCmdDrawDispatchType(
     vector<std::tuple<cvdescriptorset::DescriptorSet *, std::map<uint32_t, descriptor_req>, std::vector<uint32_t> const *>>
         *active_set_bindings_pairs,
     std::unordered_set<uint32_t> *active_bindings) {
-    MarkStoreImagesAndBuffersAsWritten(dev_data, cb_state);
     UpdateDrawState(dev_data, cb_state, bind_point, active_set_bindings_pairs, active_bindings);
+    MarkStoreImagesAndBuffersAsWritten(dev_data, cb_state);
     UpdateCmdBufferLastCmd(dev_data, cb_state, cmd_type);
 }
 


### PR DESCRIPTION
Fixes #1311

In the Draw-time refactor the marking of store images and buffers as
written was incorrectly moved before the list of images and buffers was
updated for the current active bindings.

This fix restores correct order of operations so that the buffers and
images of interest are first added to cmd buffer active list, then
they're appropriately updated as written.