### PR TITLE
Use nproc instead of ncpu

### DIFF
--- a/build-android/update_external_sources_android.sh
+++ b/build-android/update_external_sources_android.sh
@@ -32,7 +32,7 @@ echo "SPIRV_TOOLS_REVISION=$SPIRV_TOOLS_REVISION"
 echo "SHADERC_REVISION=$SHADERC_REVISION"
 
 if [[ $(uname) == "Linux" ]]; then
-    cores=$(ncpus || echo 4)
+    cores="$(nproc || echo 4)"
 elif [[ $(uname) == "Darwin" ]]; then
     cores=$(sysctl -n hw.ncpu)
 fi


### PR DESCRIPTION
The command is more widely available in Linux since it is part of Coreutils.

Followup to: https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/issues/1532