### PR TITLE
Infrastructure for Image layer merge, code segregation

### DIFF
--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -36,6 +36,7 @@ copy /Y ..\layers\vk_layer_extension_utils.cpp  generated\common\
 copy /Y ..\layers\vk_layer_utils.cpp    generated\common\
 copy /Y ..\layers\vk_layer_table.cpp    generated\common\
 copy /Y ..\layers\descriptor_sets.cpp   generated\common\
+copy /Y ..\layers\image_validation.cpp   generated\common\
 
 REM create build-script root directory
 mkdir generated\gradle-build
@@ -52,6 +53,7 @@ for %%G in (core_validation image object_tracker parameter_validation swapchain 
     echo apply from: "../common.gradle"  > generated\gradle-build\%%G\build.gradle
 )
 copy generated\common\descriptor_sets.cpp generated\layer-src\core_validation\descriptor_sets.cpp
+copy generated\common\image_validation.cpp generated\layer-src\core_validation\image_validation.cpp
 copy generated\include\vk_safe_struct.cpp generated\layer-src\core_validation\vk_safe_struct.cpp
 move generated\include\vk_safe_struct.cpp generated\layer-src\unique_objects\vk_safe_struct.cpp
 echo apply from: "../common.gradle"  > generated\gradle-build\unique_objects\build.gradle

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -36,6 +36,7 @@ cp -f ../layers/vk_layer_extension_utils.cpp  generated/common/
 cp -f ../layers/vk_layer_utils.cpp    generated/common/
 cp -f ../layers/vk_layer_table.cpp    generated/common/
 cp -f ../layers/descriptor_sets.cpp   generated/common/
+cp -f ../layers/image_validation.cpp  generated/common/
 
 # layer names and their original source files directory
 # 1 to 1 correspondence -- one layer one source file; additional files are copied
@@ -61,6 +62,7 @@ done
 
 # fixup - unique_objects need one more file
 cp  generated/common/descriptor_sets.cpp ${SRC_ROOT}/core_validation/descriptor_sets.cpp
+cp  generated/common/image_validation.cpp ${SRC_ROOT}/core_validation/image_validation.cpp
 cp  generated/include/vk_safe_struct.cpp ${SRC_ROOT}/core_validation/vk_safe_struct.cpp
 mv  generated/include/vk_safe_struct.cpp ${SRC_ROOT}/unique_objects/vk_safe_struct.cpp
 

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -33,6 +33,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_core_validation
 LOCAL_SRC_FILES += $(LAYER_DIR)/layer-src/core_validation/core_validation.cpp
 LOCAL_SRC_FILES += $(LAYER_DIR)/layer-src/core_validation/descriptor_sets.cpp
+LOCAL_SRC_FILES += $(LAYER_DIR)/layer-src/core_validation/image_validation.cpp
 LOCAL_SRC_FILES += $(LAYER_DIR)/common/vk_layer_table.cpp
 LOCAL_C_INCLUDES += $(SRC_DIR)/include \
                     $(SRC_DIR)/layers \

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -165,7 +165,7 @@ else()
     install(TARGETS VkLayer_utils DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
-add_vk_layer(core_validation core_validation.cpp vk_layer_table.cpp descriptor_sets.cpp)
+add_vk_layer(core_validation core_validation.cpp vk_layer_table.cpp descriptor_sets.cpp image_validation.cpp)
 add_vk_layer(object_tracker object_tracker.cpp vk_layer_table.cpp)
 add_vk_layer(image image.cpp vk_layer_table.cpp)
 add_vk_layer(swapchain swapchain.cpp vk_layer_table.cpp)

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -174,6 +174,7 @@ struct layer_data {
     // Device specific data
     PHYS_DEV_PROPERTIES_NODE phys_dev_properties = {};
     VkPhysicalDeviceMemoryProperties phys_dev_mem_props = {};
+    VkPhysicalDeviceProperties phys_dev_props = {};
 };
 
 // TODO : Do we need to guard access to layer_data_map w/ lock?
@@ -4280,8 +4281,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     } else {
         memset(&my_device_data->enabled_features, 0, sizeof(VkPhysicalDeviceFeatures));
     }
-    // Store physical device mem limits into device layer_data struct
+    // Store physical device properties and physical device mem limits into device layer_data structs
     my_instance_data->dispatch_table.GetPhysicalDeviceMemoryProperties(gpu, &my_device_data->phys_dev_mem_props);
+    my_instance_data->dispatch_table.GetPhysicalDeviceProperties(gpu, &my_device_data->phys_dev_props);
     lock.unlock();
 
     ValidateLayerOrdering(*pCreateInfo);

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -61,6 +61,7 @@
 #pragma GCC diagnostic warning "-Wwrite-strings"
 #endif
 #include "core_validation.h"
+#include "image_validation.h"
 #include "vk_layer_table.h"
 #include "vk_layer_data.h"
 #include "vk_layer_extension_utils.h"
