### PR TITLE
Move struct_size_helper files to use vk.xml-based codegen

### DIFF
--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -22,6 +22,8 @@ mkdir generated\include generated\common
 py -3 ../scripts/vk_helper.py --gen_struct_wrappers ../include/vulkan/vulkan.h --abs_out_dir generated/include
 
 cd generated/include
+py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_struct_size_helper.h
+py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_struct_size_helper.c
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_enum_string_helper.h
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_dispatch_table_helper.h
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml thread_check.h

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -23,6 +23,8 @@ mkdir -p generated/include generated/common
 
 python3 ../scripts/vk_helper.py --gen_struct_wrappers ../include/vulkan/vulkan.h --abs_out_dir generated/include
 
+( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_string_size_helper.h )
+( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_string_size_helper.c )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_enum_string_helper.h )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_dispatch_table_helper.h )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml thread_check.h )

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -141,21 +141,19 @@ else()
 endif()
 
 run_vk_helper(gen_struct_wrappers
-    vk_struct_size_helper.h
-    vk_struct_size_helper.c
     vk_safe_struct.h
     vk_safe_struct.cpp
 )
 
 set_source_files_properties(
-    vk_struct_size_helper.h
-    vk_struct_size_helper.c
     vk_safe_struct.h
     vk_safe_struct.cpp
     PROPERTIES GENERATED TRUE)
 
 add_custom_target(generate_enum_string_helper DEPENDS
     vk_enum_string_helper.h
+    vk_struct_size_helper.h
+    vk_struct_size_helper.c
 )
 
 add_custom_target(generate_dispatch_table_helper DEPENDS
@@ -163,12 +161,12 @@ add_custom_target(generate_dispatch_table_helper DEPENDS
 )
 
 add_custom_target(generate_vk_layer_helpers DEPENDS
-    vk_struct_size_helper.h
-    vk_struct_size_helper.c
     vk_safe_struct.h
     vk_safe_struct.cpp
 )
 
+run_vk_xml_generate(helper_file_generator.py vk_struct_size_helper.h)
+run_vk_xml_generate(helper_file_generator.py vk_struct_size_helper.c)
 run_vk_xml_generate(helper_file_generator.py vk_enum_string_helper.h)
 run_vk_xml_generate(threading_generator.py thread_check.h)
 run_vk_xml_generate(parameter_validation_generator.py parameter_validation.h)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -111,13 +111,13 @@ if (WIN32)
     )
     add_library(VkLayer_${target} SHARED ${ARGN} VkLayer_${target}.def)
     target_link_Libraries(VkLayer_${target} VkLayer_utils)
-    add_dependencies(VkLayer_${target} generate_dispatch_table_helper generate_vk_layer_helpers generate_enum_string_helper VkLayer_utils)
+    add_dependencies(VkLayer_${target} generate_dispatch_table_helper generate_vk_layer_helpers generate_vk_helper_files VkLayer_utils)
     endmacro()
 else()
     macro(add_vk_layer target)
     add_library(VkLayer_${target} SHARED ${ARGN})
     target_link_Libraries(VkLayer_${target} VkLayer_utils)
