### PR TITLE
Remove safe_struct extension special cases

### DIFF
--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -648,15 +648,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDev
 VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                            uint32_t *pPropertyCount, VkDisplayModePropertiesKHR *pProperties) {
     layer_data *my_map_data = get_my_data_ptr(get_dispatch_key(physicalDevice), layer_data_map);
-    safe_VkDisplayModePropertiesKHR *local_pProperties = NULL;
+    VkDisplayModePropertiesKHR *local_pProperties = NULL;
     {
         std::lock_guard<std::mutex> lock(global_lock);
         display = (VkDisplayKHR)my_map_data->unique_id_mapping[reinterpret_cast<uint64_t &>(display)];
         if (pProperties) {
-            local_pProperties = new safe_VkDisplayModePropertiesKHR[*pPropertyCount];
-            for (uint32_t idx0 = 0; idx0 < *pPropertyCount; ++idx0) {
-                local_pProperties[idx0].initialize(&pProperties[idx0]);
-            }
+            local_pProperties = new VkDisplayModePropertiesKHR[*pPropertyCount];
         }
     }
 

--- a/scripts/vk_helper.py
+++ b/scripts/vk_helper.py
@@ -806,9 +806,6 @@ class StructWrapperGen:
         for m in self.struct_dict[s]:
             if self.struct_dict[s][m]['ptr']:
                 return True
-        inclusions = ['VkDisplayPlanePropertiesKHR', 'VkDisplayModePropertiesKHR', 'VkDisplayPropertiesKHR']
-        if s in inclusions:
-            return True
         return False
 
     def _generateSafeStructHeader(self):


### PR DESCRIPTION
During addition of the `Display `and `DisplayMode `extensions, the unique_objects code was incorrectly cut-pasted resulting in missing safe_struct helper errors.  These in turn were hacked around by adding special cases to the vk_helper safe_struct codegen.  Removed both.