### PR TITLE
Refactor CmdFillBuffer, move Destroyimage/buffer/imageview/bufferview routines

### DIFF
--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -177,4 +177,20 @@ bool PreCallValidateCmdCopyBuffer(layer_data *device_data, GLOBAL_CB_NODE *cb_no
 void PreCallRecordCmdCopyBuffer(layer_data *device_data, GLOBAL_CB_NODE *cb_node, BUFFER_STATE *src_buffer_state,
                                 BUFFER_STATE *dst_buffer_state);
 
+bool PreCallValidateDestroyImageView(layer_data *device_data, VkImageView image_view, IMAGE_VIEW_STATE **image_view_state,
+                                     VK_OBJECT *obj_struct);
+
+void PostCallRecordDestroyImageView(layer_data *device_data, VkImageView image_view, IMAGE_VIEW_STATE *image_view_state,
+                                    VK_OBJECT obj_struct);
+
+bool PreCallValidateDestroyBuffer(layer_data *device_data, VkBuffer buffer, BUFFER_STATE **buffer_state, VK_OBJECT *obj_struct);
+
+void PostCallRecordDestroyBuffer(layer_data *device_data, VkBuffer buffer, BUFFER_STATE *buffer_state, VK_OBJECT obj_struct);
+
+bool PreCallValidateDestroyBufferView(layer_data *device_data, VkBufferView buffer_view, BUFFER_VIEW_STATE **buffer_view_state,
+                                      VK_OBJECT *obj_struct);
+
+void PostCallRecordDestroyBufferView(layer_data *device_data, VkBufferView buffer_view, BUFFER_VIEW_STATE *buffer_view_state,
+                                     VK_OBJECT obj_struct);
+
 #endif  // CORE_VALIDATION_BUFFER_VALIDATION_H_

--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -193,4 +193,8 @@ bool PreCallValidateDestroyBufferView(layer_data *device_data, VkBufferView buff
 void PostCallRecordDestroyBufferView(layer_data *device_data, VkBufferView buffer_view, BUFFER_VIEW_STATE *buffer_view_state,
                                      VK_OBJECT obj_struct);
 
+bool PreCallValidateCmdFillBuffer(layer_data *device_data, GLOBAL_CB_NODE *cb_node, BUFFER_STATE *buffer_state);
+
+void PreCallRecordCmdFillBuffer(layer_data *device_data, GLOBAL_CB_NODE *cb_node, BUFFER_STATE *buffer_state);
+
 #endif  // CORE_VALIDATION_BUFFER_VALIDATION_H_

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -771,6 +771,7 @@ void AddCommandBufferBindingBufferView(const layer_data *, GLOBAL_CB_NODE *, BUF
 bool ValidateObjectNotInUse(const layer_data *dev_data, BASE_NODE *obj_node, VK_OBJECT obj_struct, UNIQUE_VALIDATION_ERROR_CODE error_code);
 void invalidateCommandBuffers(const layer_data *dev_data, std::unordered_set<GLOBAL_CB_NODE *> const &cb_nodes, VK_OBJECT obj);
 void RemoveImageMemoryRange(uint64_t handle, DEVICE_MEM_INFO *mem_info);
+void RemoveBufferMemoryRange(uint64_t handle, DEVICE_MEM_INFO *mem_info);
 bool ClearMemoryObjectBindings(layer_data *dev_data, uint64_t handle, VkDebugReportObjectTypeEXT type);
 bool ValidateCmd(layer_data *my_data, GLOBAL_CB_NODE *pCB, const CMD_TYPE cmd, const char *caller_name);
 bool insideRenderPass(const layer_data *my_data, GLOBAL_CB_NODE *pCB, const char *apiName, UNIQUE_VALIDATION_ERROR_CODE msgCode);


### PR DESCRIPTION
Refactored FillBuffer to split validation from state updates, added pre/post routines.  Moved these, along with validate and record routines from several other image/buffer APIs into buffer_validation and updated for style.

This is pretty much it, buffer_validation-wise, except for CopyImageToBuffer and CopyBufferToImage.