### PR TITLE
build: Enable declaration hiding warning on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,12 @@ if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 endif()
 
 if(WIN32)
-    # Disable RTTI, Treat warnings as errors
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR- /WX")
+    # Treat warnings as errors
+    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/WX>")
+    # Disable RTTI
+    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/GR->")
+    # Warn about nested declarations
+    add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/w34456>")
 endif()
 
 if(NOT WIN32)

--- a/demos/cube.cpp
+++ b/demos/cube.cpp
@@ -479,16 +479,16 @@ struct Demo {
             // present queue before presenting, waiting for the draw complete
             // semaphore and signalling the ownership released semaphore when
             // finished
-            auto const submit_info = vk::SubmitInfo()
-                                         .setPWaitDstStageMask(&pipe_stage_flags)
-                                         .setWaitSemaphoreCount(1)
-                                         .setPWaitSemaphores(&draw_complete_semaphores[frame_index])
-                                         .setCommandBufferCount(1)
-                                         .setPCommandBuffers(&buffers[current_buffer].graphics_to_present_cmd)
-                                         .setSignalSemaphoreCount(1)
-                                         .setPSignalSemaphores(&image_ownership_semaphores[frame_index]);
+            auto const present_submit_info = vk::SubmitInfo()
+                                                 .setPWaitDstStageMask(&pipe_stage_flags)
+                                                 .setWaitSemaphoreCount(1)
+                                                 .setPWaitSemaphores(&draw_complete_semaphores[frame_index])
+                                                 .setCommandBufferCount(1)
+                                                 .setPCommandBuffers(&buffers[current_buffer].graphics_to_present_cmd)
+                                                 .setSignalSemaphoreCount(1)
+                                                 .setPSignalSemaphores(&image_ownership_semaphores[frame_index]);
 
-            result = present_queue.submit(1, &submit_info, vk::Fence());
+            result = present_queue.submit(1, &present_submit_info, vk::Fence());
             VERIFY(result == vk::Result::eSuccess);
         }
 