@@ -6482,13 +6483,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(VkDevice device, const VkImageCreateI
 
     if (VK_SUCCESS == result) {
         std::lock_guard<std::mutex> lock(global_lock);
-        IMAGE_LAYOUT_NODE image_state;
-        image_state.layout = pCreateInfo->initialLayout;
-        image_state.format = pCreateInfo->format;
-        dev_data->imageMap.insert(std::make_pair(*pImage, unique_ptr<IMAGE_STATE>(new IMAGE_STATE(*pImage, pCreateInfo))));
-        ImageSubresourcePair subpair = {*pImage, false, VkImageSubresource()};
-        dev_data->imageSubresourceMap[*pImage].push_back(subpair);
-        dev_data->imageLayoutMap[subpair] = image_state;
+        PostCallRecordCreateImage(&dev_data->imageMap, &dev_data->imageSubresourceMap, &dev_data->imageLayoutMap, pCreateInfo,
+                                  pImage);
     }
     return result;
 }

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -139,11 +139,6 @@ struct GENERIC_HEADER {
     const void *pNext;
 };
 
-struct IMAGE_LAYOUT_NODE {
-    VkImageLayout layout;
-    VkFormat format;
-};
-
 class PHYS_DEV_PROPERTIES_NODE {
   public:
     VkPhysicalDeviceProperties properties;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -639,6 +639,11 @@ struct CB_SUBMISSION {
     VkFence fence;
 };
 
+struct IMAGE_LAYOUT_NODE {
+    VkImageLayout layout;
+    VkFormat format;
+};
+
 // Fwd declarations of layer_data and helpers to look-up/validate state from layer_data maps
 namespace core_validation {
 struct layer_data;

--- a/layers/image_validation.cpp
+++ b/layers/image_validation.cpp
@@ -24,6 +24,20 @@
 #include "image_validation.h"
 #include "vk_enum_string_helper.h"
 #include "vk_safe_struct.h"
+#include "vulkan/vk_layer.h"
 #include <sstream>
 #include <algorithm>
+#include <memory>
 
+VK_LAYER_EXPORT void PostCallRecordCreateImage(std::unordered_map<VkImage, std::unique_ptr<IMAGE_STATE>> *imageMap,
+                                               std::unordered_map<VkImage, std::vector<ImageSubresourcePair>> *imageSubresourceMap,
+                                               std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> *imageLayoutMap,
+                                               const VkImageCreateInfo *pCreateInfo, VkImage *pImage) {
+    IMAGE_LAYOUT_NODE image_state;
+    image_state.layout = pCreateInfo->initialLayout;
+    image_state.format = pCreateInfo->format;
+    imageMap->insert(std::make_pair(*pImage, std::unique_ptr<IMAGE_STATE>(new IMAGE_STATE(*pImage, pCreateInfo))));
+    ImageSubresourcePair subpair = {*pImage, false, VkImageSubresource()};
+    (*imageSubresourceMap)[*pImage].push_back(subpair);
+    (*imageLayoutMap)[subpair] = image_state;
+}

--- a/layers/image_validation.cpp
+++ b/layers/image_validation.cpp
@@ -1,0 +1,29 @@
+/* Copyright (c) 2015-2016 The Khronos Group Inc.
+ * Copyright (c) 2015-2016 Valve Corporation
+ * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (C) 2015-2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Mark Lobodzinski <mark@lunarg.com>
+ */
+
+// Allow use of STL min and max functions in Windows
+#define NOMINMAX
+
+#include "image_validation.h"
+#include "vk_enum_string_helper.h"
+#include "vk_safe_struct.h"
+#include <sstream>
+#include <algorithm>
+

--- a/layers/image_validation.h
+++ b/layers/image_validation.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2015-2016 The Khronos Group Inc.
+ * Copyright (c) 2015-2016 Valve Corporation
+ * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (C) 2015-2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Mark Lobodzinski <mark@lunarg.com>
+ */
+#ifndef CORE_VALIDATION_IMAGE_VALIDATION_H_
+#define CORE_VALIDATION_IMAGE_VALIDATION_H_
+
+#include "core_validation_error_enums.h"
+#include "vk_validation_error_messages.h"
+#include "core_validation_types.h"
+#include "vk_layer_logging.h"
+#include "vk_layer_utils.h"
+#include "vk_safe_struct.h"
+#include "vulkan/vk_layer.h"
+#include <map>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#endif // CORE_VALIDATION_IMAGE_VALIDATION_H_

--- a/layers/image_validation.h
+++ b/layers/image_validation.h
@@ -33,17 +33,9 @@
 #include <unordered_set>
 #include <vector>
 
-
-
-
-
-
-
-
-
-
-
-
-
+VK_LAYER_EXPORT void PostCallRecordCreateImage(std::unordered_map<VkImage, std::unique_ptr<IMAGE_STATE>> *imageMap,
+    std::unordered_map<VkImage, std::vector<ImageSubresourcePair>> *imageSubresourceMap,
+    std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> *imageLayoutMap,
+    const VkImageCreateInfo *pCreateInfo, VkImage *pImage);
 
 #endif // CORE_VALIDATION_IMAGE_VALIDATION_H_


### PR DESCRIPTION
Add image_validation.cpp and image_validation.h to the repo -- these'll hold the image-related validation source.  Also, some reshuffling of some stuff formerly included in core_validation.cpp that needed to move into the header to make things visible to other modules, mostly related to the layer_data structures.  Also, moved a small portion of the CreateImage validation code into the new module as a proof-of-concept, for feedback and improvement.

The idea is that much of the current CV image-related validation can go into this new module, along with everything else that's in the image layer currently.  The long-term goal is to have CV contain only the top-level intercept functions, with all the other stuff residing elsewhere.