### PR TITLE
loader: Fix static analysis warnings

### DIFF
--- a/loader/debug_report.c
+++ b/loader/debug_report.c
@@ -336,8 +336,10 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDebugReportCallback(
             pAllocator->pUserData,
             inst->total_icd_count * sizeof(VkDebugReportCallbackEXT),
             sizeof(void *), VK_SYSTEM_ALLOCATION_SCOPE_OBJECT));
-        memset(icd_info, 0,
-               inst->total_icd_count * sizeof(VkDebugReportCallbackEXT));
+        if (icd_info) {
+            memset(icd_info, 0,
+                   inst->total_icd_count * sizeof(VkDebugReportCallbackEXT));
+        }
     } else {
 #endif
         icd_info =
@@ -407,7 +409,7 @@ out:
                 continue;
             }
 
-            if (icd_info[storage_idx]) {
+            if (icd_info && icd_info[storage_idx]) {
                 icd_term->DestroyDebugReportCallbackEXT(
                     icd_term->instance, icd_info[storage_idx], pAllocator);
             }

--- a/loader/extensions.c
+++ b/loader/extensions.c
@@ -305,9 +305,10 @@ terminator_GetPhysicalDeviceGeneratedCommandsPropertiesNVX(
         loader_log(icd_term->this_instance, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,
                    "ICD associated with VkPhysicalDevice does not support "
                    "vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX");
+    } else {
+        icd_term->GetPhysicalDeviceGeneratedCommandsPropertiesNVX(
+            phys_dev_term->phys_dev, pFeatures, pLimits);
     }
-    icd_term->GetPhysicalDeviceGeneratedCommandsPropertiesNVX(
-        phys_dev_term->phys_dev, pFeatures, pLimits);
 }
 
 // GPA helpers for non-KHR extensions

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -584,10 +584,10 @@ VkResult loaderGetRegistryFiles(const struct loader_instance *inst,
                     total_size *= 2;
                 }
                 if (strlen(*reg_data) == 0) {
-                    snprintf(*reg_data, name_size + 1, "%s", name);
+                    (void)snprintf(*reg_data, name_size + 1, "%s", name);
                 } else {
-                    snprintf(*reg_data + strlen(*reg_data), name_size + 2,
-                        "%c%s", PATH_SEPARATOR, name);
+                    (void)snprintf(*reg_data + strlen(*reg_data), name_size + 2,
+                                   "%c%s", PATH_SEPARATOR, name);
                 }
                 found = true;
             }
@@ -633,8 +633,8 @@ static size_t loader_platform_combine_path(char *dest, size_t len, ...) {
             // This path element is not the first non-empty element; prepend
             // a directory separator if space allows
             if (dest && required_len + 1 < len) {
-                snprintf(dest + required_len, len - required_len, "%c",
-                         DIRECTORY_SYMBOL);
+                (void)snprintf(dest + required_len, len - required_len, "%c",
+                               DIRECTORY_SYMBOL);
             }
             required_len++;
         }
