### PR TITLE
Add ability to handle DescriptorUpdateTemplate extension to unique objects layer

### DIFF
--- a/layers/unique_objects.h
+++ b/layers/unique_objects.h
@@ -33,6 +33,14 @@ namespace unique_objects {
 // All increments must be guarded by global_lock
 static uint64_t global_unique_id = 1;
 
+struct TEMPLATE_STATE {
+    VkDescriptorUpdateTemplateKHR desc_update_template;
+    safe_VkDescriptorUpdateTemplateCreateInfoKHR create_info;
+
+    TEMPLATE_STATE(VkDescriptorUpdateTemplateKHR update_template, safe_VkDescriptorUpdateTemplateCreateInfoKHR *pCreateInfo)
+        : desc_update_template(update_template), create_info(*pCreateInfo) {}
+};
+
 struct layer_data {
     VkInstance instance;
 
@@ -46,6 +54,8 @@ struct layer_data {
     uint32_t num_tmp_callbacks;
     VkDebugReportCallbackCreateInfoEXT *tmp_dbg_create_infos;
     VkDebugReportCallbackEXT *tmp_callbacks;
+
+    std::unordered_map<uint64_t, std::unique_ptr<TEMPLATE_STATE>> desc_template_map;
 
     bool wsi_enabled;
     std::unordered_map<uint64_t, uint64_t> unique_id_mapping;  // Map uniqueID to actual object handle

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -525,8 +525,17 @@ class HelperFileOutputGenerator(OutputGenerator):
     # safe_struct source -- create bodies of safe struct helper functions
     def GenerateSafeStructSource(self):
         safe_struct_body = []
+        wsi_structs = ['VkXlibSurfaceCreateInfoKHR',
+                       'VkXcbSurfaceCreateInfoKHR',
+                       'VkWaylandSurfaceCreateInfoKHR',
+                       'VkMirSurfaceCreateInfoKHR',
+                       'VkAndroidSurfaceCreateInfoKHR',
+                       'VkWin32SurfaceCreateInfoKHR'
+                       ]
         for item in self.structMembers:
             if self.NeedSafeStruct(item) == False:
+                continue
+            if item.name in wsi_structs:
                 continue
             if item.ifdef_protect != None:
                 safe_struct_body.append("#ifdef %s\n" % item.ifdef_protect)
@@ -583,7 +592,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                         m_type = 'safe_%s' % member.type
                 if member.ispointer and 'safe_' not in m_type and self.TypeContainsObjectHandle(member.type, False) == False:
                     # Ptr types w/o a safe_struct, for non-null case need to allocate new ptr and copy data in
-                    if 'KHR' in ss_name or m_type in ['void', 'char']:
+                    if m_type in ['void', 'char']:
                         # For these exceptions just copy initial value over for now
                         init_list += '\n    %s(in_struct->%s),' % (member.name, member.name)
                         init_func_txt += '    %s = in_struct->%s;\n' % (member.name, member.name)

--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -140,6 +140,10 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             'vkEnumerateInstanceLayerProperties',
             'vkEnumerateDeviceLayerProperties',
             'vkEnumerateInstanceExtensionProperties',
+            'vkCreateDescriptorUpdateTemplateKHR',
+            'vkDestroyDescriptorUpdateTemplateKHR',
+            'vkUpdateDescriptorSetWithTemplateKHR',
+            'vkCmdPushDescriptorSetWithTemplateKHR',
             ]
         # Commands shadowed by interface functions and are not implemented
         self.interface_functions = [


### PR DESCRIPTION
The UniqueObjects utility layer needed to unwrap vulkan object handles embedded in a buffer parameter of `vkUpdateDescriptorSetWithTemplateKHR()`.  This patch series parses that buffer, replacing the uniquified handles with the actual ones before passing the call to the hardware.  This takes care of part of issue #1529.