### PR TITLE
GH706 -- Allow validation with NV_GLSL_SHADER extension

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -1660,7 +1660,8 @@ static VkShaderModule demo_prepare_vs(struct demo *demo) {
     void *vertShaderCode;
     size_t size;
 
-    vertShaderCode = demo_read_spv("cube-vert.spv", &size);
+    // DO NOT COMMIT -- for temporary testing only -- pass GLSL straight through to driver
+    vertShaderCode = demo_read_spv("cube.vert", &size);
     if (!vertShaderCode) {
         ERR_EXIT("Failed to load cube-vert.spv", "Load Shader Failure");
     }
@@ -2968,6 +2969,12 @@ static void demo_init_vk(struct demo *demo) {
                 swapchainExtFound = 1;
                 demo->extension_names[demo->enabled_extension_count++] =
                     VK_KHR_SWAPCHAIN_EXTENSION_NAME;
+            }
+            // DO NOT COMMIT -- for temporary testing only -- load up NV_GLSL_SHADER extension
+            if (!strcmp(VK_NV_GLSL_SHADER_EXTENSION_NAME,
+                device_extensions[i].extensionName)) {
+                demo->extension_names[demo->enabled_extension_count++] =
+                    VK_NV_GLSL_SHADER_EXTENSION_NAME;
             }
             assert(demo->enabled_extension_count < 64);
         }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -259,12 +259,16 @@ struct shader_module {
     // A mapping of <id> to the first word of its def. this is useful because walking type
     // trees, constant expressions, etc requires jumping all over the instruction stream.
     unordered_map<unsigned, unsigned> def_index;
+    bool validate;
 
     shader_module(VkShaderModuleCreateInfo const *pCreateInfo)
         : words((uint32_t *)pCreateInfo->pCode, (uint32_t *)pCreateInfo->pCode + pCreateInfo->codeSize / sizeof(uint32_t)),
-          def_index() {
+          def_index(),
+          validate(true) {
         build_def_index(this);
     }
+
+    shader_module() : validate(false) {}
 
     // Expose begin() / end() to enable range-based for
     spirv_inst_iter begin() const { return spirv_inst_iter(words.begin(), words.begin() + 5); }  // First insn
@@ -2589,6 +2593,8 @@ static bool validate_pipeline_shader_stage(
     auto module_it = shaderModuleMap.find(pStage->module);
     auto module = *out_module = module_it->second.get();
 
+    if (!module->validate) return pass;
+
     // Find the entrypoint
     auto entrypoint = *out_entrypoint = find_entrypoint(module, pStage->pName, pStage->stage);
     if (entrypoint == module->end()) {
@@ -2726,7 +2732,7 @@ static bool validate_and_capture_pipeline_shader_state(
         pass &= validate_vi_consistency(report_data, vi);
     }
 
-    if (shaders[vertex_stage]) {
+    if (shaders[vertex_stage] && shaders[vertex_stage]->validate) {
         pass &= validate_vi_against_vs_inputs(report_data, vi, shaders[vertex_stage], entrypoints[vertex_stage]);
     }
 
@@ -2740,7 +2746,7 @@ static bool validate_and_capture_pipeline_shader_state(
 
     for (; producer != fragment_stage && consumer <= fragment_stage; consumer++) {
         assert(shaders[producer]);
-        if (shaders[consumer]) {
+        if (shaders[consumer] && shaders[consumer]->validate && shaders[producer]->validate) {
             pass &= validate_interface_between_stages(report_data, shaders[producer], entrypoints[producer],
                                                       &shader_stage_attribs[producer], shaders[consumer], entrypoints[consumer],
                                                       &shader_stage_attribs[consumer]);
@@ -2749,7 +2755,7 @@ static bool validate_and_capture_pipeline_shader_state(
         }
     }
 
-    if (shaders[fragment_stage]) {
+    if (shaders[fragment_stage] && shaders[fragment_stage]->validate) {
         pass &= validate_fs_outputs_against_render_pass(report_data, shaders[fragment_stage], entrypoints[fragment_stage],
                                                         pPipeline->render_pass_ci.ptr(), pCreateInfo->subpass);
     }
@@ -9907,6 +9913,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(VkDevice device, const VkShade
                                                   const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule) {
     layer_data *dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
     bool skip_call = false;
+    spv_result_t spv_valid = SPV_SUCCESS;
 
     if (!GetDisables(dev_data)->shader_validation) {
         // Use SPIRV-Tools validator to try and catch any issues with the module itself
@@ -9914,12 +9921,15 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(VkDevice device, const VkShade
         spv_const_binary_t binary{pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t)};
         spv_diagnostic diag = nullptr;
 
-        auto result = spvValidate(ctx, &binary, &diag);
-        if (result != SPV_SUCCESS) {
-            skip_call |= log_msg(dev_data->report_data,
-                                 result == SPV_WARNING ? VK_DEBUG_REPORT_WARNING_BIT_EXT : VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                 VkDebugReportObjectTypeEXT(0), 0, __LINE__, SHADER_CHECKER_INCONSISTENT_SPIRV, "SC",
-                                 "SPIR-V module not valid: %s", diag && diag->error ? diag->error : "(no error text)");
+        spv_valid = spvValidate(ctx, &binary, &diag);
+        if (spv_valid != SPV_SUCCESS) {
+            static const uint32_t kSpirvMagicNumber = 0x07230203;
+            if (!dev_data->device_extensions.nv_glsl_shader_enabled || (pCreateInfo->pCode[0] == kSpirvMagicNumber)) {
+                skip_call |= log_msg(dev_data->report_data,
+                    spv_valid == SPV_WARNING ? VK_DEBUG_REPORT_WARNING_BIT_EXT : VK_DEBUG_REPORT_ERROR_BIT_EXT,
+                    VkDebugReportObjectTypeEXT(0), 0, __LINE__, SHADER_CHECKER_INCONSISTENT_SPIRV, "SC",
+                    "SPIR-V module not valid: %s", diag && diag->error ? diag->error : "(no error text)");
+            }
         }
 
         spvDiagnosticDestroy(diag);
@@ -9932,7 +9942,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(VkDevice device, const VkShade
 
     if (res == VK_SUCCESS && !GetDisables(dev_data)->shader_validation) {
         std::lock_guard<std::mutex> lock(global_lock);
-        dev_data->shaderModuleMap[*pShaderModule] = unique_ptr<shader_module>(new shader_module(pCreateInfo));
+        const auto new_shader_module = (SPV_SUCCESS == spv_valid ? new shader_module(pCreateInfo) : new shader_module());
+        dev_data->shaderModuleMap[*pShaderModule] = unique_ptr<shader_module>(new_shader_module);
     }
     return res;
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -102,6 +102,7 @@ static const uint32_t kSurfaceSizeFromSwapchain = 0xFFFFFFFFu;
 struct devExts {
     bool wsi_enabled;
     bool wsi_display_swapchain_enabled;
+    bool nv_glsl_shader_enabled;
     unordered_map<VkSwapchainKHR, unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
     unordered_map<VkImage, VkSwapchainKHR> imageToSwapchainMap;
 };
@@ -3871,17 +3872,22 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(VkInstance instance, const VkAllocati
 
 static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo, VkDevice device) {
     uint32_t i;
-    // TBD: Need any locking, in case this function is called at the same time
-    // by more than one thread?
+    // TBD: Need any locking, in case this function is called at the same time by more than one thread?
     layer_data *dev_data = get_my_data_ptr(get_dispatch_key(device), layer_data_map);
     dev_data->device_extensions.wsi_enabled = false;
     dev_data->device_extensions.wsi_display_swapchain_enabled = false;
+    dev_data->device_extensions.nv_glsl_shader_enabled = false;
 
     for (i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0)
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
             dev_data->device_extensions.wsi_enabled = true;
-        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME) == 0)
+        }
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME) == 0) {
             dev_data->device_extensions.wsi_display_swapchain_enabled = true;
+        }
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NV_GLSL_SHADER_EXTENSION_NAME) == 0) {
+            dev_data->device_extensions.nv_glsl_shader_enabled = true;
+        }
     }
 }
 

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -705,6 +705,7 @@ struct CHECK_DISABLED {
     bool destroy_query_pool;
     bool get_query_pool_results;
     bool destroy_buffer;
+    bool shader_validation;         // Skip validation for shaders
 };
 
 struct MT_FB_ATTACHMENT_INFO {


### PR DESCRIPTION
Fixes #706.  Apps can enable this extension and use straight GLSL, which needs to be ignored by the validation layers which assume SPIR-V.  Added a disable for shader validation, set an enable flag in the CV layer for the extension, and added conditional validation based on whether a shader-module is SPIR-V or otherwise. 

The test commit is only for context and will not be pushed.  It uses GLSL for one of the two shadermodules in cube.  This change _should_ allow a mix of validated SPIR-V shaders and ignored GLSL modules.