### PR TITLE
cube: Error handling improvements

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -91,7 +91,7 @@ bool in_callback = false;
 #else
 #define ERR_EXIT(err_msg, err_class) \
     do {                             \
-        printf(err_msg);             \
+        printf("%s\n", err_msg);     \
         fflush(stdout);              \
         exit(1);                     \
     } while (0)
@@ -1661,6 +1661,9 @@ static VkShaderModule demo_prepare_vs(struct demo *demo) {
     size_t size;
 
     vertShaderCode = demo_read_spv("cube-vert.spv", &size);
+    if (!vertShaderCode) {
+        ERR_EXIT("Failed to load cube-vert.spv", "Load Shader Failure");
+    }
 
     demo->vert_shader_module =
         demo_prepare_shader_module(demo, vertShaderCode, size);
@@ -1686,6 +1689,9 @@ static VkShaderModule demo_prepare_fs(struct demo *demo) {
     size_t size;
 
     fragShaderCode = demo_read_spv("cube-frag.spv", &size);
+    if (!fragShaderCode) {
+        ERR_EXIT("Failed to load cube-frag.spv", "Load Shader Failure");
+    }
 
     demo->frag_shader_module =
         demo_prepare_shader_module(demo, fragShaderCode, size);

--- a/demos/cube.cpp
+++ b/demos/cube.cpp
@@ -64,7 +64,7 @@
 #else
 #define ERR_EXIT(err_msg, err_class) \
     do {                             \
-        printf(err_msg);             \
+        printf("%s\n", err_msg);     \
         fflush(stdout);              \
         exit(1);                     \
     } while (0)
@@ -1555,6 +1555,9 @@ struct Demo {
     vk::ShaderModule prepare_fs() {
         size_t size = 0;
         void *fragShaderCode = read_spv("cube-frag.spv", &size);
+        if (!fragShaderCode) {
+            ERR_EXIT("Failed to load cube-frag.spv", "Load Shader Failure");
+        }
 
         frag_shader_module = prepare_shader_module(fragShaderCode, size);
 
@@ -1861,6 +1864,9 @@ struct Demo {
     vk::ShaderModule prepare_vs() {
         size_t size = 0;
         void *vertShaderCode = read_spv("cube-vert.spv", &size);
+        if (!vertShaderCode) {
+            ERR_EXIT("Failed to load cube-vert.spv", "Load Shader Failure");
+        }
 
         vert_shader_module = prepare_shader_module(vertShaderCode, size);
 


### PR DESCRIPTION
- Add a newline to the end of the error message when printing to stdout
  for ERR_EXIT.
- Handle demo_read_spv failures by calling ERR_EXIT rather than just
  continuing on and calling the Vulkan library with a NULL pointer.