### PR TITLE
Update Android travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ android:
     - build-tools-23.0.2
     - android-23
 
+cache:
+  directories:
+    - external
+    - build-android/external
+
 before_install: 
   # Install the appropriate Linux packages.
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     # Android build.
     - os: linux
       compiler: gcc
-      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-21 ANDROID_ABI=armeabi-v7a
+      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=armeabi-v7a
     # Linux GCC debug build.
     - os: linux
       compiler: gcc
@@ -19,6 +19,13 @@ matrix:
     - os: linux
       compiler: clang
       env: VULKAN_BUILD_TARGET=LINUX
+
+android:
+  components:
+    - tools
+    - platform-tools
+    - build-tools-23.0.2
+    - android-23
 
 before_install: 
   # Install the appropriate Linux packages.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ sudo: required
 language: cpp
 
 matrix:
+  # Show final status immediately if a test fails.
+  fast_finish: true
   include:
     # Android build.
     - os: linux
@@ -55,8 +57,9 @@ script:
       make -C dbuild;
     fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then
-      cd build-android;
+      pushd build-android;
       ./update_external_sources_android.sh;
       ./android-generate.sh;
       ndk-build APP_ABI=$ANDROID_ABI;
+      popd;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ before_install:
   # Install the Android NDK.
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then
       export ARCH=`uname -m`;
-      wget http://dl.google.com/android/repository/android-ndk-r12b-linux-${ARCH}.zip;
-      unzip -u -q android-ndk-r12b-linux-${ARCH}.zip;
-      export ANDROID_NDK_HOME=`pwd`/android-ndk-r12b;
+      wget http://dl.google.com/android/repository/android-ndk-r13b-linux-${ARCH}.zip;
+      unzip -u -q android-ndk-r13b-linux-${ARCH}.zip;
+      export ANDROID_NDK_HOME=`pwd`/android-ndk-r13b;
       export JAVA_HOME="/usr/lib/jvm/java-8-oracle";
       export PATH="$ANDROID_NDK_HOME:$PATH";
     fi


### PR DESCRIPTION
Changes to improve build testing, mostly targeting Android:
- Move to earliest Android version that supports Vulkan (23)
- Switch to latest NDK
- Cache external build directories.  This improves build time from ~20 minutes to ~5 minutes.
- Return early is any test fails