### PR TITLE
loader: Fix getenv probing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,10 @@ if(NOT WIN32)
 endif()
 
 if(UNIX)
+    include(CheckFunctionExists)
+    CHECK_FUNCTION_EXISTS(secure_getenv HAVE_SECURE_GETENV)
+    CHECK_FUNCTION_EXISTS(__secure_getenv HAVE___SECURE_GETENV)
+
     install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -199,20 +199,17 @@ static inline char *loader_getenv(const char *name, const struct loader_instance
     // the inst pointer to get rid of compiler warnings.
     (void)inst;
 
-#if defined(__GNUC__)
-
-// Before GLIBC 2.17, the function was __secure_getenv not secure_getenv
-#if (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 17))
+#ifdef HAVE_SECURE_GETENV
+    return secure_getenv(name);
+#else
+#ifdef HAVE___SECURE_GETENV
+    // Old Glibc only has __secure_getenv()
     return __secure_getenv(name);
 #else
-    return secure_getenv(name);
-#endif
-
-// Other compilers don't support secure_getenv
-#else
+    // libc does not have any secure_getenv(), e.g. musl
     return getenv(name);
 #endif
-
+#endif
 }
 
 static inline void loader_free_getenv(char *val, const struct loader_instance *inst) {


### PR DESCRIPTION
__GNUC__ depends on the compiler not libc, but here we are actually
interested in libc: current code ends up using getenv() when compiler
is not gcc.

Also, it's better to check for features anyway instead of libc's and
their versions.

Fixes #1538.