### PR TITLE
headers: Add missing include to vk_icd.h

### DIFF
--- a/include/vulkan/vk_icd.h
+++ b/include/vulkan/vk_icd.h
@@ -24,6 +24,7 @@
 #define VKICD_H
 
 #include "vulkan.h"
+#include <stdbool.h>
 
 // Loader-ICD version negotiation API.  Versions add the following features:
 //   Version 0 - Initial.  Doesn't support vk_icdGetInstanceProcAddr


### PR DESCRIPTION
I messed up the amend, was #1563.