### PR TITLE
tests: Workaround Clang bug in Android NDK r14

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -13548,6 +13548,7 @@ TEST_F(VkLayerTest, CreatePipelineCheckShaderDescriptorTypeMismatch) {
     descriptorset_layout_binding.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     descriptorset_layout_binding.descriptorCount = 1;
     descriptorset_layout_binding.stageFlags = VK_SHADER_STAGE_ALL;
+    descriptorset_layout_binding.pImmutableSamplers = nullptr;
 
     VkDescriptorSetLayoutCreateInfo descriptorset_layout_create_info = {};
     descriptorset_layout_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
@@ -13643,6 +13644,7 @@ TEST_F(VkLayerTest, CreatePipelineCheckShaderDescriptorNotAccessible) {
     descriptorset_layout_binding.descriptorCount = 1;
     // Intentionally make the uniform buffer inaccessible to the vertex shader to challenge core_validation
     descriptorset_layout_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    descriptorset_layout_binding.pImmutableSamplers = nullptr;
 
     VkDescriptorSetLayoutCreateInfo descriptorset_layout_create_info = {};
     descriptorset_layout_create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;


### PR DESCRIPTION
When using Android NDK r14, incorrect arm64 assembly is generated unless we write directly to the last member of this struct.

This is a workaround for a bug that does not occur after clang 3688880, which should be included in next NDK release.

We will ensure the bug is fixed (and not just masked) separately.  This should unblock regression testing on r14.

This partially addresses issue #1551.