### PR TITLE
loader: Minor language clarification, fix markup.

### DIFF
--- a/loader/LoaderAndLayerInterface.md
+++ b/loader/LoaderAndLayerInterface.md
@@ -62,12 +62,12 @@ wanting a better understanding of the Vulkan runtime.
 
 #### The Loader
 
-As you can see, the application sits on one end, and interfaces directly to the
-loader.  The loader itself can contain some number of [layers](#layers), which
-provide special functionality an application may wish to take advantage of.
-Finally, on the other end of the loader from the application are the ICDs, which
+The application sits on one end of, and interfaces directly with, the
+loader.  On the other end of the loader from the application are the ICDs, which
 control the Vulkan-capable hardware.  An important point to remember is that
-Vulkan-capable hardware can be graphics-based, compute-based, or both.
+Vulkan-capable hardware can be graphics-based, compute-based, or both. Between
+the application and the ICDs the loader can inject a number of optional
+[layers](#layers) that provide special functionality.
 
 The loader is responsible for working with the various layers as well as
 supporting multiple GPUs and their drivers.  Any Vulkan function may
@@ -371,7 +371,7 @@ backwards compatibility is guaranteed for all versions with the same major
 number (e.g. 1.0 and 1.1). On Windows, the loader library encodes the ABI
 version in its name such that multiple ABI incompatible versions of the loader
 can peacefully coexist on a given system. The Vulkan loader library file name is
-"vulkan-<ABI version>.dll". For example, for Vulkan version 1.X on Windows the
+`vulkan-<ABI version>.dll`. For example, for Vulkan version 1.X on Windows the
 library filename is vulkan-1.dll. And this library file can typically be found
 in the windows/system32 directory (on 64-bit Windows installs, the 32-bit
 version of the loader with the same name can be found in the windows/sysWOW64


### PR DESCRIPTION
The layers are not "inside" the loader as was implied by the previous language.

Add missing markup so that the `<abi version>` portion of the loader filename renders correctly in a web browser.