@@ -1153,18 +1153,18 @@ struct Demo {
         }
 
         if (separate_present_queue) {
-            auto const cmd_pool_info = vk::CommandPoolCreateInfo().setQueueFamilyIndex(present_queue_family_index);
+            auto const present_cmd_pool_info = vk::CommandPoolCreateInfo().setQueueFamilyIndex(present_queue_family_index);
 
-            result = device.createCommandPool(&cmd_pool_info, nullptr, &present_cmd_pool);
+            result = device.createCommandPool(&present_cmd_pool_info, nullptr, &present_cmd_pool);
             VERIFY(result == vk::Result::eSuccess);
 
-            auto const cmd = vk::CommandBufferAllocateInfo()
-                                 .setCommandPool(present_cmd_pool)
-                                 .setLevel(vk::CommandBufferLevel::ePrimary)
-                                 .setCommandBufferCount(1);
+            auto const present_cmd = vk::CommandBufferAllocateInfo()
+                                         .setCommandPool(present_cmd_pool)
+                                         .setLevel(vk::CommandBufferLevel::ePrimary)
+                                         .setCommandBufferCount(1);
 
             for (uint32_t i = 0; i < swapchainImageCount; i++) {
-                result = device.allocateCommandBuffers(&cmd, &buffers[i].graphics_to_present_cmd);
+                result = device.allocateCommandBuffers(&present_cmd, &buffers[i].graphics_to_present_cmd);
                 VERIFY(result == vk::Result::eSuccess);
 
                 build_image_ownership_cmd(i);

--- a/demos/vulkaninfo.c
+++ b/demos/vulkaninfo.c
@@ -1395,10 +1395,10 @@ static void ConsoleEnlarge() {
 #endif
 
 int main(int argc, char **argv) {
-    unsigned int major, minor, patch;
+    uint32_t vulkan_major, vulkan_minor, vulkan_patch;
     struct AppGpu *gpus;
     VkPhysicalDevice *objs;
-    uint32_t gpu_count, i;
+    uint32_t gpu_count;
     VkResult err;
     struct AppInstance inst;
 
@@ -1406,14 +1406,14 @@ int main(int argc, char **argv) {
     if (ConsoleIsExclusive()) ConsoleEnlarge();
 #endif
 
-    major = VK_VERSION_MAJOR(VK_API_VERSION_1_0);
-    minor = VK_VERSION_MINOR(VK_API_VERSION_1_0);
-    patch = VK_VERSION_PATCH(VK_HEADER_VERSION);
+    vulkan_major = VK_VERSION_MAJOR(VK_API_VERSION_1_0);
+    vulkan_minor = VK_VERSION_MINOR(VK_API_VERSION_1_0);
+    vulkan_patch = VK_VERSION_PATCH(VK_HEADER_VERSION);
 
     printf("===========\n");
     printf("VULKAN INFO\n");
     printf("===========\n\n");
-    printf("Vulkan API Version: %d.%d.%d\n\n", major, minor, patch);
+    printf("Vulkan API Version: %d.%d.%d\n\n", vulkan_major, vulkan_minor, vulkan_patch);
 
     AppCreateInstance(&inst);
 
@@ -1430,7 +1430,7 @@ int main(int argc, char **argv) {
 
     gpus = malloc(sizeof(gpus[0]) * gpu_count);
     if (!gpus) ERR_EXIT(VK_ERROR_OUT_OF_HOST_MEMORY);
-    for (i = 0; i < gpu_count; i++) {
+    for (uint32_t i = 0; i < gpu_count; i++) {
         AppGpuInit(&gpus[i], i, objs[i]);
         printf("\n\n");
     }
@@ -1439,12 +1439,12 @@ int main(int argc, char **argv) {
     printf("Layers: count = %d\n", inst.global_layer_count);
     printf("=======\n");
     for (uint32_t i = 0; i < inst.global_layer_count; i++) {
-        uint32_t major, minor, patch;
+        uint32_t layer_major, layer_minor, layer_patch;
         char spec_version[64], layer_version[64];
         VkLayerProperties const *layer_prop = &inst.global_layers[i].layer_properties;
 
-        ExtractVersion(layer_prop->specVersion, &major, &minor, &patch);
-        snprintf(spec_version, sizeof(spec_version), "%d.%d.%d", major, minor, patch);
+        ExtractVersion(layer_prop->specVersion, &layer_major, &layer_minor, &layer_patch);
+        snprintf(spec_version, sizeof(spec_version), "%d.%d.%d", layer_major, layer_minor, layer_patch);
         snprintf(layer_version, sizeof(layer_version), "%d", layer_prop->implementationVersion);
         printf("%s (%s) Vulkan version %s, layer version %s\n", layer_prop->layerName, (char *)layer_prop->description,
                spec_version, layer_version);
@@ -1484,7 +1484,7 @@ int main(int argc, char **argv) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     if (HasExtension(VK_KHR_WIN32_SURFACE_EXTENSION_NAME, inst.global_extension_count, inst.global_extensions)) {
         AppCreateWin32Window(&inst);
-        for (i = 0; i < gpu_count; i++) {
+        for (uint32_t i = 0; i < gpu_count; i++) {
             AppCreateWin32Surface(&inst);
             printf("GPU id       : %u (%s)\n", i, gpus[i].props.deviceName);
             printf("Surface type : %s\n", VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
@@ -1498,7 +1498,7 @@ int main(int argc, char **argv) {
 #elif VK_USE_PLATFORM_XCB_KHR
     if (HasExtension(VK_KHR_XCB_SURFACE_EXTENSION_NAME, inst.global_extension_count, inst.global_extensions)) {
         AppCreateXcbWindow(&inst);
-        for (i = 0; i < gpu_count; i++) {
+        for (uint32_t i = 0; i < gpu_count; i++) {
             AppCreateXcbSurface(&inst);
             printf("GPU id       : %u (%s)\n", i, gpus[i].props.deviceName);
             printf("Surface type : %s\n", VK_KHR_XCB_SURFACE_EXTENSION_NAME);
@@ -1512,7 +1512,7 @@ int main(int argc, char **argv) {
 #elif VK_USE_PLATFORM_XLIB_KHR
     if (HasExtension(VK_KHR_XLIB_SURFACE_EXTENSION_NAME, inst.global_extension_count, inst.global_extensions)) {
         AppCreateXlibWindow(&inst);
-        for (i = 0; i < gpu_count; i++) {
+        for (uint32_t i = 0; i < gpu_count; i++) {
             AppCreateXlibSurface(&inst);
             printf("GPU id       : %u (%s)\n", i, gpus[i].props.deviceName);
             printf("Surface type : %s\n", VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
@@ -1527,12 +1527,12 @@ int main(int argc, char **argv) {
     if (!format_count && !present_mode_count) printf("None found\n");
     //---------
 
-    for (i = 0; i < gpu_count; i++) {
+    for (uint32_t i = 0; i < gpu_count; i++) {
         AppGpuDump(&gpus[i]);
         printf("\n\n");
     }
 
-    for (i = 0; i < gpu_count; i++) AppGpuDestroy(&gpus[i]);
+    for (uint32_t i = 0; i < gpu_count; i++) AppGpuDestroy(&gpus[i]);
     free(gpus);
     free(objs);
 

--- a/layers/object_tracker.cpp
+++ b/layers/object_tracker.cpp
@@ -4338,7 +4338,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(VkDevice device, const VkD
     if (dev_data->dispatch_table.RegisterDeviceEventEXT) {
         result = dev_data->dispatch_table.RegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence);
         if (result == VK_SUCCESS && pFence != NULL) {
-            std::lock_guard<std::mutex> lock(global_lock);
+            std::lock_guard<std::mutex> create_lock(global_lock);
             CreateObject(device, *pFence, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, pAllocator);
         }
     }
@@ -4360,7 +4360,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(VkDevice device, VkDispla
     if (dev_data->dispatch_table.RegisterDisplayEventEXT) {
         result = dev_data->dispatch_table.RegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence);
         if (result == VK_SUCCESS && pFence != NULL) {
-            std::lock_guard<std::mutex> lock(global_lock);
+            std::lock_guard<std::mutex> create_lock(global_lock);
             CreateObject(device, *pFence, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, pAllocator);
         }
     }

--- a/layers/threading.h
+++ b/layers/threading.h
@@ -101,10 +101,10 @@ class counter {
                             counter_condition.wait(lock);
                         }
                         // There is now no current use of the object.  Record writer thread.
-                        struct object_use_data *use_data = &uses[object];
-                        use_data->thread = tid;
-                        use_data->reader_count = 0;
-                        use_data->writer_count = 1;
+                        struct object_use_data *new_use_data = &uses[object];
+                        new_use_data->thread = tid;
+                        new_use_data->reader_count = 0;
+                        new_use_data->writer_count = 1;
                     } else {
                         // Continue with an unsafe use of the object.
                         use_data->thread = tid;
@@ -128,10 +128,10 @@ class counter {
                             counter_condition.wait(lock);
                         }
                         // There is now no current use of the object.  Record writer thread.
-                        struct object_use_data *use_data = &uses[object];
-                        use_data->thread = tid;
-                        use_data->reader_count = 0;
-                        use_data->writer_count = 1;
+                        struct object_use_data *new_use_data = &uses[object];
+                        new_use_data->thread = tid;
+                        new_use_data->reader_count = 0;
+                        new_use_data->writer_count = 1;
                     } else {
                         // Continue with an unsafe use of the object.
                         use_data->thread = tid;

--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -103,7 +103,6 @@ static void checkInstanceRegisterExtensions(const VkInstanceCreateInfo *pCreateI
 #endif
 
         // Check for recognized instance extensions
-        layer_data *instance_data = get_my_data_ptr(get_dispatch_key(instance), layer_data_map);
         if (!white_list(pCreateInfo->ppEnabledExtensionNames[i], kUniqueObjectsSupportedInstanceExtensions)) {
             log_msg(instance_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
                     VALIDATION_ERROR_UNDEFINED, "UniqueObjects",

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2641,7 +2641,6 @@ TEST_F(VkLayerTest, ImageSampleCounts) {
     // buffer to image
     {
         vk_testing::Buffer src_buffer;
-        VkMemoryPropertyFlags reqs = 0;
         src_buffer.init_as_src(*m_device, 128 * 128 * 4, reqs);
         image_create_info.samples = VK_SAMPLE_COUNT_8_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
@@ -20503,7 +20502,7 @@ TEST_F(VkPositiveLayerTest, ValidStructPNext) {
         buffer_create_info.pQueueFamilyIndices = &queue_family_index;
 
         VkBuffer buffer;
-        VkResult err = vkCreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
+        err = vkCreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
         ASSERT_VK_SUCCESS(err);
 
         VkMemoryRequirements memory_reqs;


### PR DESCRIPTION
Fixes #1388
Turn on the Windows compiler option (4456) to report
hidden declarations.
Fix all places where this was occurring.

Change-Id: I3346d87da8b70d6299c206fcac68520a091ed1a6