### PR TITLE
tests: vk_layer_validation_tests depends on layer targets.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,14 @@ endif()
 if(WIN32)
    target_link_libraries(vk_layer_validation_tests ${LIBVK} gtest gtest_main VkLayer_utils ${GLSLANG_LIBRARIES})
 endif()
+add_dependencies(vk_layer_validation_tests
+   VkLayer_core_validation
+   VkLayer_object_tracker
+   VkLayer_swapchain
+   VkLayer_threading
+   VkLayer_unique_objects
+   VkLayer_parameter_validation
+)
 
 add_executable(vk_loader_validation_tests loader_validation_tests.cpp ${COMMON_CPP})
 set_target_properties(vk_loader_validation_tests


### PR DESCRIPTION
After my fifth time of forgetting to rebuild the layers before running the validation tests, I decided to add an explicit build dependency in CMake. I figured it might help others as well, but feel free to reject if it doesn't seem useful.