### PR TITLE
loader: Configurable fallback search paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(PythonInterp 3 REQUIRED)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(FALLBACK_CONFIG_DIRS "/etc/xdg" CACHE STRING
+        "Search path to use when XDG_CONFIG_DIRS is unset or empty or the current process is SUID/SGID. Default is freedesktop compliant.")
+    set(FALLBACK_DATA_DIRS "/usr/local/share:/usr/share" CACHE STRING
+        "Search path to use when XDG_DATA_DIRS is unset or empty or the current process is SUID/SGID. Default is freedesktop compliant.")
+
     include(FindPkgConfig)
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
     option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
@@ -286,7 +291,10 @@ run_vk_xml_generate(dispatch_table_generator.py vk_dispatch_table_helper.h)
 if(NOT WIN32)
     include(GNUInstallDirs)
 
+    add_definitions(-DFALLBACK_CONFIG_DIRS="${FALLBACK_CONFIG_DIRS}")
+    add_definitions(-DFALLBACK_DATA_DIRS="${FALLBACK_DATA_DIRS}")
     add_definitions(-DSYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}")
+
     # Make sure /etc is searched by the loader
     if(NOT (CMAKE_INSTALL_FULL_SYSCONFDIR STREQUAL "/etc"))
         add_definitions(-DEXTRASYSCONFDIR="/etc")

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2655,9 +2655,9 @@ static VkResult loader_get_manifest_files(const struct loader_instance *inst, co
         const char *xdgconfdirs = secure_getenv("XDG_CONFIG_DIRS");
         const char *xdgdatadirs = secure_getenv("XDG_DATA_DIRS");
         if (xdgconfdirs == NULL || xdgconfdirs[0] == '\0')
-            xdgconfdirs = "/etc/xdg";
+            xdgconfdirs = FALLBACK_CONFIG_DIRS;
         if (xdgdatadirs == NULL || xdgdatadirs[0] == '\0')
-            xdgdatadirs = "/usr/local/share:/usr/share";
+            xdgdatadirs = FALLBACK_DATA_DIRS;
         const size_t rel_size = strlen(relative_location);
         // Leave space for trailing separators
         loc_size += strlen(xdgconfdirs) + strlen(xdgdatadirs) + 2*rel_size + 2;


### PR DESCRIPTION
This makes it easier for non-FHS distributions to behave well when the loader is used by a SUID process or in an otherwise unusual environment.