### PR TITLE
demos: smoketest: Add --flush option for tracing

### DIFF
--- a/demos/smoke/Game.h
+++ b/demos/smoke/Game.h
@@ -47,6 +47,9 @@ public:
         bool no_render;
         bool no_present;
 
+        // Whether or not to use VkFlushMappedMemoryRanges
+        bool flush_buffers;
+
         int max_frame_count;
     };
     const Settings &settings() const { return settings_; }
@@ -97,6 +100,8 @@ public:
         settings_.no_render = false;
         settings_.no_present = false;
 
+        settings_.flush_buffers = false;
+
         settings_.max_frame_count = -1;
 
         parse_args(args);
@@ -134,6 +139,8 @@ private:
                 settings_.no_render = true;
             } else if (*it == "--np") {
                 settings_.no_present = true;
+            } else if (*it == "--flush") {
+                settings_.flush_buffers = true;
             } else if (*it == "--c") {
                 ++it;
                 settings_.max_frame_count = std::stoi(*it);

--- a/demos/smoke/Smoke.cpp
+++ b/demos/smoke/Smoke.cpp
@@ -483,14 +483,15 @@ void Smoke::create_buffer_memory()
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(dev_, frame_data_[0].buf, &mem_reqs);
 
-    VkDeviceSize aligned_size = mem_reqs.size;
-    if (aligned_size % mem_reqs.alignment)
-        aligned_size += mem_reqs.alignment - (aligned_size % mem_reqs.alignment);
+    frame_data_aligned_size_ = mem_reqs.size;
+    if (frame_data_aligned_size_ % mem_reqs.alignment)
+        frame_data_aligned_size_ += mem_reqs.alignment - 
+        (frame_data_aligned_size_ % mem_reqs.alignment);
 
     // allocate memory
     VkMemoryAllocateInfo mem_info = {};
     mem_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    mem_info.allocationSize = aligned_size * (frame_data_.size() - 1) +
+    mem_info.allocationSize = frame_data_aligned_size_ * (frame_data_.size() - 1) +
         mem_reqs.size;
 
     for (uint32_t idx = 0; idx < mem_flags_.size(); idx++) {
@@ -512,7 +513,7 @@ void Smoke::create_buffer_memory()
     for (auto &data : frame_data_) {
         vk::BindBufferMemory(dev_, data.buf, frame_data_mem_, offset);
         data.base = reinterpret_cast<uint8_t *>(ptr) + offset;
-        offset += aligned_size;
+        offset += frame_data_aligned_size_;
     }
 }
 
@@ -810,6 +811,19 @@ void Smoke::on_frame(float frame_pred)
     // record render pass commands
     for (auto &worker : workers_)
         worker->wait_idle();
+
+    // Flush buffers if enabled
+    if (settings_.flush_buffers) {
+        VkMappedMemoryRange range = {};
+        range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+        range.pNext = nullptr;
+        range.memory = frame_data_mem_;
+        range.offset = frame_data_index_ * frame_data_aligned_size_;
+        range.size = frame_data_aligned_size_;
+
+        vk::FlushMappedMemoryRanges(dev_, 1, &range);
+    }
+
     vk::CmdExecuteCommands(data.primary_cmd,
             static_cast<uint32_t>(data.worker_cmds.size()),
             data.worker_cmds.data());

--- a/demos/smoke/Smoke.h
+++ b/demos/smoke/Smoke.h
@@ -158,6 +158,7 @@ private:
     std::vector<VkCommandPool> worker_cmd_pools_;
     VkDescriptorPool desc_pool_;
     VkDeviceMemory frame_data_mem_;
+    VkDeviceSize frame_data_aligned_size_;
     std::vector<FrameData> frame_data_;
     int frame_data_index_;
 


### PR DESCRIPTION
Running smoketest with --flush will call vkFlushMappedMemoryRanges so
that the trace layer is aware of modified memory. This is not
necessary with the --PMB option in vktrace.

Change-Id: If72c0ed0c651cf82f2f2c4c78ec2534a0d475a9c