-    add_dependencies(VkLayer_${target} generate_dispatch_table_helper generate_vk_layer_helpers generate_enum_string_helper VkLayer_utils)
+    add_dependencies(VkLayer_${target} generate_dispatch_table_helper generate_vk_layer_helpers generate_vk_helper_files VkLayer_utils)
     set_target_properties(VkLayer_${target} PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic,--exclude-libs,ALL")
     install(TARGETS VkLayer_${target} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     endmacro()
@@ -150,7 +150,7 @@ set_source_files_properties(
     vk_safe_struct.cpp
     PROPERTIES GENERATED TRUE)
 
-add_custom_target(generate_enum_string_helper DEPENDS
+add_custom_target(generate_vk_helper_files DEPENDS
     vk_enum_string_helper.h
     vk_struct_size_helper.h
     vk_struct_size_helper.c

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -51,7 +51,6 @@
 #if defined(__GNUC__)
 #pragma GCC diagnostic warning "-Wwrite-strings"
 #endif
-#include "vk_struct_size_helper.h"
 #include "core_validation.h"
 #include "vk_layer_table.h"
 #include "vk_layer_data.h"

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -55,7 +55,6 @@ class HelperFileOutputGeneratorOptions(GeneratorOptions):
                                   addExtensions, removeExtensions, sortProcedure)
         self.prefixText       = prefixText
         self.genFuncPointers  = genFuncPointers
-        self.prefixText       = None
         self.protectFile      = protectFile
         self.protectFeature   = protectFeature
         self.protectProto     = protectProto
@@ -67,8 +66,7 @@ class HelperFileOutputGeneratorOptions(GeneratorOptions):
         self.library_name     = library_name
         self.helper_file_type = helper_file_type
 #
-# HelperFileOutputGenerator - subclass of OutputGenerator.
-# Outputs Vulkan helper files
+# HelperFileOutputGenerator - subclass of OutputGenerator. Outputs Vulkan helper files
 class HelperFileOutputGenerator(OutputGenerator):
     """Generate Windows def file based on XML element attributes"""
     def __init__(self,
@@ -79,14 +77,24 @@ class HelperFileOutputGenerator(OutputGenerator):
         # Internal state - accumulators for different inner block text
         self.enum_output = ''      # string built up of enum string routines
         self.enum_list = ()
+        # Internal state - accumulators for different inner block text
+        ########## self.sections = dict([(section, []) for section in self.ALL_SECTIONS])
+        self.structNames = []                             # List of Vulkan struct typenames
+        self.structTypes = dict()                         # Map of Vulkan struct typename to required VkStructureType
+        self.handleTypes = set()                          # Set of handle type names
+        self.commands = []                                # List of CommandData records for all Vulkan commands
+        self.structMembers = []                           # List of StructMemberData records for all Vulkan structs
+        self.flags = set()                                # Map of flags typenames
+        # Named tuples to store struct and command data
+        self.StructType = namedtuple('StructType', ['name', 'value'])
+        self.CommandParam = namedtuple('CommandParam', ['type', 'name', 'ispointer', 'isconst', 'iscount', 'len', 'extstructs', 'cdecl', 'islocal', 'iscreate', 'isdestroy'])
+        self.CommandData = namedtuple('CommandData', ['name', 'return_type', 'params', 'cdecl'])
+        self.StructMemberData = namedtuple('StructMemberData', ['name', 'members'])
     #
     # Called once at the beginning of each run
     def beginFile(self, genOpts):
         OutputGenerator.beginFile(self, genOpts)
         # User-supplied prefix text, if any (list of strings)
-        if (genOpts.prefixText):
-            for s in genOpts.prefixText:
-                write(s, file=self.outFile)
         self.helper_file_type = genOpts.helper_file_type
         self.library_name = genOpts.library_name
         # File Comment
@@ -134,8 +142,8 @@ class HelperFileOutputGenerator(OutputGenerator):
     def genGroup(self, groupinfo, groupName):
         OutputGenerator.genGroup(self, groupinfo, groupName)
         groupElem = groupinfo.elem
-        # For enum_string_helper
-        if self.helper_file_type == 'enum_string_helper':
+        # For enum_string_header
+        if self.helper_file_type == 'enum_string_header':
             value_list = []
             for elem in groupElem.findall('enum'):
                 if elem.get('supported') != 'disabled':
@@ -144,7 +152,106 @@ class HelperFileOutputGenerator(OutputGenerator):
             if value_list is not None:
                 self.enum_output += self.GenerateEnumStringConversion(groupName, value_list)
     #
-    # Enum_string_helper: Create a routine to convert an enumerated value into a string
+    # Called for each type -- if the type is a struct/union, grab the metadata
+    def genType(self, typeinfo, name):
+        OutputGenerator.genType(self, typeinfo, name)
+        typeElem = typeinfo.elem
+        # If the type is a struct type, traverse the imbedded <member> tags generating a structure.
+        # Otherwise, emit the tag text.
+        category = typeElem.get('category')
+        if (category == 'struct' or category == 'union'):
+            self.structNames.append(name)
+            self.genStruct(typeinfo, name)
+    #
+    # Generate a VkStructureType based on a structure typename
+    def genVkStructureType(self, typename):
+        # Add underscore between lowercase then uppercase
+        value = re.sub('([a-z0-9])([A-Z])', r'\1_\2', typename)
+        # Change to uppercase
+        value = value.upper()
+        # Add STRUCTURE_TYPE_
+        return re.sub('VK_', 'VK_STRUCTURE_TYPE_', value)
+    #
+    # Check if the parameter passed in is a pointer
+    def paramIsPointer(self, param):
+        ispointer = False
+        for elem in param:
+            if ((elem.tag is not 'type') and (elem.tail is not None)) and '*' in elem.tail:
+                ispointer = True
+        return ispointer
+    #
+    # Retrieve the type and name for a parameter
+    def getTypeNameTuple(self, param):
+        type = ''
+        name = ''
+        for elem in param:
+            if elem.tag == 'type':
+                type = noneStr(elem.text)
+            elif elem.tag == 'name':
+                name = noneStr(elem.text)
+        return (type, name)
+    #
+    # Retrieve the value of the len tag
+    def getLen(self, param):
+        result = None
+        len = param.attrib.get('len')
+        if len and len != 'null-terminated':
+            # For string arrays, 'len' can look like 'count,null-terminated', indicating that we
+            # have a null terminated array of strings.  We strip the null-terminated from the
+            # 'len' field and only return the parameter specifying the string count
+            if 'null-terminated' in len:
+                result = len.split(',')[0]
+            else:
+                result = len
+            # Spec has now notation for len attributes, using :: instead of platform specific pointer symbol
+            result = str(result).replace('::', '->')
+        return result
+    #
+    # Generate local ready-access data describing Vulkan structures and unions from the XML metadata
+    def genStruct(self, typeinfo, typeName):
+        OutputGenerator.genStruct(self, typeinfo, typeName)
+        members = typeinfo.elem.findall('.//member')
+        # Iterate over members once to get length parameters for arrays
+        lens = set()
+        for member in members:
+            len = self.getLen(member)
+            if len:
+                lens.add(len)
+        # Generate member info
+        membersInfo = []
+        for member in members:
+            # Get the member's type and name
+            info = self.getTypeNameTuple(member)
+            type = info[0]
+            name = info[1]
+            cdecl = self.makeCParamDecl(member, 0)
+            # Process VkStructureType
+            if type == 'VkStructureType':
+                # Extract the required struct type value from the comments
+                # embedded in the original text defining the 'typeinfo' element
+                rawXml = etree.tostring(typeinfo.elem).decode('ascii')
+                result = re.search(r'VK_STRUCTURE_TYPE_\w+', rawXml)
+                if result:
+                    value = result.group(0)
+                else:
+                    value = self.genVkStructureType(typeName)
+                # Store the required type value
+                self.structTypes[typeName] = self.StructType(name=name, value=value)
+            # Store pointer/array/string info
+            membersInfo.append(self.CommandParam(type=type,
+                                                 name=name,
+                                                 ispointer=self.paramIsPointer(member),
+                                                 isconst=True if 'const' in cdecl else False,
+                                                 iscount=True if name in lens else False,
+                                                 len=self.getLen(member),
+                                                 extstructs=member.attrib.get('validextensionstructs') if name == 'pNext' else None,
+                                                 cdecl=cdecl,
+                                                 islocal=False,
+                                                 iscreate=False,
+                                                 isdestroy=False))
+        self.structMembers.append(self.StructMemberData(name=typeName, members=membersInfo))
+    #
+    # Enum_string_header: Create a routine to convert an enumerated value into a string
     def GenerateEnumStringConversion(self, groupName, value_list):
         outstring = '\n'
         outstring += 'static inline const char* string_%s(%s input_value)\n' % (groupName, groupName)
@@ -163,7 +270,8 @@ class HelperFileOutputGenerator(OutputGenerator):
     #
     # Create a helper file and return it as a string
     def OutputDestFile(self):
-        if self.helper_file_type == 'enum_string_helper':
+        out_file_entries = ''
+        if self.helper_file_type == 'enum_string_header':
             out_file_entries = '\n'
             out_file_entries += '#pragma once\n'
             out_file_entries += '#ifdef _WIN32\n'
@@ -173,11 +281,16 @@ class HelperFileOutputGenerator(OutputGenerator):
             out_file_entries += '#include <vulkan/vulkan.h>\n'
             out_file_entries += '\n'
             out_file_entries += self.enum_output
-        elif self.helper_file_type == 'test':
+        elif self.helper_file_type == 'struct_size_header':
             out_file_entries = '\n'
-            out_file_entries += 'TEST FILE!!!!!\n'
+            out_file_entries += 'Helper File header code\n'
             out_file_entries += '\n'
-            out_file_entries += 'THISLL BE SOMETHING, SOMEDAY. \n'
-            out_file_entries += 'MORE STUFF HERE\n'
+            out_file_entries += 'helper file.h \n'
+            out_file_entries += '\n'
+        elif self.helper_file_type == 'struct_size_source':
+            out_file_entries = '\n'
+            out_file_entries += 'Helper File source code\n'
+            out_file_entries += '\n'
+            out_file_entries += 'helper file.c \n'
             out_file_entries += '\n'
         return out_file_entries

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -134,15 +134,17 @@ class HelperFileOutputGenerator(OutputGenerator):
     def genGroup(self, groupinfo, groupName):
         OutputGenerator.genGroup(self, groupinfo, groupName)
         groupElem = groupinfo.elem
-        value_list = []
-        for elem in groupElem.findall('enum'):
-            if elem.get('supported') != 'disabled':
-                item_name = elem.get('name')
-                value_list.append(item_name)
-        if value_list is not None:
-            self.enum_output += self.GenerateEnumStringConversion(groupName, value_list)
+        # For enum_string_helper
+        if self.helper_file_type == 'enum_string_helper':
+            value_list = []
+            for elem in groupElem.findall('enum'):
+                if elem.get('supported') != 'disabled':
+                    item_name = elem.get('name')
+                    value_list.append(item_name)
+            if value_list is not None:
+                self.enum_output += self.GenerateEnumStringConversion(groupName, value_list)
     #
-    # Create a routine to convert an enumerated value into a string
+    # Enum_string_helper: Create a routine to convert an enumerated value into a string
     def GenerateEnumStringConversion(self, groupName, value_list):
         outstring = '\n'
         outstring += 'static inline const char* string_%s(%s input_value)\n' % (groupName, groupName)
@@ -161,13 +163,21 @@ class HelperFileOutputGenerator(OutputGenerator):
     #
     # Create a helper file and return it as a string
     def OutputDestFile(self):
-        out_file_entries = '\n'
-        out_file_entries += '#pragma once\n'
-        out_file_entries += '#ifdef _WIN32\n'
-        out_file_entries += '#pragma warning( disable : 4065 )\n'
-        out_file_entries += '#endif\n'
-        out_file_entries += '\n'
-        out_file_entries += '#include <vulkan/vulkan.h>\n'
-        out_file_entries += '\n'
-        out_file_entries += self.enum_output
+        if self.helper_file_type == 'enum_string_helper':
+            out_file_entries = '\n'
+            out_file_entries += '#pragma once\n'
+            out_file_entries += '#ifdef _WIN32\n'
+            out_file_entries += '#pragma warning( disable : 4065 )\n'
+            out_file_entries += '#endif\n'
+            out_file_entries += '\n'
+            out_file_entries += '#include <vulkan/vulkan.h>\n'
+            out_file_entries += '\n'
+            out_file_entries += self.enum_output
+        elif self.helper_file_type == 'test':
+            out_file_entries = '\n'
+            out_file_entries += 'TEST FILE!!!!!\n'
+            out_file_entries += '\n'
+            out_file_entries += 'THISLL BE SOMETHING, SOMEDAY. \n'
+            out_file_entries += 'MORE STUFF HERE\n'
+            out_file_entries += '\n'
         return out_file_entries

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -318,18 +318,48 @@ class HelperFileOutputGenerator(OutputGenerator):
             declare_flag = True
         return string_var, declare_flag
     #
+    # Build the header of the get_struct_chain_size function
+    def GenerateChainSizePreamble(self):
+        preable = '\nsize_t get_struct_chain_size(const void* struct_ptr) {\n'
+        preable += '    // Use VkApplicationInfo as struct until actual type is resolved\n'
+        preable += '    VkApplicationInfo* pNext = (VkApplicationInfo*)struct_ptr;\n'
+        preable += '    size_t struct_size = 0;\n'
+        preable += '    while (pNext) {\n'
+        preable += '        switch (pNext->sType) {\n'
+        return preable
+    #
+    # Build the footer of the get_struct_chain_size function
+    def GenerateChainSizePostamble(self):
+        postamble  = '            default:\n'
+        postamble += '                assert(0);\n'
+        postamble += '                struct_size += 0;\n'
+        postamble += '        }\n'
+        postamble += '        pNext = (VkApplicationInfo*)pNext->pNext;\n'
+        postamble += '    }\n'
+        postamble += '    return struct_size;\n'
+        postamble += '}'
+        return postamble
+    #
     # struct_size_helper source -- create bodies of struct size helper functions
     def GenerateStructSizeSource(self):
-        outstring = ''
+        # Construct the body of the routine and get_struct_chain_size() simultaneously
+        struct_size_body = ''
+        chain_size  = self.GenerateChainSizePreamble()
         for item in self.structMembers:
-            outstring += '\n'
+            struct_size_body += '\n'
             lower_case_name = item.name.lower()
             if item.ifdef_protect != None:
-                outstring += '#ifdef %s\n' % item.ifdef_protect
-            outstring += 'size_t vk_size_%s(const %s* struct_ptr) {\n' % (item.name.lower(), item.name)
-            outstring += '    size_t struct_size = 0;\n'
-            outstring += '    if (struct_ptr) {\n'
-            outstring += '        struct_size = sizeof(%s);\n' % item.name
+                struct_size_body += '#ifdef %s\n' % item.ifdef_protect
+                chain_size += '#ifdef %s\n' % item.ifdef_protect
+            if item.name in self.structTypes:
+                chain_size += '            case %s: {\n' % self.structTypes[item.name].value
+                chain_size += '                struct_size += vk_size_%s((%s*)pNext);\n' % (item.name.lower(), item.name)
+                chain_size += '                break;\n'
+                chain_size += '            }\n'
+            struct_size_body += 'size_t vk_size_%s(const %s* struct_ptr) {\n' % (item.name.lower(), item.name)
+            struct_size_body += '    size_t struct_size = 0;\n'
+            struct_size_body += '    if (struct_ptr) {\n'
+            struct_size_body += '        struct_size = sizeof(%s);\n' % item.name
             counter_declared = False
             for member in item.members:
                 vulkan_type = next((i for i, v in enumerate(self.structMembers) if v[0] == member.type), None)
@@ -337,34 +367,38 @@ class HelperFileOutputGenerator(OutputGenerator):
                     if vulkan_type is not None:
                         # If this is another Vulkan structure call generated size function
                         if member.len is not None:
-                            outstring, counter_declared = self.DeclareCounter(outstring, counter_declared)
-                            outstring += '        for (i = 0; i < pStruct->%s; i++) {\n' % member.len
-                            outstring += '            struct_size += vk_size_%s(&struct_ptr->%s[i]);\n' % (member.type.lower(), member.name)
-                            outstring += '        }\n'
+                            struct_size_body, counter_declared = self.DeclareCounter(struct_size_body, counter_declared)
+                            struct_size_body += '        for (i = 0; i < struct_ptr->%s; i++) {\n' % member.len
+                            struct_size_body += '            struct_size += vk_size_%s(&struct_ptr->%s[i]);\n' % (member.type.lower(), member.name)
+                            struct_size_body += '        }\n'
                         else:
-                            outstring += '        struct_size += vk_size_%s(struct_ptr->%s);\n' % (member.type.lower(), member.name)
+                            struct_size_body += '        struct_size += vk_size_%s(struct_ptr->%s);\n' % (member.type.lower(), member.name)
                     else:
                         if member.type == 'char':
                             # Deal with sizes of character strings
                             if member.len is not None:
-                                outstring, counter_declared = self.DeclareCounter(outstring, counter_declared)
-                                outstring += '        for (i = 0; i < pStruct->%s; i++) {\n' % member.len
-                                outstring += '            struct_size += (sizeof(char*) + (sizeof(char) * (1 + strlen(pStruct->%s[i]))));\n' % (member.name)
-                                outstring += '        }\n'
+                                struct_size_body, counter_declared = self.DeclareCounter(struct_size_body, counter_declared)
+                                struct_size_body += '        for (i = 0; i < struct_ptr->%s; i++) {\n' % member.len
+                                struct_size_body += '            struct_size += (sizeof(char*) + (sizeof(char) * (1 + strlen(struct_ptr->%s[i]))));\n' % (member.name)
+                                struct_size_body += '        }\n'
                             else:
-                                outstring += '        struct_size += (struct_ptr->%s != NULL) ? sizeof(char)*(1+strlen(struct_ptr->%s)) : 0;\n' % (member.name, member.name)
+                                struct_size_body += '        struct_size += (struct_ptr->%s != NULL) ? sizeof(char)*(1+strlen(struct_ptr->%s)) : 0;\n' % (member.name, member.name)
                         else:
                             if member.len is not None:
-                                outstring += '        struct_size += struct_ptr->%s * sizeof(%s);\n' % (member.len, member.name)
-            outstring += '    }\n'
-            outstring += '    return struct_size\n'
-            outstring += '}\n'
+                                # Avoid using 'sizeof(void)', which generates compile-time warnings/errors
+                                checked_type = member.type
+                                if checked_type == 'void':
+                                    checked_type = 'void*'
+                                struct_size_body += '        struct_size += struct_ptr->%s * sizeof(%s);\n' % (member.len, checked_type)
+            struct_size_body += '    }\n'
+            struct_size_body += '    return struct_size;\n'
+            struct_size_body += '}\n'
             if item.ifdef_protect != None:
-                outstring += '#endif // %s\n' % item.ifdef_protect
-        outstring += '#ifdef __cplusplus\n'
-        outstring += '}\n'
-        outstring += '#endif'
-        return outstring
+                struct_size_body += '#endif // %s\n' % item.ifdef_protect
+                chain_size += '#endif // %s\n' % item.ifdef_protect
+        chain_size += self.GenerateChainSizePostamble()
+        struct_size_body += chain_size;
+        return struct_size_body
     #
     # Combine struct size helper source file preamble with body text and return
     def GenerateStructSizeHelperSource(self):
@@ -387,3 +421,4 @@ class HelperFileOutputGenerator(OutputGenerator):
             return self.GenerateStructSizeHelperSource()
         else:
             return 'Bad Helper Generator Option %s' % self.helper_file_type
+

--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -203,14 +203,14 @@ def makeGenOpts(extensions = [], removeExtensions = [], protect = True, director
             apientry          = 'VKAPI_CALL ',
             apientryp         = 'VKAPI_PTR *',
             alignFuncParam    = 48,
-            helper_file_type  = 'enum_string_helper')
+            helper_file_type  = 'enum_string_header')
         ]
 
-    # Helper file generator options for vk_test.h
-    genOpts['vk_test.h'] = [
+    # Helper file generator options for vk_struct_size_helper.h
+    genOpts['vk_struct_size_helper.h'] = [
           HelperFileOutputGenerator,
           HelperFileOutputGeneratorOptions(
-            filename          = 'vk_test.h',
+            filename          = 'vk_struct_size_helper.h',
             directory         = directory,
             apiname           = 'vulkan',
             profile           = None,
@@ -225,7 +225,29 @@ def makeGenOpts(extensions = [], removeExtensions = [], protect = True, director
             apientry          = 'VKAPI_CALL ',
             apientryp         = 'VKAPI_PTR *',
             alignFuncParam    = 48,
-            helper_file_type  = 'test')
+            helper_file_type  = 'struct_size_header')
+        ]
+
+    # Helper file generator options for vk_struct_size_helper.c
+    genOpts['vk_struct_size_helper.c'] = [
+          HelperFileOutputGenerator,
+          HelperFileOutputGeneratorOptions(
+            filename          = 'vk_struct_size_helper.c',
+            directory         = directory,
+            apiname           = 'vulkan',
+            profile           = None,
+            versions          = allVersions,
+            emitversions      = allVersions,
+            defaultExtensions = 'vulkan',
+            addExtensions     = addExtensions,
+            removeExtensions  = removeExtensions,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            protectFeature    = False,
+            apicall           = 'VKAPI_ATTR ',
+            apientry          = 'VKAPI_CALL ',
+            apientryp         = 'VKAPI_PTR *',
+            alignFuncParam    = 48,
+            helper_file_type  = 'struct_size_source')
         ]
 
 

--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -184,7 +184,7 @@ def makeGenOpts(extensions = [], removeExtensions = [], protect = True, director
             alignFuncParam    = 48)
         ]
 
-    # Options for helper file generator
+    # Helper file generator options for vk_enum_string_helper.h
     genOpts['vk_enum_string_helper.h'] = [
           HelperFileOutputGenerator,
           HelperFileOutputGeneratorOptions(
@@ -202,9 +202,31 @@ def makeGenOpts(extensions = [], removeExtensions = [], protect = True, director
             apicall           = 'VKAPI_ATTR ',
             apientry          = 'VKAPI_CALL ',
             apientryp         = 'VKAPI_PTR *',
-            alignFuncParam    = 48)
+            alignFuncParam    = 48,
+            helper_file_type  = 'enum_string_helper')
         ]
 
+    # Helper file generator options for vk_test.h
+    genOpts['vk_test.h'] = [
+          HelperFileOutputGenerator,
+          HelperFileOutputGeneratorOptions(
+            filename          = 'vk_test.h',
+            directory         = directory,
+            apiname           = 'vulkan',
+            profile           = None,
+            versions          = allVersions,
+            emitversions      = allVersions,
+            defaultExtensions = 'vulkan',
+            addExtensions     = addExtensions,
+            removeExtensions  = removeExtensions,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            protectFeature    = False,
+            apicall           = 'VKAPI_ATTR ',
+            apientry          = 'VKAPI_CALL ',
+            apientryp         = 'VKAPI_PTR *',
+            alignFuncParam    = 48,
+            helper_file_type  = 'test')
+        ]
 
 
 


### PR DESCRIPTION
Added option-blocks for the two files, added codegen source to the existing helper-file-generator, removed references to the old codegen/source.

Safe_struct is next (and last!).