### PR TITLE
Add Maintenance1 Extension tolerance for negative viewport heights

### DIFF
--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -4239,7 +4239,7 @@ static bool preCmdSetViewport(layer_data *my_data, uint32_t first_viewport, uint
             }
 
             bool invalid_height = (viewport.height <= 0 || viewport.height > limits.maxViewportDimensions[1]);
-            if (my_data->enables.amd_negative_viewport_height && (viewport.height < 0)) {
+            if ((my_data->enables.amd_negative_viewport_height || my_data->enables.khr_maintenance1) && (viewport.height < 0)) {
                 // VALIDATION_ERROR_01790
                 invalid_height = false;
             }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -355,6 +355,7 @@ class VkLayerTest : public VkRenderFramework {
    protected:
     ErrorMonitor *m_errorMonitor;
     bool m_enableWSI;
+    bool m_enable_maintenance1_ext;
 
     virtual void SetUp() {
         std::vector<const char *> instance_layer_names;
@@ -398,6 +399,9 @@ class VkLayerTest : public VkRenderFramework {
 #elif defined(VK_USE_PLATFORM_XLIB_KHR)
             instance_extension_names.push_back(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
 #endif  // VK_USE_PLATFORM_XLIB_KHR
+        }
+        if (m_enable_maintenance1_ext) {
+            device_extension_names.push_back(VK_KHR_MAINTENANCE1_EXTENSION_NAME);
         }
 
         this->app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
@@ -581,6 +585,12 @@ void VkLayerTest::GenericDrawPreparation(VkCommandBufferObj *commandBuffer, VkPi
     commandBuffer->BindPipeline(pipelineobj);
     commandBuffer->BindDescriptorSet(descriptorSet);
 }
+
+class VkMaintenance1LayerTest : public VkLayerTest {
+   public:
+   protected:
+       VkMaintenance1LayerTest(){ m_enable_maintenance1_ext = true; }
+};
 
 class VkPositiveLayerTest : public VkLayerTest {
    public:
@@ -22336,6 +22346,59 @@ TEST_F(VkPositiveLayerTest, CreateComputePipelineCombinedImageSamplerConsumedAsB
 
     vkDestroyPipelineLayout(m_device->device(), pl, nullptr);
     vkDestroyDescriptorSetLayout(m_device->device(), dsl, nullptr);
+}
+
+// This test class enables the Maintenance1 extension for related validation tests
+TEST_F(VkMaintenance1LayerTest, Maintenance1Tests) {
+    TEST_DESCRIPTION("Validate various special cases for the Maintenance1_KHR extension");
+
+    // Ensure that extension is available and enabled.
+    uint32_t extension_count = 0;
+    bool supports_maintenance1_extension = false;
+    VkResult err = vkEnumerateDeviceExtensionProperties(gpu(), nullptr, &extension_count, nullptr);
+    ASSERT_VK_SUCCESS(err);
+    if (extension_count > 0) {
+        std::vector<VkExtensionProperties> available_extensions(extension_count);
+
+        err = vkEnumerateDeviceExtensionProperties(gpu(), nullptr, &extension_count, &available_extensions[0]);
+        ASSERT_VK_SUCCESS(err);
+        for (const auto &extension_props : available_extensions) {
+            if (strcmp(extension_props.extensionName, VK_KHR_MAINTENANCE1_EXTENSION_NAME) == 0) {
+                supports_maintenance1_extension = true;
+            }
+        }
+    }
+
+    // Proceed if extension is supported by hardware
+    if (!supports_maintenance1_extension) {
+        printf("             Maintenance1 Extension not supported, skipping tests\n");
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    m_errorMonitor->ExpectSuccess();
+
+    VkCommandBuffer cmd_buf;
+    VkCommandBufferAllocateInfo alloc_info;
+    alloc_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    alloc_info.pNext = NULL;
+    alloc_info.commandBufferCount = 1;
+    alloc_info.commandPool = m_commandPool;
+    alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    vkAllocateCommandBuffers(m_device->device(), &alloc_info, &cmd_buf);
+
+    VkCommandBufferBeginInfo cb_binfo;
+    cb_binfo.pNext = NULL;
+    cb_binfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    cb_binfo.pInheritanceInfo = VK_NULL_HANDLE;
+    cb_binfo.flags = 0;
+    vkBeginCommandBuffer(cmd_buf, &cb_binfo);
+    // Set Negative height, should give error if Maintenance 1 is not enabled
+    VkViewport viewport = {0, 0, 16, -16, 0, 1};
+    vkCmdSetViewport(cmd_buf, 0, 1, &viewport);
+    vkEndCommandBuffer(cmd_buf);
+
+    m_errorMonitor->VerifyNotFound();
 }
 
 TEST_F(VkPositiveLayerTest, ValidStructPNext) {


### PR DESCRIPTION
If this extension is enabled, negative viewports should not trigger validation errors.  Added mod to parameter_validation layer and a new maintenance1-specific test class and test for this.