### PR TITLE
loader: Fix handling of surface parameters

### DIFF
--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -1090,13 +1090,14 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                     funcs += '                   "ICD associated with VkPhysicalDevice does not support '
                     funcs += base_name
                     funcs += '");\n'
+                    funcs += '    }\n'
 
                     if has_surface == 1:
-                        funcs += '        VkIcdSurface *icd_surface = (VkIcdSurface *)(surface);\n'
-                        funcs += '        uint8_t icd_index = phys_dev_term->icd_index;\n'
-                        funcs += '        if (NULL != icd_surface->real_icd_surfaces) {\n'
-                        funcs += '            if (NULL != (void *)icd_surface->real_icd_surfaces[icd_index]) {\n'
-                        funcs += '                return icd_term->dispatch.'
+                        funcs += '    VkIcdSurface *icd_surface = (VkIcdSurface *)(surface);\n'
+                        funcs += '    uint8_t icd_index = phys_dev_term->icd_index;\n'
+                        funcs += '    if (NULL != icd_surface->real_icd_surfaces) {\n'
+                        funcs += '        if (NULL != (void *)icd_surface->real_icd_surfaces[icd_index]) {\n'
+                        funcs += '        ' + return_prefix + 'icd_term->dispatch.'
                         funcs += base_name
                         funcs += '('
                         count = 0
@@ -1113,10 +1114,10 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
 
                             count += 1
                         funcs += ');\n'
-                        funcs += '            }\n'
+                        if not has_return_type:
+                            funcs += '            return;\n'
                         funcs += '        }\n'
-
-                    funcs += '    }\n'
+                        funcs += '    }\n'
 
                     funcs += return_prefix
                     funcs += 'icd_term->dispatch.'
@@ -1160,7 +1161,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                         funcs += '                return;\n'
                     funcs += '            }\n'
                     funcs += '        }\n'
-                    funcs += '    %sicd_term->dispatch.%s(' % (return_prefix, base_name)
+                    funcs += '        %sicd_term->dispatch.%s(' % (return_prefix, base_name)
                     count = 0
                     for param in ext_cmd.params:
                         if count != 0:
@@ -1168,7 +1169,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                         funcs += param.name
                         count += 1
                     funcs += ');\n'
-                    funcs += '     }\n'
+                    funcs += '    }\n'
                     if has_return_type:
                         funcs += '    return VK_SUCCESS;\n'
 


### PR DESCRIPTION
The loader code generation scripts had a bug that
caused all the surface->ICD surface translation C
code to be placed inside a block that only ran if
the ICD didn't support the extension function,
making it effectively a no-op.  ICDs that
supported the extension were instead called with
the un-translated surface handle, which could
cause a crash if they were expecting their local
surface handle.

Also, speculatively fix up return handling in this
same class of functions by handling the void
return type.