@@ -860,10 +860,10 @@ static VkResult loader_add_instance_extensions(
         bool ext_unsupported =
             wsi_unsupported_instance_extension(&ext_props[i]);
         if (!ext_unsupported) {
-            snprintf(spec_version, sizeof(spec_version), "%d.%d.%d",
-                     VK_MAJOR(ext_props[i].specVersion),
-                     VK_MINOR(ext_props[i].specVersion),
-                     VK_PATCH(ext_props[i].specVersion));
+            (void)snprintf(spec_version, sizeof(spec_version), "%d.%d.%d",
+                           VK_MAJOR(ext_props[i].specVersion),
+                           VK_MINOR(ext_props[i].specVersion),
+                           VK_PATCH(ext_props[i].specVersion));
             loader_log(inst, VK_DEBUG_REPORT_DEBUG_BIT_EXT, 0,
                        "Instance Extension: %s (%s) version %s",
                        ext_props[i].extensionName, lib_name, spec_version);
@@ -904,10 +904,10 @@ loader_init_device_extensions(const struct loader_instance *inst,
     for (i = 0; i < count; i++) {
         char spec_version[64];
 
-        snprintf(spec_version, sizeof(spec_version), "%d.%d.%d",
-                 VK_MAJOR(ext_props[i].specVersion),
-                 VK_MINOR(ext_props[i].specVersion),
-                 VK_PATCH(ext_props[i].specVersion));
+        (void)snprintf(spec_version, sizeof(spec_version), "%d.%d.%d",
+                       VK_MAJOR(ext_props[i].specVersion),
+                       VK_MINOR(ext_props[i].specVersion),
+                       VK_PATCH(ext_props[i].specVersion));
         loader_log(
             inst, VK_DEBUG_REPORT_DEBUG_BIT_EXT, 0,
             "Device Extension: %s (%s) version %s", ext_props[i].extensionName,
@@ -948,10 +948,10 @@ VkResult loader_add_device_extensions(const struct loader_instance *inst,
         for (i = 0; i < count; i++) {
             char spec_version[64];
 
-            snprintf(spec_version, sizeof(spec_version), "%d.%d.%d",
-                     VK_MAJOR(ext_props[i].specVersion),
-                     VK_MINOR(ext_props[i].specVersion),
-                     VK_PATCH(ext_props[i].specVersion));
+            (void)snprintf(spec_version, sizeof(spec_version), "%d.%d.%d",
+                           VK_MAJOR(ext_props[i].specVersion),
+                           VK_MINOR(ext_props[i].specVersion),
+                           VK_PATCH(ext_props[i].specVersion));
             loader_log(inst, VK_DEBUG_REPORT_DEBUG_BIT_EXT, 0,
                        "Device Extension: %s (%s) version %s",
                        ext_props[i].extensionName, lib_name, spec_version);
@@ -2004,7 +2004,7 @@ static void loader_get_fullpath(const char *file, const char *dirs,
         }
     }
 
-    snprintf(out_fullpath, out_size, "%s", file);
+    (void)snprintf(out_fullpath, out_size, "%s", file);
 }
 
 /**
@@ -3740,7 +3740,8 @@ static bool loader_name_in_dev_ext_table(struct loader_instance *inst,
     // search the list of secondary locations (shallow search, not deep search)
     for (uint32_t i = 0; i < inst->disp_hash[*idx].list.count; i++) {
         alt_idx = inst->disp_hash[*idx].list.index[i];
-        if (!strcmp(inst->disp_hash[*idx].func_name, funcName)) {
+        if (inst->disp_hash[*idx].func_name &&
+            !strcmp(inst->disp_hash[*idx].func_name, funcName)) {
             *idx = alt_idx;
             return true;
         }
@@ -4578,6 +4579,9 @@ out:
 VKAPI_ATTR void VKAPI_CALL terminator_DestroyInstance(
     VkInstance instance, const VkAllocationCallbacks *pAllocator) {
     struct loader_instance *ptr_instance = loader_instance(instance);
+    if (NULL == ptr_instance) {
+        return;
+    }
     struct loader_icd_term *icd_terms = ptr_instance->icd_terms;
     struct loader_icd_term *next_icd_term;
 

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -321,7 +321,8 @@ loader_platform_open_library(const char *libPath) {
 }
 static char *loader_platform_open_library_error(const char *libPath) {
     static char errorMsg[164];
-    snprintf(errorMsg, 163, "Failed to open dynamic library \"%s\"", libPath);
+    (void)snprintf(errorMsg, 163, "Failed to open dynamic library \"%s\"",
+                   libPath);
     return errorMsg;
 }
 static void loader_platform_close_library(loader_platform_dl_handle library) {
@@ -335,8 +336,8 @@ static void *loader_platform_get_proc_address(loader_platform_dl_handle library,
 }
 static char *loader_platform_get_proc_address_error(const char *name) {
     static char errorMsg[120];
-    snprintf(errorMsg, 119, "Failed to find function \"%s\" in dynamic library",
-             name);
+    (void)snprintf(errorMsg, 119,
+                   "Failed to find function \"%s\" in dynamic library", name);
     return errorMsg;
 }
 


### PR DESCRIPTION
Handle possible null pointer dereferences.
Misc other warnings, nothing too serious.
Not addressing alloca concerns yet.

Change-Id: I712a6b4996a4d900604867e373521ff4d1c53df5