### PR TITLE
demos: Make spacebar pause work in cube demo (Linux).

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -743,7 +743,7 @@ void demo_update_data_buffer(struct demo *demo) {
 
     mat4x4_mul(VP, demo->projection_matrix, demo->view_matrix);
 
-    // Rotate 22.5 degrees around the Y axis
+    // Rotate around the Y axis
     mat4x4_dup(Model, demo->model_matrix);
     mat4x4_rotate(demo->model_matrix, Model, 0.0f, 1.0f, 0.0f,
                   (float)degreesToRadians(demo->spin_angle));
@@ -2295,12 +2295,12 @@ static void demo_handle_xlib_event(struct demo *demo, const XEvent *event) {
             demo->quit = true;
             break;
         case 0x71: // left arrow key
-            demo->spin_angle += demo->spin_increment;
-            break;
-        case 0x72: // right arrow key
             demo->spin_angle -= demo->spin_increment;
             break;
-        case 0x41:
+        case 0x72: // right arrow key
+            demo->spin_angle += demo->spin_increment;
+            break;
+        case 0x41: // space bar
             demo->pause = !demo->pause;
             break;
         }
@@ -2327,11 +2327,10 @@ static void demo_run_xlib(struct demo *demo) {
         if (demo->pause) {
             XNextEvent(demo->display, &event);
             demo_handle_xlib_event(demo, &event);
-        } else {
-            while (XPending(demo->display) > 0) {
-                XNextEvent(demo->display, &event);
-                demo_handle_xlib_event(demo, &event);
-            }
+        }
+        while (XPending(demo->display) > 0) {
+            XNextEvent(demo->display, &event);
+            demo_handle_xlib_event(demo, &event);
         }
 
         demo_update_data_buffer(demo);
@@ -2364,12 +2363,12 @@ static void demo_handle_xcb_event(struct demo *demo,
             demo->quit = true;
             break;
         case 0x71: // left arrow key
-            demo->spin_angle += demo->spin_increment;
-            break;
-        case 0x72: // right arrow key
             demo->spin_angle -= demo->spin_increment;
             break;
-        case 0x41:
+        case 0x72: // right arrow key
+            demo->spin_angle += demo->spin_increment;
+            break;
+        case 0x41: // space bar
             demo->pause = !demo->pause;
             break;
         }
@@ -2396,13 +2395,14 @@ static void demo_run_xcb(struct demo *demo) {
 
         if (demo->pause) {
             event = xcb_wait_for_event(demo->connection);
-        } else {
+        }
+        else {
             event = xcb_poll_for_event(demo->connection);
-            while(event) {
-                demo_handle_xcb_event(demo, event);
-                free(event);
-                event = xcb_poll_for_event(demo->connection);
-            }
+        }
+        while (event) {
+            demo_handle_xcb_event(demo, event);
+            free(event);
+            event = xcb_poll_for_event(demo->connection);
         }
 
         demo_update_data_buffer(demo);

--- a/demos/cube.cpp
+++ b/demos/cube.cpp
@@ -2178,7 +2178,7 @@ struct Demo {
         mat4x4 VP;
         mat4x4_mul(VP, projection_matrix, view_matrix);
 
-        // Rotate 22.5 degrees around the Y axis
+        // Rotate around the Y axis
         mat4x4 Model;
         mat4x4_dup(Model, model_matrix);
         mat4x4_rotate(model_matrix, Model, 0.0f, 1.0f, 0.0f,
@@ -2385,12 +2385,12 @@ struct Demo {
                 quit = true;
                 break;
             case 0x71: // left arrow key
-                spin_angle += spin_increment;
-                break;
-            case 0x72: // right arrow key
                 spin_angle -= spin_increment;
                 break;
-            case 0x41:
+            case 0x72: // right arrow key
+                spin_angle += spin_increment;
+                break;
+            case 0x41: // space bar
                 pause = !pause;
                 break;
             }
@@ -2415,11 +2415,10 @@ struct Demo {
             if (pause) {
                 XNextEvent(display, &event);
                 handle_xlib_event(&event);
-            } else {
-                while (XPending(display) > 0) {
-                    XNextEvent(display, &event);
-                    handle_xlib_event(&event);
-                }
+            }
+            while (XPending(display) > 0) {
+                XNextEvent(display, &event);
+                handle_xlib_event(&event);
             }
 
             update_data_buffer();
@@ -2454,12 +2453,12 @@ struct Demo {
                 quit = true;
                 break;
             case 0x71: // left arrow key
-                spin_angle += spin_increment;
-                break;
-            case 0x72: // right arrow key
                 spin_angle -= spin_increment;
                 break;
-            case 0x41:
+            case 0x72: // right arrow key
+                spin_angle += spin_increment;
+                break;
+            case 0x41: // space bar
                 pause = !pause;
                 break;
             }
@@ -2488,11 +2487,11 @@ struct Demo {
                 event = xcb_wait_for_event(connection);
             } else {
                 event = xcb_poll_for_event(connection);
-                while (event) {
-                    handle_xcb_event(event);
-                    free(event);
-                    event = xcb_poll_for_event(connection);
-                }
+            }
+            while (event) {
+                handle_xcb_event(event);
+                free(event);
+                event = xcb_poll_for_event(connection);
             }
 
             update_data_buffer();


### PR DESCRIPTION
Fixes #1316.
Rework XCB event processing code to handle events
properly and avoid hangs when pausing.
Fix polarity of decrease/increase spin rate keys.  I
suspect that this was an artifact from fixes made
to the transforms a while back.

Change-Id: I74adf7309227fafd175d8972ca930a304c58a1dd