### PR TITLE
build: Turn on "treat warnings as errors" on Win

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,9 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 endif()
 
 if(WIN32)
-    # Disable RTTI
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+    # Disable RTTI, Treat warnings as errors
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR- /WX")
 endif()
 
 if(NOT WIN32)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required (VERSION 2.8.11)
-
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
     set(DisplayServer Win32)
@@ -122,6 +121,9 @@ if (WIN32)
     set (CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE} -D_CRT_SECURE_NO_WARNINGS")
     set (CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -D_CRT_SECURE_NO_WARNINGS /bigobj")
     set (CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} -D_CRT_SECURE_NO_WARNINGS /bigobj")
+    # Turn off transitional "changed behavior" warning message for Visual Studio versions prior to 2015.
+    # The changed behavior is that constructor initializers are now fixed to clear the struct members.
+    add_compile_options("$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19>>:/wd4351>")
 else()
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpointer-arith -Wno-unused-function -Wno-sign-compare")
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Wno-unused-function -Wno-sign-compare")

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -90,6 +90,8 @@ if (WIN32)
     target_compile_options(loader-opt PUBLIC "$<$<CONFIG:DEBUG>:${LOCAL_C_FLAGS_REL}>")
     add_library(${API_LOWERCASE}-${MAJOR} SHARED $<TARGET_OBJECTS:loader-opt> $<TARGET_OBJECTS:loader-norm> ${CMAKE_CURRENT_BINARY_DIR}/${API_LOWERCASE}-${MAJOR}.def ${CMAKE_CURRENT_SOURCE_DIR}/loader.rc)
     add_library(VKstatic.${MAJOR} STATIC $<TARGET_OBJECTS:loader-opt> $<TARGET_OBJECTS:loader-norm>)
+    # Suppress conflicting libs warning for debug builds.
+    set_target_properties(${API_LOWERCASE}-${MAJOR} PROPERTIES LINK_FLAGS_DEBUG /ignore:4098)
     set_target_properties(VKstatic.${MAJOR} PROPERTIES OUTPUT_NAME VKstatic.${MAJOR})
     target_link_libraries(${API_LOWERCASE}-${MAJOR} shlwapi)
     target_link_libraries(VKstatic.${MAJOR} shlwapi)

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -22,10 +22,21 @@
 
 #include "vktestframework.h"
 #include "vkrenderframework.h"
+
+// For versions prior to VS 2015, suppress the warning
+// caused by the inconsistent redefinition of snprintf
+// between a vulkan header and a glslang header.
+#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
+#pragma warning(push)
+#pragma warning(disable : 4005)
+#endif
 // TODO FIXME remove this once glslang doesn't define this
 #undef BadValue
 #include "SPIRV/GlslangToSpv.h"
 #include "SPIRV/SPVRemapper.h"
+#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
+#pragma warning(pop)
+#endif
 #include <limits.h>
 #include <math.h>
 


### PR DESCRIPTION
Address compiler warnings:

- Suppress warnings for inconsistently redefined snprintf
  on Windows with Visual Studio < 2015.  Warnings for
  preprocessor redefinitions are still enabled on VS 2015
  because snprintf is not redefined on VS 2015.

- Turn off "changed behavior" warning with Visual Studio < 2015
  for using initializers in constructors.  MSFT "fixed" some
  forms of these initializers so that they clear members instead
  of just leaving them alone.  Since clearing is usually desired,
  this isn't a problem in most cases.  But if an object is
  reinstantiated on top of an existing object, via placement new
  for example, the clearing may not be desired if the first object's
  data was meant to be preserved.  We don't count on this behavior.

- Suppress linker warning for linking the loader in debug build on
  Windows.  This warning is for mismatched runtime libraries and
  causes extra code to be linked in only for debug builds.  Ignoring
  the warning is generally regarded as better than the alternatives.

Change-Id: I8b0e311d3c80a8dd9ac0cc95f764ed1123efa86f