### PR TITLE
Update Vulkan-LVL to 1.0.43 version of the header

### DIFF
--- a/include/vulkan/vulkan.h
+++ b/include/vulkan/vulkan.h
@@ -43,7 +43,7 @@ extern "C" {
 #define VK_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3ff)
 #define VK_VERSION_PATCH(version) ((uint32_t)(version) & 0xfff)
 // Version of this file
-#define VK_HEADER_VERSION 42
+#define VK_HEADER_VERSION 43
 
 
 #define VK_NULL_HANDLE 0
@@ -294,10 +294,12 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT = 1000091001,
     VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT = 1000091002,
     VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT = 1000091003,
+    VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE = 1000092000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX = 1000097000,
     VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV = 1000098000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT = 1000099000,
     VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT = 1000099001,
+    VK_STRUCTURE_TYPE_HDR_METADATA_EXT = 1000105000,
     VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK = 1000122000,
     VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK = 1000123000,
     VK_STRUCTURE_TYPE_BEGIN_RANGE = VK_STRUCTURE_TYPE_APPLICATION_INFO,
@@ -3703,7 +3705,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXcbPresentationSupportKHR(
 #define VK_KHR_wayland_surface 1
 #include <wayland-client.h>
 
-#define VK_KHR_WAYLAND_SURFACE_SPEC_VERSION 5
+#define VK_KHR_WAYLAND_SURFACE_SPEC_VERSION 6
 #define VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME "VK_KHR_wayland_surface"
 
 typedef VkFlags VkWaylandSurfaceCreateFlagsKHR;
@@ -4849,47 +4851,14 @@ typedef struct VkPhysicalDeviceIDPropertiesKHX {
     VkBool32           deviceLUIDValid;
 } VkPhysicalDeviceIDPropertiesKHX;
 
-typedef struct VkPhysicalDeviceProperties2KHX {
-    VkStructureType               sType;
-    void*                         pNext;
-    VkPhysicalDeviceProperties    properties;
-} VkPhysicalDeviceProperties2KHX;
-
-typedef struct VkImageFormatProperties2KHX {
-    VkStructureType            sType;
-    void*                      pNext;
-    VkImageFormatProperties    imageFormatProperties;
-} VkImageFormatProperties2KHX;
-
-typedef struct VkPhysicalDeviceImageFormatInfo2KHX {
-    VkStructureType       sType;
-    const void*           pNext;
-    VkFormat              format;
-    VkImageType           type;
-    VkImageTiling         tiling;
-    VkImageUsageFlags     usage;
-    VkImageCreateFlags    flags;
-} VkPhysicalDeviceImageFormatInfo2KHX;
-
 
 typedef void (VKAPI_PTR *PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHX)(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalBufferInfoKHX* pExternalBufferInfo, VkExternalBufferPropertiesKHX* pExternalBufferProperties);
-typedef void (VKAPI_PTR *PFN_vkGetPhysicalDeviceProperties2KHX)(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2KHX* pProperties);
-typedef VkResult (VKAPI_PTR *PFN_vkGetPhysicalDeviceImageFormatProperties2KHX)(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2KHX* pImageFormatInfo, VkImageFormatProperties2KHX* pImageFormatProperties);
 
 #ifndef VK_NO_PROTOTYPES
 VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalBufferPropertiesKHX(
     VkPhysicalDevice                            physicalDevice,
     const VkPhysicalDeviceExternalBufferInfoKHX* pExternalBufferInfo,
     VkExternalBufferPropertiesKHX*              pExternalBufferProperties);
-
-VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceProperties2KHX(
-    VkPhysicalDevice                            physicalDevice,
-    VkPhysicalDeviceProperties2KHX*             pProperties);
-
-VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceImageFormatProperties2KHX(
-    VkPhysicalDevice                            physicalDevice,
-    const VkPhysicalDeviceImageFormatInfo2KHX*  pImageFormatInfo,
-    VkImageFormatProperties2KHX*                pImageFormatProperties);
 #endif
 
 #define VK_KHX_external_memory 1
@@ -5565,6 +5534,51 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetSwapchainCounterEXT(
     uint64_t*                                   pCounterValue);
 #endif
 
+#define VK_GOOGLE_display_timing 1
+#define VK_GOOGLE_DISPLAY_TIMING_SPEC_VERSION 1
+#define VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME "VK_GOOGLE_display_timing"
+
+typedef struct VkRefreshCycleDurationGOOGLE {
+    uint64_t    refreshDuration;
+} VkRefreshCycleDurationGOOGLE;
+
+typedef struct VkPastPresentationTimingGOOGLE {
+    uint32_t    presentID;
+    uint64_t    desiredPresentTime;
+    uint64_t    actualPresentTime;
+    uint64_t    earliestPresentTime;
+    uint64_t    presentMargin;
+} VkPastPresentationTimingGOOGLE;
+
+typedef struct VkPresentTimeGOOGLE {
+    uint32_t    presentID;
+    uint64_t    desiredPresentTime;
+} VkPresentTimeGOOGLE;
+
+typedef struct VkPresentTimesInfoGOOGLE {
+    VkStructureType               sType;
+    const void*                   pNext;
+    uint32_t                      swapchainCount;
+    const VkPresentTimeGOOGLE*    pTimes;
+} VkPresentTimesInfoGOOGLE;
+
+
+typedef VkResult (VKAPI_PTR *PFN_vkGetRefreshCycleDurationGOOGLE)(VkDevice device, VkSwapchainKHR swapchain, VkRefreshCycleDurationGOOGLE* pDisplayTimingProperties);
+typedef VkResult (VKAPI_PTR *PFN_vkGetPastPresentationTimingGOOGLE)(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pPresentationTimingCount, VkPastPresentationTimingGOOGLE* pPresentationTimings);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR VkResult VKAPI_CALL vkGetRefreshCycleDurationGOOGLE(
+    VkDevice                                    device,
+    VkSwapchainKHR                              swapchain,
+    VkRefreshCycleDurationGOOGLE*               pDisplayTimingProperties);
+
+VKAPI_ATTR VkResult VKAPI_CALL vkGetPastPresentationTimingGOOGLE(
+    VkDevice                                    device,
+    VkSwapchainKHR                              swapchain,
+    uint32_t*                                   pPresentationTimingCount,
+    VkPastPresentationTimingGOOGLE*             pPresentationTimings);
+#endif
+
 #define VK_NV_sample_mask_override_coverage 1
 #define VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_SPEC_VERSION 1
 #define VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME "VK_NV_sample_mask_override_coverage"
@@ -5673,9 +5687,42 @@ VKAPI_ATTR void VKAPI_CALL vkCmdSetDiscardRectangleEXT(
     const VkRect2D*                             pDiscardRectangles);
 #endif
 
+#define VK_EXT_hdr_metadata 1
+#define VK_EXT_HDR_METADATA_SPEC_VERSION  0
+#define VK_EXT_HDR_METADATA_EXTENSION_NAME "VK_EXT_hdr_metadata"
+
+typedef struct VkXYColorEXT {
+    float    x;
+    float    y;
+} VkXYColorEXT;
+
+typedef struct VkHdrMetadataEXT {
+    VkStructureType    sType;
+    const void*        pNext;
+    VkXYColorEXT       displayPrimaryRed;
+    VkXYColorEXT       displayPrimaryGreen;
+    VkXYColorEXT       displayPrimaryBlue;
+    VkXYColorEXT       whitePoint;
+    float              maxLuminance;
+    float              minLuminance;
+    float              maxContentLightLevel;
+    float              maxFrameAverageLightLevel;
+} VkHdrMetadataEXT;
+
+
+typedef void (VKAPI_PTR *PFN_vkSetHdrMetadataEXT)(VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR* pSwapchains, const VkHdrMetadataEXT* pMetadata);
+
+#ifndef VK_NO_PROTOTYPES
+VKAPI_ATTR void VKAPI_CALL vkSetHdrMetadataEXT(
+    VkDevice                                    device,
+    uint32_t                                    swapchainCount,
+    const VkSwapchainKHR*                       pSwapchains,
+    const VkHdrMetadataEXT*                     pMetadata);
+#endif
+
 #ifdef VK_USE_PLATFORM_IOS_MVK
 #define VK_MVK_ios_surface 1
-#define VK_MVK_IOS_SURFACE_SPEC_VERSION   1
+#define VK_MVK_IOS_SURFACE_SPEC_VERSION   2
 #define VK_MVK_IOS_SURFACE_EXTENSION_NAME "VK_MVK_ios_surface"
 
 typedef VkFlags VkIOSSurfaceCreateFlagsMVK;
@@ -5701,7 +5748,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkCreateIOSSurfaceMVK(
 
 #ifdef VK_USE_PLATFORM_MACOS_MVK
 #define VK_MVK_macos_surface 1
-#define VK_MVK_MACOS_SURFACE_SPEC_VERSION 1
+#define VK_MVK_MACOS_SURFACE_SPEC_VERSION 2
 #define VK_MVK_MACOS_SURFACE_EXTENSION_NAME "VK_MVK_macos_surface"
 
 typedef VkFlags VkMacOSSurfaceCreateFlagsMVK;

--- a/include/vulkan/vulkan.hpp
+++ b/include/vulkan/vulkan.hpp
@@ -42,7 +42,7 @@
 # include <vector>
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-static_assert( VK_HEADER_VERSION ==  42 , "Wrong VK_HEADER_VERSION!" );
+static_assert( VK_HEADER_VERSION ==  43 , "Wrong VK_HEADER_VERSION!" );
 
 // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
 // To enable this feature on 32-bit platforms please define VULKAN_HPP_TYPESAFE_CONVERSION
@@ -4788,6 +4788,232 @@ namespace vk
   };
   static_assert( sizeof( DisplayModePropertiesKHR ) == sizeof( VkDisplayModePropertiesKHR ), "struct and wrapper have different size!" );
 
+  struct XYColorEXT
+  {
+    XYColorEXT( float x_ = 0, float y_ = 0 )
+      : x( x_ )
+      , y( y_ )
+    {
+    }
+
+    XYColorEXT( VkXYColorEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(XYColorEXT) );
+    }
+
+    XYColorEXT& operator=( VkXYColorEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(XYColorEXT) );
+      return *this;
+    }
+
+    XYColorEXT& setX( float x_ )
+    {
+      x = x_;
+      return *this;
+    }
+
+    XYColorEXT& setY( float y_ )
+    {
+      y = y_;
+      return *this;
+    }
+
+    operator const VkXYColorEXT&() const
+    {
+      return *reinterpret_cast<const VkXYColorEXT*>(this);
+    }
+
+    bool operator==( XYColorEXT const& rhs ) const
+    {
+      return ( x == rhs.x )
+          && ( y == rhs.y );
+    }
+
+    bool operator!=( XYColorEXT const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+    float x;
+    float y;
+  };
+  static_assert( sizeof( XYColorEXT ) == sizeof( VkXYColorEXT ), "struct and wrapper have different size!" );
+
+  struct RefreshCycleDurationGOOGLE
+  {
+    RefreshCycleDurationGOOGLE( uint64_t refreshDuration_ = 0 )
+      : refreshDuration( refreshDuration_ )
+    {
+    }
+
+    RefreshCycleDurationGOOGLE( VkRefreshCycleDurationGOOGLE const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(RefreshCycleDurationGOOGLE) );
+    }
+
+    RefreshCycleDurationGOOGLE& operator=( VkRefreshCycleDurationGOOGLE const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(RefreshCycleDurationGOOGLE) );
+      return *this;
+    }
+
+    RefreshCycleDurationGOOGLE& setRefreshDuration( uint64_t refreshDuration_ )
+    {
+      refreshDuration = refreshDuration_;
+      return *this;
+    }
+
+    operator const VkRefreshCycleDurationGOOGLE&() const
+    {
+      return *reinterpret_cast<const VkRefreshCycleDurationGOOGLE*>(this);
+    }
+
+    bool operator==( RefreshCycleDurationGOOGLE const& rhs ) const
+    {
+      return ( refreshDuration == rhs.refreshDuration );
+    }
+
+    bool operator!=( RefreshCycleDurationGOOGLE const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+    uint64_t refreshDuration;
+  };
+  static_assert( sizeof( RefreshCycleDurationGOOGLE ) == sizeof( VkRefreshCycleDurationGOOGLE ), "struct and wrapper have different size!" );
+
+  struct PastPresentationTimingGOOGLE
+  {
+    PastPresentationTimingGOOGLE( uint32_t presentID_ = 0, uint64_t desiredPresentTime_ = 0, uint64_t actualPresentTime_ = 0, uint64_t earliestPresentTime_ = 0, uint64_t presentMargin_ = 0 )
+      : presentID( presentID_ )
+      , desiredPresentTime( desiredPresentTime_ )
+      , actualPresentTime( actualPresentTime_ )
+      , earliestPresentTime( earliestPresentTime_ )
+      , presentMargin( presentMargin_ )
+    {
+    }
+
+    PastPresentationTimingGOOGLE( VkPastPresentationTimingGOOGLE const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PastPresentationTimingGOOGLE) );
+    }
+
+    PastPresentationTimingGOOGLE& operator=( VkPastPresentationTimingGOOGLE const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PastPresentationTimingGOOGLE) );
+      return *this;
+    }
+
+    PastPresentationTimingGOOGLE& setPresentID( uint32_t presentID_ )
+    {
+      presentID = presentID_;
+      return *this;
+    }
+
+    PastPresentationTimingGOOGLE& setDesiredPresentTime( uint64_t desiredPresentTime_ )
+    {
+      desiredPresentTime = desiredPresentTime_;
+      return *this;
+    }
+
+    PastPresentationTimingGOOGLE& setActualPresentTime( uint64_t actualPresentTime_ )
+    {
+      actualPresentTime = actualPresentTime_;
+      return *this;
+    }
+
+    PastPresentationTimingGOOGLE& setEarliestPresentTime( uint64_t earliestPresentTime_ )
+    {
+      earliestPresentTime = earliestPresentTime_;
+      return *this;
+    }
+
+    PastPresentationTimingGOOGLE& setPresentMargin( uint64_t presentMargin_ )
+    {
+      presentMargin = presentMargin_;
+      return *this;
+    }
+
+    operator const VkPastPresentationTimingGOOGLE&() const
+    {
+      return *reinterpret_cast<const VkPastPresentationTimingGOOGLE*>(this);
+    }
+
+    bool operator==( PastPresentationTimingGOOGLE const& rhs ) const
+    {
+      return ( presentID == rhs.presentID )
+          && ( desiredPresentTime == rhs.desiredPresentTime )
+          && ( actualPresentTime == rhs.actualPresentTime )
+          && ( earliestPresentTime == rhs.earliestPresentTime )
+          && ( presentMargin == rhs.presentMargin );
+    }
+
+    bool operator!=( PastPresentationTimingGOOGLE const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+    uint32_t presentID;
+    uint64_t desiredPresentTime;
+    uint64_t actualPresentTime;
+    uint64_t earliestPresentTime;
+    uint64_t presentMargin;
+  };
+  static_assert( sizeof( PastPresentationTimingGOOGLE ) == sizeof( VkPastPresentationTimingGOOGLE ), "struct and wrapper have different size!" );
+
+  struct PresentTimeGOOGLE
+  {
+    PresentTimeGOOGLE( uint32_t presentID_ = 0, uint64_t desiredPresentTime_ = 0 )
+      : presentID( presentID_ )
+      , desiredPresentTime( desiredPresentTime_ )
+    {
+    }
+
+    PresentTimeGOOGLE( VkPresentTimeGOOGLE const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PresentTimeGOOGLE) );
+    }
+
+    PresentTimeGOOGLE& operator=( VkPresentTimeGOOGLE const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PresentTimeGOOGLE) );
+      return *this;
+    }
+
+    PresentTimeGOOGLE& setPresentID( uint32_t presentID_ )
+    {
+      presentID = presentID_;
+      return *this;
+    }
+
+    PresentTimeGOOGLE& setDesiredPresentTime( uint64_t desiredPresentTime_ )
+    {
+      desiredPresentTime = desiredPresentTime_;
+      return *this;
+    }
+
+    operator const VkPresentTimeGOOGLE&() const
+    {
+      return *reinterpret_cast<const VkPresentTimeGOOGLE*>(this);
+    }
+
+    bool operator==( PresentTimeGOOGLE const& rhs ) const
+    {
+      return ( presentID == rhs.presentID )
+          && ( desiredPresentTime == rhs.desiredPresentTime );
+    }
+
+    bool operator!=( PresentTimeGOOGLE const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+    uint32_t presentID;
+    uint64_t desiredPresentTime;
+  };
+  static_assert( sizeof( PresentTimeGOOGLE ) == sizeof( VkPresentTimeGOOGLE ), "struct and wrapper have different size!" );
+
   struct ViewportWScalingNV
   {
     ViewportWScalingNV( float xcoeff_ = 0, float ycoeff_ = 0 )
@@ -6036,10 +6262,12 @@ namespace vk
     eDeviceEventInfoEXT = VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT,
     eDisplayEventInfoEXT = VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT,
     eSwapchainCounterCreateInfoEXT = VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT,
+    ePresentTimesInfoGOOGLE = VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE,
     ePhysicalDeviceMultiviewPerViewAttributesPropertiesNVX = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX,
     ePipelineViewportSwizzleStateCreateInfoNV = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV,
     ePhysicalDeviceDiscardRectanglePropertiesEXT = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT,
     ePipelineDiscardRectangleStateCreateInfoEXT = VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT,
+    eHdrMetadataEXT = VK_STRUCTURE_TYPE_HDR_METADATA_EXT,
     eIosSurfaceCreateInfoMVK = VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK,
     eMacosSurfaceCreateInfoMVK = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK
   };
@@ -11189,6 +11417,194 @@ namespace vk
   };
   static_assert( sizeof( AcquireNextImageInfoKHX ) == sizeof( VkAcquireNextImageInfoKHX ), "struct and wrapper have different size!" );
 
+  struct HdrMetadataEXT
+  {
+    HdrMetadataEXT( XYColorEXT displayPrimaryRed_ = XYColorEXT(), XYColorEXT displayPrimaryGreen_ = XYColorEXT(), XYColorEXT displayPrimaryBlue_ = XYColorEXT(), XYColorEXT whitePoint_ = XYColorEXT(), float maxLuminance_ = 0, float minLuminance_ = 0, float maxContentLightLevel_ = 0, float maxFrameAverageLightLevel_ = 0 )
+      : sType( StructureType::eHdrMetadataEXT )
+      , pNext( nullptr )
+      , displayPrimaryRed( displayPrimaryRed_ )
+      , displayPrimaryGreen( displayPrimaryGreen_ )
+      , displayPrimaryBlue( displayPrimaryBlue_ )
+      , whitePoint( whitePoint_ )
+      , maxLuminance( maxLuminance_ )
+      , minLuminance( minLuminance_ )
+      , maxContentLightLevel( maxContentLightLevel_ )
+      , maxFrameAverageLightLevel( maxFrameAverageLightLevel_ )
+    {
+    }
+
+    HdrMetadataEXT( VkHdrMetadataEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(HdrMetadataEXT) );
+    }
+
+    HdrMetadataEXT& operator=( VkHdrMetadataEXT const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(HdrMetadataEXT) );
+      return *this;
+    }
+
+    HdrMetadataEXT& setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    HdrMetadataEXT& setDisplayPrimaryRed( XYColorEXT displayPrimaryRed_ )
+    {
+      displayPrimaryRed = displayPrimaryRed_;
+      return *this;
+    }
+
+    HdrMetadataEXT& setDisplayPrimaryGreen( XYColorEXT displayPrimaryGreen_ )
+    {
+      displayPrimaryGreen = displayPrimaryGreen_;
+      return *this;
+    }
+
+    HdrMetadataEXT& setDisplayPrimaryBlue( XYColorEXT displayPrimaryBlue_ )
+    {
+      displayPrimaryBlue = displayPrimaryBlue_;
+      return *this;
+    }
+
+    HdrMetadataEXT& setWhitePoint( XYColorEXT whitePoint_ )
+    {
+      whitePoint = whitePoint_;
+      return *this;
+    }
+
+    HdrMetadataEXT& setMaxLuminance( float maxLuminance_ )
+    {
+      maxLuminance = maxLuminance_;
+      return *this;
+    }
+
+    HdrMetadataEXT& setMinLuminance( float minLuminance_ )
+    {
+      minLuminance = minLuminance_;
+      return *this;
+    }
+
+    HdrMetadataEXT& setMaxContentLightLevel( float maxContentLightLevel_ )
+    {
+      maxContentLightLevel = maxContentLightLevel_;
+      return *this;
+    }
+
+    HdrMetadataEXT& setMaxFrameAverageLightLevel( float maxFrameAverageLightLevel_ )
+    {
+      maxFrameAverageLightLevel = maxFrameAverageLightLevel_;
+      return *this;
+    }
+
+    operator const VkHdrMetadataEXT&() const
+    {
+      return *reinterpret_cast<const VkHdrMetadataEXT*>(this);
+    }
+
+    bool operator==( HdrMetadataEXT const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( displayPrimaryRed == rhs.displayPrimaryRed )
+          && ( displayPrimaryGreen == rhs.displayPrimaryGreen )
+          && ( displayPrimaryBlue == rhs.displayPrimaryBlue )
+          && ( whitePoint == rhs.whitePoint )
+          && ( maxLuminance == rhs.maxLuminance )
+          && ( minLuminance == rhs.minLuminance )
+          && ( maxContentLightLevel == rhs.maxContentLightLevel )
+          && ( maxFrameAverageLightLevel == rhs.maxFrameAverageLightLevel );
+    }
+
+    bool operator!=( HdrMetadataEXT const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType;
+
+  public:
+    const void* pNext;
+    XYColorEXT displayPrimaryRed;
+    XYColorEXT displayPrimaryGreen;
+    XYColorEXT displayPrimaryBlue;
+    XYColorEXT whitePoint;
+    float maxLuminance;
+    float minLuminance;
+    float maxContentLightLevel;
+    float maxFrameAverageLightLevel;
+  };
+  static_assert( sizeof( HdrMetadataEXT ) == sizeof( VkHdrMetadataEXT ), "struct and wrapper have different size!" );
+
+  struct PresentTimesInfoGOOGLE
+  {
+    PresentTimesInfoGOOGLE( uint32_t swapchainCount_ = 0, const PresentTimeGOOGLE* pTimes_ = nullptr )
+      : sType( StructureType::ePresentTimesInfoGOOGLE )
+      , pNext( nullptr )
+      , swapchainCount( swapchainCount_ )
+      , pTimes( pTimes_ )
+    {
+    }
+
+    PresentTimesInfoGOOGLE( VkPresentTimesInfoGOOGLE const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PresentTimesInfoGOOGLE) );
+    }
+
+    PresentTimesInfoGOOGLE& operator=( VkPresentTimesInfoGOOGLE const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PresentTimesInfoGOOGLE) );
+      return *this;
+    }
+
+    PresentTimesInfoGOOGLE& setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    PresentTimesInfoGOOGLE& setSwapchainCount( uint32_t swapchainCount_ )
+    {
+      swapchainCount = swapchainCount_;
+      return *this;
+    }
+
+    PresentTimesInfoGOOGLE& setPTimes( const PresentTimeGOOGLE* pTimes_ )
+    {
+      pTimes = pTimes_;
+      return *this;
+    }
+
+    operator const VkPresentTimesInfoGOOGLE&() const
+    {
+      return *reinterpret_cast<const VkPresentTimesInfoGOOGLE*>(this);
+    }
+
+    bool operator==( PresentTimesInfoGOOGLE const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( swapchainCount == rhs.swapchainCount )
+          && ( pTimes == rhs.pTimes );
+    }
+
+    bool operator!=( PresentTimesInfoGOOGLE const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType;
+
+  public:
+    const void* pNext;
+    uint32_t swapchainCount;
+    const PresentTimeGOOGLE* pTimes;
+  };
+  static_assert( sizeof( PresentTimesInfoGOOGLE ) == sizeof( VkPresentTimesInfoGOOGLE ), "struct and wrapper have different size!" );
+
 #ifdef VK_USE_PLATFORM_IOS_MVK
   struct IOSSurfaceCreateInfoMVK
   {
@@ -12956,100 +13372,6 @@ namespace vk
     ImageCreateFlags flags;
   };
   static_assert( sizeof( PhysicalDeviceImageFormatInfo2KHR ) == sizeof( VkPhysicalDeviceImageFormatInfo2KHR ), "struct and wrapper have different size!" );
-
-  struct PhysicalDeviceImageFormatInfo2KHX
-  {
-    PhysicalDeviceImageFormatInfo2KHX( Format format_ = Format::eUndefined, ImageType type_ = ImageType::e1D, ImageTiling tiling_ = ImageTiling::eOptimal, ImageUsageFlags usage_ = ImageUsageFlags(), ImageCreateFlags flags_ = ImageCreateFlags() )
-      : sType( StructureType::ePhysicalDeviceImageFormatInfo2KHX )
-      , pNext( nullptr )
-      , format( format_ )
-      , type( type_ )
-      , tiling( tiling_ )
-      , usage( usage_ )
-      , flags( flags_ )
-    {
-    }
-
-    PhysicalDeviceImageFormatInfo2KHX( VkPhysicalDeviceImageFormatInfo2KHX const & rhs )
-    {
-      memcpy( this, &rhs, sizeof(PhysicalDeviceImageFormatInfo2KHX) );
-    }
-
-    PhysicalDeviceImageFormatInfo2KHX& operator=( VkPhysicalDeviceImageFormatInfo2KHX const & rhs )
-    {
-      memcpy( this, &rhs, sizeof(PhysicalDeviceImageFormatInfo2KHX) );
-      return *this;
-    }
-
-    PhysicalDeviceImageFormatInfo2KHX& setPNext( const void* pNext_ )
-    {
-      pNext = pNext_;
-      return *this;
-    }
-
-    PhysicalDeviceImageFormatInfo2KHX& setFormat( Format format_ )
-    {
-      format = format_;
-      return *this;
-    }
-
-    PhysicalDeviceImageFormatInfo2KHX& setType( ImageType type_ )
-    {
-      type = type_;
-      return *this;
-    }
-
-    PhysicalDeviceImageFormatInfo2KHX& setTiling( ImageTiling tiling_ )
-    {
-      tiling = tiling_;
-      return *this;
-    }
-
-    PhysicalDeviceImageFormatInfo2KHX& setUsage( ImageUsageFlags usage_ )
-    {
-      usage = usage_;
-      return *this;
-    }
-
-    PhysicalDeviceImageFormatInfo2KHX& setFlags( ImageCreateFlags flags_ )
-    {
-      flags = flags_;
-      return *this;
-    }
-
-    operator const VkPhysicalDeviceImageFormatInfo2KHX&() const
-    {
-      return *reinterpret_cast<const VkPhysicalDeviceImageFormatInfo2KHX*>(this);
-    }
-
-    bool operator==( PhysicalDeviceImageFormatInfo2KHX const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( format == rhs.format )
-          && ( type == rhs.type )
-          && ( tiling == rhs.tiling )
-          && ( usage == rhs.usage )
-          && ( flags == rhs.flags );
-    }
-
-    bool operator!=( PhysicalDeviceImageFormatInfo2KHX const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType;
-
-  public:
-    const void* pNext;
-    Format format;
-    ImageType type;
-    ImageTiling tiling;
-    ImageUsageFlags usage;
-    ImageCreateFlags flags;
-  };
-  static_assert( sizeof( PhysicalDeviceImageFormatInfo2KHX ) == sizeof( VkPhysicalDeviceImageFormatInfo2KHX ), "struct and wrapper have different size!" );
 
   enum class PipelineCreateFlagBits
   {
@@ -16549,62 +16871,6 @@ namespace vk
     ImageTiling tiling;
   };
   static_assert( sizeof( PhysicalDeviceSparseImageFormatInfo2KHR ) == sizeof( VkPhysicalDeviceSparseImageFormatInfo2KHR ), "struct and wrapper have different size!" );
-
-  struct PhysicalDeviceProperties2KHX
-  {
-    operator const VkPhysicalDeviceProperties2KHX&() const
-    {
-      return *reinterpret_cast<const VkPhysicalDeviceProperties2KHX*>(this);
-    }
-
-    bool operator==( PhysicalDeviceProperties2KHX const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( properties == rhs.properties );
-    }
-
-    bool operator!=( PhysicalDeviceProperties2KHX const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType;
-
-  public:
-    void* pNext;
-    PhysicalDeviceProperties properties;
-  };
-  static_assert( sizeof( PhysicalDeviceProperties2KHX ) == sizeof( VkPhysicalDeviceProperties2KHX ), "struct and wrapper have different size!" );
-
-  struct ImageFormatProperties2KHX
-  {
-    operator const VkImageFormatProperties2KHX&() const
-    {
-      return *reinterpret_cast<const VkImageFormatProperties2KHX*>(this);
-    }
-
-    bool operator==( ImageFormatProperties2KHX const& rhs ) const
-    {
-      return ( sType == rhs.sType )
-          && ( pNext == rhs.pNext )
-          && ( imageFormatProperties == rhs.imageFormatProperties );
-    }
-
-    bool operator!=( ImageFormatProperties2KHX const& rhs ) const
-    {
-      return !operator==( rhs );
-    }
-
-  private:
-    StructureType sType;
-
-  public:
-    void* pNext;
-    ImageFormatProperties imageFormatProperties;
-  };
-  static_assert( sizeof( ImageFormatProperties2KHX ) == sizeof( VkImageFormatProperties2KHX ), "struct and wrapper have different size!" );
 
   enum class AttachmentDescriptionFlagBits
   {
@@ -21324,6 +21590,7 @@ namespace vk
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
+
     Result enumerateInstanceExtensionProperties( const char* pLayerName, uint32_t* pPropertyCount, ExtensionProperties* pProperties );
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<ExtensionProperties>> 
@@ -21355,6 +21622,7 @@ namespace vk
     return createResultValue( result, properties, "vk::enumerateInstanceExtensionProperties" );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
 
   // forward declarations
   struct CmdProcessCommandsInfoNVX;
@@ -22126,6 +22394,7 @@ namespace vk
     vkCmdSetDiscardRectangleEXT( m_commandBuffer, firstDiscardRectangle, discardRectangles.size() , reinterpret_cast<const VkRect2D*>( discardRectangles.data() ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
   struct SubmitInfo
   {
     SubmitInfo( uint32_t waitSemaphoreCount_ = 0, const Semaphore* pWaitSemaphores_ = nullptr, const PipelineStageFlags* pWaitDstStageMask_ = nullptr, uint32_t commandBufferCount_ = 0, const CommandBuffer* pCommandBuffers_ = nullptr, uint32_t signalSemaphoreCount_ = 0, const Semaphore* pSignalSemaphores_ = nullptr )
@@ -22371,6 +22640,7 @@ namespace vk
     return createResultValue( result, "vk::Queue::presentKHR", { Result::eSuccess, Result::eSuboptimalKHR } );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
   class BufferDeleter;
   using UniqueBuffer = UniqueHandle<Buffer, BufferDeleter>;
@@ -22570,11 +22840,7 @@ namespace vk
     ResultValueType<void>::type resetFences( ArrayProxy<const Fence> fences ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
     Result getFenceStatus( Fence fence ) const;
-#else
-    Result getFenceStatus( Fence fence ) const;
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     Result waitForFences( uint32_t fenceCount, const Fence* pFences, Bool32 waitAll, uint64_t timeout ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -22607,11 +22873,7 @@ namespace vk
     void destroyEvent( Event event, Optional<const AllocationCallbacks> allocator = nullptr ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
     Result getEventStatus( Event event ) const;
-#else
-    Result getEventStatus( Event event ) const;
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
 #ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
     Result setEvent( Event event ) const;
@@ -22999,7 +23261,11 @@ namespace vk
     ResultValueType<void>::type unregisterObjectsNVX( ObjectTableNVX objectTable, ArrayProxy<const ObjectEntryTypeNVX> objectEntryTypes, ArrayProxy<const uint32_t> objectIndices ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
+#ifdef VULKAN_HPP_DISABLE_ENHANCED_MODE
     void trimCommandPoolKHR( CommandPool commandPool, CommandPoolTrimFlagsKHR flags ) const;
+#else
+    void trimCommandPoolKHR( CommandPool commandPool, CommandPoolTrimFlagsKHR flags = CommandPoolTrimFlagsKHR() ) const;
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     Result getMemoryWin32HandleKHX( DeviceMemory memory, ExternalMemoryHandleTypeFlagBitsKHX handleType, HANDLE* pHandle ) const;
@@ -23113,6 +23379,22 @@ namespace vk
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     void updateDescriptorSetWithTemplateKHR( DescriptorSet descriptorSet, DescriptorUpdateTemplateKHR descriptorUpdateTemplate, const void* pData ) const;
+
+    void setHdrMetadataEXT( uint32_t swapchainCount, const SwapchainKHR* pSwapchains, const HdrMetadataEXT* pMetadata ) const;
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    void setHdrMetadataEXT( ArrayProxy<const SwapchainKHR> swapchains, ArrayProxy<const HdrMetadataEXT> metadata ) const;
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+    Result getRefreshCycleDurationGOOGLE( SwapchainKHR swapchain, RefreshCycleDurationGOOGLE* pDisplayTimingProperties ) const;
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    ResultValueType<RefreshCycleDurationGOOGLE>::type getRefreshCycleDurationGOOGLE( SwapchainKHR swapchain ) const;
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+    Result getPastPresentationTimingGOOGLE( SwapchainKHR swapchain, uint32_t* pPresentationTimingCount, PastPresentationTimingGOOGLE* pPresentationTimings ) const;
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template <typename Allocator = std::allocator<PastPresentationTimingGOOGLE>> 
+    typename ResultValueType<std::vector<PastPresentationTimingGOOGLE,Allocator>>::type getPastPresentationTimingGOOGLE( SwapchainKHR swapchain ) const;
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDevice() const
     {
@@ -23604,7 +23886,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroy( Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyDevice( m_device, reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyDevice( m_device, reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -23642,7 +23924,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<DeviceMemory>::type Device::allocateMemory( const MemoryAllocateInfo & allocateInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     DeviceMemory memory;
-    Result result = static_cast<Result>( vkAllocateMemory( m_device, reinterpret_cast<const VkMemoryAllocateInfo*>( &allocateInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkDeviceMemory*>( &memory ) ) );
+    Result result = static_cast<Result>( vkAllocateMemory( m_device, reinterpret_cast<const VkMemoryAllocateInfo*>( &allocateInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkDeviceMemory*>( &memory ) ) );
     return createResultValue( result, memory, "vk::Device::allocateMemory" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -23661,7 +23943,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::freeMemory( DeviceMemory memory, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkFreeMemory( m_device, static_cast<VkDeviceMemory>( memory ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkFreeMemory( m_device, static_cast<VkDeviceMemory>( memory ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -23797,7 +24079,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<Fence>::type Device::createFence( const FenceCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Fence fence;
-    Result result = static_cast<Result>( vkCreateFence( m_device, reinterpret_cast<const VkFenceCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkFence*>( &fence ) ) );
+    Result result = static_cast<Result>( vkCreateFence( m_device, reinterpret_cast<const VkFenceCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkFence*>( &fence ) ) );
     return createResultValue( result, fence, "vk::Device::createFence" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -23816,7 +24098,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyFence( Fence fence, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyFence( m_device, static_cast<VkFence>( fence ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyFence( m_device, static_cast<VkFence>( fence ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -23865,7 +24147,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<Semaphore>::type Device::createSemaphore( const SemaphoreCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Semaphore semaphore;
-    Result result = static_cast<Result>( vkCreateSemaphore( m_device, reinterpret_cast<const VkSemaphoreCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSemaphore*>( &semaphore ) ) );
+    Result result = static_cast<Result>( vkCreateSemaphore( m_device, reinterpret_cast<const VkSemaphoreCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSemaphore*>( &semaphore ) ) );
     return createResultValue( result, semaphore, "vk::Device::createSemaphore" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -23884,7 +24166,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroySemaphore( Semaphore semaphore, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroySemaphore( m_device, static_cast<VkSemaphore>( semaphore ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroySemaphore( m_device, static_cast<VkSemaphore>( semaphore ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -23896,7 +24178,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<Event>::type Device::createEvent( const EventCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Event event;
-    Result result = static_cast<Result>( vkCreateEvent( m_device, reinterpret_cast<const VkEventCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkEvent*>( &event ) ) );
+    Result result = static_cast<Result>( vkCreateEvent( m_device, reinterpret_cast<const VkEventCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkEvent*>( &event ) ) );
     return createResultValue( result, event, "vk::Device::createEvent" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -23915,7 +24197,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyEvent( Event event, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyEvent( m_device, static_cast<VkEvent>( event ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyEvent( m_device, static_cast<VkEvent>( event ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -23966,7 +24248,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<QueryPool>::type Device::createQueryPool( const QueryPoolCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     QueryPool queryPool;
-    Result result = static_cast<Result>( vkCreateQueryPool( m_device, reinterpret_cast<const VkQueryPoolCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkQueryPool*>( &queryPool ) ) );
+    Result result = static_cast<Result>( vkCreateQueryPool( m_device, reinterpret_cast<const VkQueryPoolCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkQueryPool*>( &queryPool ) ) );
     return createResultValue( result, queryPool, "vk::Device::createQueryPool" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -23985,7 +24267,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyQueryPool( QueryPool queryPool, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyQueryPool( m_device, static_cast<VkQueryPool>( queryPool ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyQueryPool( m_device, static_cast<VkQueryPool>( queryPool ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24010,7 +24292,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<Buffer>::type Device::createBuffer( const BufferCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Buffer buffer;
-    Result result = static_cast<Result>( vkCreateBuffer( m_device, reinterpret_cast<const VkBufferCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkBuffer*>( &buffer ) ) );
+    Result result = static_cast<Result>( vkCreateBuffer( m_device, reinterpret_cast<const VkBufferCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkBuffer*>( &buffer ) ) );
     return createResultValue( result, buffer, "vk::Device::createBuffer" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24029,7 +24311,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyBuffer( Buffer buffer, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyBuffer( m_device, static_cast<VkBuffer>( buffer ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyBuffer( m_device, static_cast<VkBuffer>( buffer ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24041,7 +24323,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<BufferView>::type Device::createBufferView( const BufferViewCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     BufferView view;
-    Result result = static_cast<Result>( vkCreateBufferView( m_device, reinterpret_cast<const VkBufferViewCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkBufferView*>( &view ) ) );
+    Result result = static_cast<Result>( vkCreateBufferView( m_device, reinterpret_cast<const VkBufferViewCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkBufferView*>( &view ) ) );
     return createResultValue( result, view, "vk::Device::createBufferView" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24060,7 +24342,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyBufferView( BufferView bufferView, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyBufferView( m_device, static_cast<VkBufferView>( bufferView ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyBufferView( m_device, static_cast<VkBufferView>( bufferView ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24072,7 +24354,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<Image>::type Device::createImage( const ImageCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Image image;
-    Result result = static_cast<Result>( vkCreateImage( m_device, reinterpret_cast<const VkImageCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkImage*>( &image ) ) );
+    Result result = static_cast<Result>( vkCreateImage( m_device, reinterpret_cast<const VkImageCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkImage*>( &image ) ) );
     return createResultValue( result, image, "vk::Device::createImage" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24091,7 +24373,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyImage( Image image, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyImage( m_device, static_cast<VkImage>( image ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyImage( m_device, static_cast<VkImage>( image ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24116,7 +24398,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<ImageView>::type Device::createImageView( const ImageViewCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     ImageView view;
-    Result result = static_cast<Result>( vkCreateImageView( m_device, reinterpret_cast<const VkImageViewCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkImageView*>( &view ) ) );
+    Result result = static_cast<Result>( vkCreateImageView( m_device, reinterpret_cast<const VkImageViewCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkImageView*>( &view ) ) );
     return createResultValue( result, view, "vk::Device::createImageView" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24135,7 +24417,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyImageView( ImageView imageView, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyImageView( m_device, static_cast<VkImageView>( imageView ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyImageView( m_device, static_cast<VkImageView>( imageView ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24147,7 +24429,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<ShaderModule>::type Device::createShaderModule( const ShaderModuleCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     ShaderModule shaderModule;
-    Result result = static_cast<Result>( vkCreateShaderModule( m_device, reinterpret_cast<const VkShaderModuleCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkShaderModule*>( &shaderModule ) ) );
+    Result result = static_cast<Result>( vkCreateShaderModule( m_device, reinterpret_cast<const VkShaderModuleCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkShaderModule*>( &shaderModule ) ) );
     return createResultValue( result, shaderModule, "vk::Device::createShaderModule" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24166,7 +24448,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyShaderModule( ShaderModule shaderModule, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyShaderModule( m_device, static_cast<VkShaderModule>( shaderModule ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyShaderModule( m_device, static_cast<VkShaderModule>( shaderModule ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24178,7 +24460,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<PipelineCache>::type Device::createPipelineCache( const PipelineCacheCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     PipelineCache pipelineCache;
-    Result result = static_cast<Result>( vkCreatePipelineCache( m_device, reinterpret_cast<const VkPipelineCacheCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkPipelineCache*>( &pipelineCache ) ) );
+    Result result = static_cast<Result>( vkCreatePipelineCache( m_device, reinterpret_cast<const VkPipelineCacheCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkPipelineCache*>( &pipelineCache ) ) );
     return createResultValue( result, pipelineCache, "vk::Device::createPipelineCache" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24197,7 +24479,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyPipelineCache( PipelineCache pipelineCache, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyPipelineCache( m_device, static_cast<VkPipelineCache>( pipelineCache ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyPipelineCache( m_device, static_cast<VkPipelineCache>( pipelineCache ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24248,13 +24530,13 @@ namespace vk
   VULKAN_HPP_INLINE typename ResultValueType<std::vector<Pipeline,Allocator>>::type Device::createGraphicsPipelines( PipelineCache pipelineCache, ArrayProxy<const GraphicsPipelineCreateInfo> createInfos, Optional<const AllocationCallbacks> allocator ) const
   {
     std::vector<Pipeline,Allocator> pipelines( createInfos.size() );
-    Result result = static_cast<Result>( vkCreateGraphicsPipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), createInfos.size() , reinterpret_cast<const VkGraphicsPipelineCreateInfo*>( createInfos.data() ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkPipeline*>( pipelines.data() ) ) );
+    Result result = static_cast<Result>( vkCreateGraphicsPipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), createInfos.size() , reinterpret_cast<const VkGraphicsPipelineCreateInfo*>( createInfos.data() ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkPipeline*>( pipelines.data() ) ) );
     return createResultValue( result, pipelines, "vk::Device::createGraphicsPipelines" );
   }
   VULKAN_HPP_INLINE ResultValueType<Pipeline>::type Device::createGraphicsPipeline( PipelineCache pipelineCache, const GraphicsPipelineCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Pipeline pipeline;
-    Result result = static_cast<Result>( vkCreateGraphicsPipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), 1 , reinterpret_cast<const VkGraphicsPipelineCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkPipeline*>( &pipeline ) ) );
+    Result result = static_cast<Result>( vkCreateGraphicsPipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), 1 , reinterpret_cast<const VkGraphicsPipelineCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkPipeline*>( &pipeline ) ) );
     return createResultValue( result, pipeline, "vk::Device::createGraphicsPipeline" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24288,13 +24570,13 @@ namespace vk
   VULKAN_HPP_INLINE typename ResultValueType<std::vector<Pipeline,Allocator>>::type Device::createComputePipelines( PipelineCache pipelineCache, ArrayProxy<const ComputePipelineCreateInfo> createInfos, Optional<const AllocationCallbacks> allocator ) const
   {
     std::vector<Pipeline,Allocator> pipelines( createInfos.size() );
-    Result result = static_cast<Result>( vkCreateComputePipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), createInfos.size() , reinterpret_cast<const VkComputePipelineCreateInfo*>( createInfos.data() ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkPipeline*>( pipelines.data() ) ) );
+    Result result = static_cast<Result>( vkCreateComputePipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), createInfos.size() , reinterpret_cast<const VkComputePipelineCreateInfo*>( createInfos.data() ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkPipeline*>( pipelines.data() ) ) );
     return createResultValue( result, pipelines, "vk::Device::createComputePipelines" );
   }
   VULKAN_HPP_INLINE ResultValueType<Pipeline>::type Device::createComputePipeline( PipelineCache pipelineCache, const ComputePipelineCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Pipeline pipeline;
-    Result result = static_cast<Result>( vkCreateComputePipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), 1 , reinterpret_cast<const VkComputePipelineCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkPipeline*>( &pipeline ) ) );
+    Result result = static_cast<Result>( vkCreateComputePipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), 1 , reinterpret_cast<const VkComputePipelineCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkPipeline*>( &pipeline ) ) );
     return createResultValue( result, pipeline, "vk::Device::createComputePipeline" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24326,7 +24608,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyPipeline( Pipeline pipeline, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyPipeline( m_device, static_cast<VkPipeline>( pipeline ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyPipeline( m_device, static_cast<VkPipeline>( pipeline ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24338,7 +24620,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<PipelineLayout>::type Device::createPipelineLayout( const PipelineLayoutCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     PipelineLayout pipelineLayout;
-    Result result = static_cast<Result>( vkCreatePipelineLayout( m_device, reinterpret_cast<const VkPipelineLayoutCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkPipelineLayout*>( &pipelineLayout ) ) );
+    Result result = static_cast<Result>( vkCreatePipelineLayout( m_device, reinterpret_cast<const VkPipelineLayoutCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkPipelineLayout*>( &pipelineLayout ) ) );
     return createResultValue( result, pipelineLayout, "vk::Device::createPipelineLayout" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24357,7 +24639,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyPipelineLayout( PipelineLayout pipelineLayout, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyPipelineLayout( m_device, static_cast<VkPipelineLayout>( pipelineLayout ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyPipelineLayout( m_device, static_cast<VkPipelineLayout>( pipelineLayout ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24369,7 +24651,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<Sampler>::type Device::createSampler( const SamplerCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Sampler sampler;
-    Result result = static_cast<Result>( vkCreateSampler( m_device, reinterpret_cast<const VkSamplerCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSampler*>( &sampler ) ) );
+    Result result = static_cast<Result>( vkCreateSampler( m_device, reinterpret_cast<const VkSamplerCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSampler*>( &sampler ) ) );
     return createResultValue( result, sampler, "vk::Device::createSampler" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24388,7 +24670,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroySampler( Sampler sampler, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroySampler( m_device, static_cast<VkSampler>( sampler ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroySampler( m_device, static_cast<VkSampler>( sampler ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24400,7 +24682,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<DescriptorSetLayout>::type Device::createDescriptorSetLayout( const DescriptorSetLayoutCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     DescriptorSetLayout setLayout;
-    Result result = static_cast<Result>( vkCreateDescriptorSetLayout( m_device, reinterpret_cast<const VkDescriptorSetLayoutCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkDescriptorSetLayout*>( &setLayout ) ) );
+    Result result = static_cast<Result>( vkCreateDescriptorSetLayout( m_device, reinterpret_cast<const VkDescriptorSetLayoutCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkDescriptorSetLayout*>( &setLayout ) ) );
     return createResultValue( result, setLayout, "vk::Device::createDescriptorSetLayout" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24419,7 +24701,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyDescriptorSetLayout( DescriptorSetLayout descriptorSetLayout, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyDescriptorSetLayout( m_device, static_cast<VkDescriptorSetLayout>( descriptorSetLayout ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyDescriptorSetLayout( m_device, static_cast<VkDescriptorSetLayout>( descriptorSetLayout ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24431,7 +24713,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<DescriptorPool>::type Device::createDescriptorPool( const DescriptorPoolCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     DescriptorPool descriptorPool;
-    Result result = static_cast<Result>( vkCreateDescriptorPool( m_device, reinterpret_cast<const VkDescriptorPoolCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkDescriptorPool*>( &descriptorPool ) ) );
+    Result result = static_cast<Result>( vkCreateDescriptorPool( m_device, reinterpret_cast<const VkDescriptorPoolCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkDescriptorPool*>( &descriptorPool ) ) );
     return createResultValue( result, descriptorPool, "vk::Device::createDescriptorPool" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24450,7 +24732,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyDescriptorPool( DescriptorPool descriptorPool, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyDescriptorPool( m_device, static_cast<VkDescriptorPool>( descriptorPool ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyDescriptorPool( m_device, static_cast<VkDescriptorPool>( descriptorPool ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24527,7 +24809,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<Framebuffer>::type Device::createFramebuffer( const FramebufferCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Framebuffer framebuffer;
-    Result result = static_cast<Result>( vkCreateFramebuffer( m_device, reinterpret_cast<const VkFramebufferCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkFramebuffer*>( &framebuffer ) ) );
+    Result result = static_cast<Result>( vkCreateFramebuffer( m_device, reinterpret_cast<const VkFramebufferCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkFramebuffer*>( &framebuffer ) ) );
     return createResultValue( result, framebuffer, "vk::Device::createFramebuffer" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24546,7 +24828,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyFramebuffer( Framebuffer framebuffer, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyFramebuffer( m_device, static_cast<VkFramebuffer>( framebuffer ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyFramebuffer( m_device, static_cast<VkFramebuffer>( framebuffer ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24558,7 +24840,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<RenderPass>::type Device::createRenderPass( const RenderPassCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     RenderPass renderPass;
-    Result result = static_cast<Result>( vkCreateRenderPass( m_device, reinterpret_cast<const VkRenderPassCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkRenderPass*>( &renderPass ) ) );
+    Result result = static_cast<Result>( vkCreateRenderPass( m_device, reinterpret_cast<const VkRenderPassCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkRenderPass*>( &renderPass ) ) );
     return createResultValue( result, renderPass, "vk::Device::createRenderPass" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24577,7 +24859,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyRenderPass( RenderPass renderPass, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyRenderPass( m_device, static_cast<VkRenderPass>( renderPass ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyRenderPass( m_device, static_cast<VkRenderPass>( renderPass ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24602,7 +24884,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<CommandPool>::type Device::createCommandPool( const CommandPoolCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     CommandPool commandPool;
-    Result result = static_cast<Result>( vkCreateCommandPool( m_device, reinterpret_cast<const VkCommandPoolCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkCommandPool*>( &commandPool ) ) );
+    Result result = static_cast<Result>( vkCreateCommandPool( m_device, reinterpret_cast<const VkCommandPoolCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkCommandPool*>( &commandPool ) ) );
     return createResultValue( result, commandPool, "vk::Device::createCommandPool" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24621,7 +24903,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyCommandPool( CommandPool commandPool, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyCommandPool( m_device, static_cast<VkCommandPool>( commandPool ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyCommandPool( m_device, static_cast<VkCommandPool>( commandPool ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24687,13 +24969,13 @@ namespace vk
   VULKAN_HPP_INLINE typename ResultValueType<std::vector<SwapchainKHR,Allocator>>::type Device::createSharedSwapchainsKHR( ArrayProxy<const SwapchainCreateInfoKHR> createInfos, Optional<const AllocationCallbacks> allocator ) const
   {
     std::vector<SwapchainKHR,Allocator> swapchains( createInfos.size() );
-    Result result = static_cast<Result>( vkCreateSharedSwapchainsKHR( m_device, createInfos.size() , reinterpret_cast<const VkSwapchainCreateInfoKHR*>( createInfos.data() ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSwapchainKHR*>( swapchains.data() ) ) );
+    Result result = static_cast<Result>( vkCreateSharedSwapchainsKHR( m_device, createInfos.size() , reinterpret_cast<const VkSwapchainCreateInfoKHR*>( createInfos.data() ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSwapchainKHR*>( swapchains.data() ) ) );
     return createResultValue( result, swapchains, "vk::Device::createSharedSwapchainsKHR" );
   }
   VULKAN_HPP_INLINE ResultValueType<SwapchainKHR>::type Device::createSharedSwapchainKHR( const SwapchainCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SwapchainKHR swapchain;
-    Result result = static_cast<Result>( vkCreateSharedSwapchainsKHR( m_device, 1 , reinterpret_cast<const VkSwapchainCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSwapchainKHR*>( &swapchain ) ) );
+    Result result = static_cast<Result>( vkCreateSharedSwapchainsKHR( m_device, 1 , reinterpret_cast<const VkSwapchainCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSwapchainKHR*>( &swapchain ) ) );
     return createResultValue( result, swapchain, "vk::Device::createSharedSwapchainKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24726,7 +25008,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SwapchainKHR>::type Device::createSwapchainKHR( const SwapchainCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SwapchainKHR swapchain;
-    Result result = static_cast<Result>( vkCreateSwapchainKHR( m_device, reinterpret_cast<const VkSwapchainCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSwapchainKHR*>( &swapchain ) ) );
+    Result result = static_cast<Result>( vkCreateSwapchainKHR( m_device, reinterpret_cast<const VkSwapchainCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSwapchainKHR*>( &swapchain ) ) );
     return createResultValue( result, swapchain, "vk::Device::createSwapchainKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24745,7 +25027,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroySwapchainKHR( SwapchainKHR swapchain, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroySwapchainKHR( m_device, static_cast<VkSwapchainKHR>( swapchain ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroySwapchainKHR( m_device, static_cast<VkSwapchainKHR>( swapchain ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24837,7 +25119,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<IndirectCommandsLayoutNVX>::type Device::createIndirectCommandsLayoutNVX( const IndirectCommandsLayoutCreateInfoNVX & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     IndirectCommandsLayoutNVX indirectCommandsLayout;
-    Result result = static_cast<Result>( vkCreateIndirectCommandsLayoutNVX( m_device, reinterpret_cast<const VkIndirectCommandsLayoutCreateInfoNVX*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkIndirectCommandsLayoutNVX*>( &indirectCommandsLayout ) ) );
+    Result result = static_cast<Result>( vkCreateIndirectCommandsLayoutNVX( m_device, reinterpret_cast<const VkIndirectCommandsLayoutCreateInfoNVX*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkIndirectCommandsLayoutNVX*>( &indirectCommandsLayout ) ) );
     return createResultValue( result, indirectCommandsLayout, "vk::Device::createIndirectCommandsLayoutNVX" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24856,7 +25138,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyIndirectCommandsLayoutNVX( IndirectCommandsLayoutNVX indirectCommandsLayout, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyIndirectCommandsLayoutNVX( m_device, static_cast<VkIndirectCommandsLayoutNVX>( indirectCommandsLayout ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyIndirectCommandsLayoutNVX( m_device, static_cast<VkIndirectCommandsLayoutNVX>( indirectCommandsLayout ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -24868,7 +25150,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<ObjectTableNVX>::type Device::createObjectTableNVX( const ObjectTableCreateInfoNVX & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     ObjectTableNVX objectTable;
-    Result result = static_cast<Result>( vkCreateObjectTableNVX( m_device, reinterpret_cast<const VkObjectTableCreateInfoNVX*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkObjectTableNVX*>( &objectTable ) ) );
+    Result result = static_cast<Result>( vkCreateObjectTableNVX( m_device, reinterpret_cast<const VkObjectTableCreateInfoNVX*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkObjectTableNVX*>( &objectTable ) ) );
     return createResultValue( result, objectTable, "vk::Device::createObjectTableNVX" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -24887,7 +25169,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyObjectTableNVX( ObjectTableNVX objectTable, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyObjectTableNVX( m_device, static_cast<VkObjectTableNVX>( objectTable ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyObjectTableNVX( m_device, static_cast<VkObjectTableNVX>( objectTable ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -25181,7 +25463,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<DescriptorUpdateTemplateKHR>::type Device::createDescriptorUpdateTemplateKHR( const DescriptorUpdateTemplateCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     DescriptorUpdateTemplateKHR descriptorUpdateTemplate;
-    Result result = static_cast<Result>( vkCreateDescriptorUpdateTemplateKHR( m_device, reinterpret_cast<const VkDescriptorUpdateTemplateCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkDescriptorUpdateTemplateKHR*>( &descriptorUpdateTemplate ) ) );
+    Result result = static_cast<Result>( vkCreateDescriptorUpdateTemplateKHR( m_device, reinterpret_cast<const VkDescriptorUpdateTemplateCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkDescriptorUpdateTemplateKHR*>( &descriptorUpdateTemplate ) ) );
     return createResultValue( result, descriptorUpdateTemplate, "vk::Device::createDescriptorUpdateTemplateKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -25200,7 +25482,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Device::destroyDescriptorUpdateTemplateKHR( DescriptorUpdateTemplateKHR descriptorUpdateTemplate, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyDescriptorUpdateTemplateKHR( m_device, static_cast<VkDescriptorUpdateTemplateKHR>( descriptorUpdateTemplate ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyDescriptorUpdateTemplateKHR( m_device, static_cast<VkDescriptorUpdateTemplateKHR>( descriptorUpdateTemplate ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -25208,6 +25490,59 @@ namespace vk
   {
     vkUpdateDescriptorSetWithTemplateKHR( m_device, static_cast<VkDescriptorSet>( descriptorSet ), static_cast<VkDescriptorUpdateTemplateKHR>( descriptorUpdateTemplate ), pData );
   }
+
+  VULKAN_HPP_INLINE void Device::setHdrMetadataEXT( uint32_t swapchainCount, const SwapchainKHR* pSwapchains, const HdrMetadataEXT* pMetadata ) const
+  {
+    vkSetHdrMetadataEXT( m_device, swapchainCount, reinterpret_cast<const VkSwapchainKHR*>( pSwapchains ), reinterpret_cast<const VkHdrMetadataEXT*>( pMetadata ) );
+  }
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  VULKAN_HPP_INLINE void Device::setHdrMetadataEXT( ArrayProxy<const SwapchainKHR> swapchains, ArrayProxy<const HdrMetadataEXT> metadata ) const
+  {
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+    assert( swapchains.size() == metadata.size() );
+#else
+    if ( swapchains.size() != metadata.size() )
+    {
+      throw std::logic_error( "vk::Device::setHdrMetadataEXT: swapchains.size() != metadata.size()" );
+    }
+#endif  // VULKAN_HPP_NO_EXCEPTIONS
+    vkSetHdrMetadataEXT( m_device, swapchains.size() , reinterpret_cast<const VkSwapchainKHR*>( swapchains.data() ), reinterpret_cast<const VkHdrMetadataEXT*>( metadata.data() ) );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+  VULKAN_HPP_INLINE Result Device::getRefreshCycleDurationGOOGLE( SwapchainKHR swapchain, RefreshCycleDurationGOOGLE* pDisplayTimingProperties ) const
+  {
+    return static_cast<Result>( vkGetRefreshCycleDurationGOOGLE( m_device, static_cast<VkSwapchainKHR>( swapchain ), reinterpret_cast<VkRefreshCycleDurationGOOGLE*>( pDisplayTimingProperties ) ) );
+  }
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  VULKAN_HPP_INLINE ResultValueType<RefreshCycleDurationGOOGLE>::type Device::getRefreshCycleDurationGOOGLE( SwapchainKHR swapchain ) const
+  {
+    RefreshCycleDurationGOOGLE displayTimingProperties;
+    Result result = static_cast<Result>( vkGetRefreshCycleDurationGOOGLE( m_device, static_cast<VkSwapchainKHR>( swapchain ), reinterpret_cast<VkRefreshCycleDurationGOOGLE*>( &displayTimingProperties ) ) );
+    return createResultValue( result, displayTimingProperties, "vk::Device::getRefreshCycleDurationGOOGLE" );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
+  VULKAN_HPP_INLINE Result Device::getPastPresentationTimingGOOGLE( SwapchainKHR swapchain, uint32_t* pPresentationTimingCount, PastPresentationTimingGOOGLE* pPresentationTimings ) const
+  {
+    return static_cast<Result>( vkGetPastPresentationTimingGOOGLE( m_device, static_cast<VkSwapchainKHR>( swapchain ), pPresentationTimingCount, reinterpret_cast<VkPastPresentationTimingGOOGLE*>( pPresentationTimings ) ) );
+  }
+#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template <typename Allocator> 
+  VULKAN_HPP_INLINE typename ResultValueType<std::vector<PastPresentationTimingGOOGLE,Allocator>>::type Device::getPastPresentationTimingGOOGLE( SwapchainKHR swapchain ) const
+  {
+    std::vector<PastPresentationTimingGOOGLE,Allocator> presentationTimings;
+    uint32_t presentationTimingCount;
+    Result result = static_cast<Result>( vkGetPastPresentationTimingGOOGLE( m_device, static_cast<VkSwapchainKHR>( swapchain ), &presentationTimingCount, nullptr ) );
+    if ( ( result == Result::eSuccess ) && presentationTimingCount )
+    {
+      presentationTimings.resize( presentationTimingCount );
+      result = static_cast<Result>( vkGetPastPresentationTimingGOOGLE( m_device, static_cast<VkSwapchainKHR>( swapchain ), &presentationTimingCount, reinterpret_cast<VkPastPresentationTimingGOOGLE*>( presentationTimings.data() ) ) );
+    }
+    return createResultValue( result, presentationTimings, "vk::Device::getPastPresentationTimingGOOGLE" );
+  }
+#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
   class DeviceDeleter;
   using UniqueDevice = UniqueHandle<Device, DeviceDeleter>;
@@ -25449,16 +25784,6 @@ namespace vk
     std::vector<SparseImageFormatProperties2KHR,Allocator> getSparseImageFormatProperties2KHR( const PhysicalDeviceSparseImageFormatInfo2KHR & formatInfo ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-    void getProperties2KHX( PhysicalDeviceProperties2KHX* pProperties ) const;
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    PhysicalDeviceProperties2KHX getProperties2KHX() const;
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-
-    Result getImageFormatProperties2KHX( const PhysicalDeviceImageFormatInfo2KHX* pImageFormatInfo, ImageFormatProperties2KHX* pImageFormatProperties ) const;
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-    ResultValueType<ImageFormatProperties2KHX>::type getImageFormatProperties2KHX( const PhysicalDeviceImageFormatInfo2KHX & imageFormatInfo ) const;
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-
     void getExternalBufferPropertiesKHX( const PhysicalDeviceExternalBufferInfoKHX* pExternalBufferInfo, ExternalBufferPropertiesKHX* pExternalBufferProperties ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     ExternalBufferPropertiesKHX getExternalBufferPropertiesKHX( const PhysicalDeviceExternalBufferInfoKHX & externalBufferInfo ) const;
@@ -25628,7 +25953,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<Device>::type PhysicalDevice::createDevice( const DeviceCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     Device device;
-    Result result = static_cast<Result>( vkCreateDevice( m_physicalDevice, reinterpret_cast<const VkDeviceCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkDevice*>( &device ) ) );
+    Result result = static_cast<Result>( vkCreateDevice( m_physicalDevice, reinterpret_cast<const VkDeviceCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkDevice*>( &device ) ) );
     return createResultValue( result, device, "vk::PhysicalDevice::createDevice" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -25821,7 +26146,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<DisplayModeKHR>::type PhysicalDevice::createDisplayModeKHR( DisplayKHR display, const DisplayModeCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     DisplayModeKHR mode;
-    Result result = static_cast<Result>( vkCreateDisplayModeKHR( m_physicalDevice, static_cast<VkDisplayKHR>( display ), reinterpret_cast<const VkDisplayModeCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkDisplayModeKHR*>( &mode ) ) );
+    Result result = static_cast<Result>( vkCreateDisplayModeKHR( m_physicalDevice, static_cast<VkDisplayKHR>( display ), reinterpret_cast<const VkDisplayModeCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkDisplayModeKHR*>( &mode ) ) );
     return createResultValue( result, mode, "vk::PhysicalDevice::createDisplayModeKHR" );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
@@ -26101,32 +26426,6 @@ namespace vk
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-  VULKAN_HPP_INLINE void PhysicalDevice::getProperties2KHX( PhysicalDeviceProperties2KHX* pProperties ) const
-  {
-    vkGetPhysicalDeviceProperties2KHX( m_physicalDevice, reinterpret_cast<VkPhysicalDeviceProperties2KHX*>( pProperties ) );
-  }
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  VULKAN_HPP_INLINE PhysicalDeviceProperties2KHX PhysicalDevice::getProperties2KHX() const
-  {
-    PhysicalDeviceProperties2KHX properties;
-    vkGetPhysicalDeviceProperties2KHX( m_physicalDevice, reinterpret_cast<VkPhysicalDeviceProperties2KHX*>( &properties ) );
-    return properties;
-  }
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-
-  VULKAN_HPP_INLINE Result PhysicalDevice::getImageFormatProperties2KHX( const PhysicalDeviceImageFormatInfo2KHX* pImageFormatInfo, ImageFormatProperties2KHX* pImageFormatProperties ) const
-  {
-    return static_cast<Result>( vkGetPhysicalDeviceImageFormatProperties2KHX( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceImageFormatInfo2KHX*>( pImageFormatInfo ), reinterpret_cast<VkImageFormatProperties2KHX*>( pImageFormatProperties ) ) );
-  }
-#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
-  VULKAN_HPP_INLINE ResultValueType<ImageFormatProperties2KHX>::type PhysicalDevice::getImageFormatProperties2KHX( const PhysicalDeviceImageFormatInfo2KHX & imageFormatInfo ) const
-  {
-    ImageFormatProperties2KHX imageFormatProperties;
-    Result result = static_cast<Result>( vkGetPhysicalDeviceImageFormatProperties2KHX( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceImageFormatInfo2KHX*>( &imageFormatInfo ), reinterpret_cast<VkImageFormatProperties2KHX*>( &imageFormatProperties ) ) );
-    return createResultValue( result, imageFormatProperties, "vk::PhysicalDevice::getImageFormatProperties2KHX" );
-  }
-#endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-
   VULKAN_HPP_INLINE void PhysicalDevice::getExternalBufferPropertiesKHX( const PhysicalDeviceExternalBufferInfoKHX* pExternalBufferInfo, ExternalBufferPropertiesKHX* pExternalBufferProperties ) const
   {
     vkGetPhysicalDeviceExternalBufferPropertiesKHX( m_physicalDevice, reinterpret_cast<const VkPhysicalDeviceExternalBufferInfoKHX*>( pExternalBufferInfo ), reinterpret_cast<VkExternalBufferPropertiesKHX*>( pExternalBufferProperties ) );
@@ -26234,6 +26533,7 @@ namespace vk
     return createResultValue( result, rects, "vk::PhysicalDevice::getPresentRectanglesKHX" );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
   struct CmdProcessCommandsInfoNVX
   {
     CmdProcessCommandsInfoNVX( ObjectTableNVX objectTable_ = ObjectTableNVX(), IndirectCommandsLayoutNVX indirectCommandsLayout_ = IndirectCommandsLayoutNVX(), uint32_t indirectCommandsTokenCount_ = 0, const IndirectCommandsTokenNVX* pIndirectCommandsTokens_ = nullptr, uint32_t maxSequencesCount_ = 0, CommandBuffer targetCommandBuffer_ = CommandBuffer(), Buffer sequencesCountBuffer_ = Buffer(), DeviceSize sequencesCountOffset_ = 0, Buffer sequencesIndexBuffer_ = Buffer(), DeviceSize sequencesIndexOffset_ = 0 )
@@ -26664,7 +26964,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Instance::destroy( Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyInstance( m_instance, reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyInstance( m_instance, reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -26714,7 +27014,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createAndroidSurfaceKHR( const AndroidSurfaceCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateAndroidSurfaceKHR( m_instance, reinterpret_cast<const VkAndroidSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateAndroidSurfaceKHR( m_instance, reinterpret_cast<const VkAndroidSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createAndroidSurfaceKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26735,7 +27035,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createDisplayPlaneSurfaceKHR( const DisplaySurfaceCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateDisplayPlaneSurfaceKHR( m_instance, reinterpret_cast<const VkDisplaySurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateDisplayPlaneSurfaceKHR( m_instance, reinterpret_cast<const VkDisplaySurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createDisplayPlaneSurfaceKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26756,7 +27056,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createMirSurfaceKHR( const MirSurfaceCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateMirSurfaceKHR( m_instance, reinterpret_cast<const VkMirSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateMirSurfaceKHR( m_instance, reinterpret_cast<const VkMirSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createMirSurfaceKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26776,7 +27076,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Instance::destroySurfaceKHR( SurfaceKHR surface, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroySurfaceKHR( m_instance, static_cast<VkSurfaceKHR>( surface ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroySurfaceKHR( m_instance, static_cast<VkSurfaceKHR>( surface ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -26789,7 +27089,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createViSurfaceNN( const ViSurfaceCreateInfoNN & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateViSurfaceNN( m_instance, reinterpret_cast<const VkViSurfaceCreateInfoNN*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateViSurfaceNN( m_instance, reinterpret_cast<const VkViSurfaceCreateInfoNN*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createViSurfaceNN" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26811,7 +27111,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createWaylandSurfaceKHR( const WaylandSurfaceCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateWaylandSurfaceKHR( m_instance, reinterpret_cast<const VkWaylandSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateWaylandSurfaceKHR( m_instance, reinterpret_cast<const VkWaylandSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createWaylandSurfaceKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26833,7 +27133,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createWin32SurfaceKHR( const Win32SurfaceCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateWin32SurfaceKHR( m_instance, reinterpret_cast<const VkWin32SurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateWin32SurfaceKHR( m_instance, reinterpret_cast<const VkWin32SurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createWin32SurfaceKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26855,7 +27155,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createXlibSurfaceKHR( const XlibSurfaceCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateXlibSurfaceKHR( m_instance, reinterpret_cast<const VkXlibSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateXlibSurfaceKHR( m_instance, reinterpret_cast<const VkXlibSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createXlibSurfaceKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26877,7 +27177,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createXcbSurfaceKHR( const XcbSurfaceCreateInfoKHR & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateXcbSurfaceKHR( m_instance, reinterpret_cast<const VkXcbSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateXcbSurfaceKHR( m_instance, reinterpret_cast<const VkXcbSurfaceCreateInfoKHR*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createXcbSurfaceKHR" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26898,7 +27198,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<DebugReportCallbackEXT>::type Instance::createDebugReportCallbackEXT( const DebugReportCallbackCreateInfoEXT & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     DebugReportCallbackEXT callback;
-    Result result = static_cast<Result>( vkCreateDebugReportCallbackEXT( m_instance, reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkDebugReportCallbackEXT*>( &callback ) ) );
+    Result result = static_cast<Result>( vkCreateDebugReportCallbackEXT( m_instance, reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkDebugReportCallbackEXT*>( &callback ) ) );
     return createResultValue( result, callback, "vk::Instance::createDebugReportCallbackEXT" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26917,7 +27217,7 @@ namespace vk
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   VULKAN_HPP_INLINE void Instance::destroyDebugReportCallbackEXT( DebugReportCallbackEXT callback, Optional<const AllocationCallbacks> allocator ) const
   {
-    vkDestroyDebugReportCallbackEXT( m_instance, static_cast<VkDebugReportCallbackEXT>( callback ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)) );
+    vkDestroyDebugReportCallbackEXT( m_instance, static_cast<VkDebugReportCallbackEXT>( callback ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ) );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
@@ -26975,7 +27275,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createIOSSurfaceMVK( const IOSSurfaceCreateInfoMVK & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateIOSSurfaceMVK( m_instance, reinterpret_cast<const VkIOSSurfaceCreateInfoMVK*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateIOSSurfaceMVK( m_instance, reinterpret_cast<const VkIOSSurfaceCreateInfoMVK*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createIOSSurfaceMVK" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -26997,7 +27297,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<SurfaceKHR>::type Instance::createMacOSSurfaceMVK( const MacOSSurfaceCreateInfoMVK & createInfo, Optional<const AllocationCallbacks> allocator ) const
   {
     SurfaceKHR surface;
-    Result result = static_cast<Result>( vkCreateMacOSSurfaceMVK( m_instance, reinterpret_cast<const VkMacOSSurfaceCreateInfoMVK*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
+    Result result = static_cast<Result>( vkCreateMacOSSurfaceMVK( m_instance, reinterpret_cast<const VkMacOSSurfaceCreateInfoMVK*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkSurfaceKHR*>( &surface ) ) );
     return createResultValue( result, surface, "vk::Instance::createMacOSSurfaceMVK" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -27009,6 +27309,7 @@ namespace vk
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 #endif /*VK_USE_PLATFORM_MACOS_MVK*/
+
   struct DeviceGroupDeviceCreateInfoKHX
   {
     DeviceGroupDeviceCreateInfoKHX( uint32_t physicalDeviceCount_ = 0, const PhysicalDevice* pPhysicalDevices_ = nullptr )
@@ -27115,7 +27416,7 @@ namespace vk
   VULKAN_HPP_INLINE ResultValueType<Instance>::type createInstance( const InstanceCreateInfo & createInfo, Optional<const AllocationCallbacks> allocator )
   {
     Instance instance;
-    Result result = static_cast<Result>( vkCreateInstance( reinterpret_cast<const VkInstanceCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkInstance*>( &instance ) ) );
+    Result result = static_cast<Result>( vkCreateInstance( reinterpret_cast<const VkInstanceCreateInfo*>( &createInfo ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator ) ), reinterpret_cast<VkInstance*>( &instance ) ) );
     return createResultValue( result, instance, "vk::createInstance" );
   }
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
@@ -27126,6 +27427,7 @@ namespace vk
   }
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
+
 
   VULKAN_HPP_INLINE std::string to_string(FramebufferCreateFlagBits)
   {
@@ -28339,10 +28641,12 @@ namespace vk
     case StructureType::eDeviceEventInfoEXT: return "DeviceEventInfoEXT";
     case StructureType::eDisplayEventInfoEXT: return "DisplayEventInfoEXT";
     case StructureType::eSwapchainCounterCreateInfoEXT: return "SwapchainCounterCreateInfoEXT";
+    case StructureType::ePresentTimesInfoGOOGLE: return "PresentTimesInfoGOOGLE";
     case StructureType::ePhysicalDeviceMultiviewPerViewAttributesPropertiesNVX: return "PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX";
     case StructureType::ePipelineViewportSwizzleStateCreateInfoNV: return "PipelineViewportSwizzleStateCreateInfoNV";
     case StructureType::ePhysicalDeviceDiscardRectanglePropertiesEXT: return "PhysicalDeviceDiscardRectanglePropertiesEXT";
     case StructureType::ePipelineDiscardRectangleStateCreateInfoEXT: return "PipelineDiscardRectangleStateCreateInfoEXT";
+    case StructureType::eHdrMetadataEXT: return "HdrMetadataEXT";
     case StructureType::eIosSurfaceCreateInfoMVK: return "IosSurfaceCreateInfoMVK";
     case StructureType::eMacosSurfaceCreateInfoMVK: return "MacosSurfaceCreateInfoMVK";
     default: return "invalid";

--- a/layers/linux/VkLayer_core_validation.json
+++ b/layers/linux/VkLayer_core_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_core_validation",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_core_validation.so",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_object_tracker.json
+++ b/layers/linux/VkLayer_object_tracker.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_object_tracker",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_object_tracker.so",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_parameter_validation.json
+++ b/layers/linux/VkLayer_parameter_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_parameter_validation",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_parameter_validation.so",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_swapchain.json
+++ b/layers/linux/VkLayer_swapchain.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_swapchain",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_swapchain.so",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_threading.json
+++ b/layers/linux/VkLayer_threading.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_threading",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_threading.so",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "Google Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_unique_objects.json
+++ b/layers/linux/VkLayer_unique_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_unique_objects",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_unique_objects.so",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "Google Validation Layer"
     }

--- a/layers/object_tracker.cpp
+++ b/layers/object_tracker.cpp
@@ -4498,38 +4498,6 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferPropertiesKHX(
     }
 }
 
-VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHX(VkPhysicalDevice physicalDevice,
-                                                           VkPhysicalDeviceProperties2KHX *pProperties) {
-    bool skip = false;
-    {
-        std::unique_lock<std::mutex> lock(global_lock);
-        skip |= ValidateObject(physicalDevice, physicalDevice, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, false,
-                               VALIDATION_ERROR_UNDEFINED, VALIDATION_ERROR_UNDEFINED);
-    }
-    if (!skip) {
-        get_dispatch_table(ot_instance_table_map, physicalDevice)->GetPhysicalDeviceProperties2KHX(physicalDevice, pProperties);
-    }
-}
-
-VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHX(
-    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2KHX *pImageFormatInfo,
-    VkImageFormatProperties2KHX *pImageFormatProperties) {
-    VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
-    bool skip = false;
-    {
-        std::unique_lock<std::mutex> lock(global_lock);
-        skip |= ValidateObject(physicalDevice, physicalDevice, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, false,
-                               VALIDATION_ERROR_UNDEFINED, VALIDATION_ERROR_UNDEFINED);
-    }
-    if (skip) {
-        return VK_ERROR_VALIDATION_FAILED_EXT;
-    }
-    result = get_dispatch_table(ot_instance_table_map, physicalDevice)
-                 ->GetPhysicalDeviceImageFormatProperties2KHX(physicalDevice, pImageFormatInfo, pImageFormatProperties);
-
-    return result;
-}
-
 // VK_KHX_external_memory_fd Extension
 VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHX(VkDevice device, VkDeviceMemory memory,
                                               VkExternalMemoryHandleTypeFlagBitsKHX handleType, int *pFd) {
@@ -5364,9 +5332,6 @@ static inline PFN_vkVoidFunction InterceptInstanceExtensionCommand(const char *n
     // VK_KHX_external_memory_capabilities Extension
     if (!strcmp(name, "GetPhysicalDeviceExternalBufferPropertiesKHX"))
         return (PFN_vkVoidFunction)GetPhysicalDeviceExternalBufferPropertiesKHX;
-    if (!strcmp(name, "GetPhysicalDeviceProperties2KHX")) return (PFN_vkVoidFunction)GetPhysicalDeviceProperties2KHX;
-    if (!strcmp(name, "GetPhysicalDeviceImageFormatProperties2KHX"))
-        return (PFN_vkVoidFunction)GetPhysicalDeviceImageFormatProperties2KHX;
     // VK_KHX_external_semaphore_capabilities Extension
     if (!strcmp(name, "GetPhysicalDeviceExternalSemaphorePropertiesKHX"))
         return (PFN_vkVoidFunction)GetPhysicalDeviceExternalSemaphorePropertiesKHX;

--- a/layers/object_tracker.cpp
+++ b/layers/object_tracker.cpp
@@ -5146,6 +5146,64 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceGeneratedCommandsPropertiesNVX(VkPhy
     }
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL GetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain,
+                                                               uint32_t *pPresentationTimingCount,
+                                                               VkPastPresentationTimingGOOGLE *pPresentationTimings) {
+    VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
+    bool skip = false;
+    {
+        std::unique_lock<std::mutex> lock(global_lock);
+        skip |= ValidateObject(device, device, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, false, VALIDATION_ERROR_UNDEFINED,
+                               VALIDATION_ERROR_UNDEFINED);
+        skip |= ValidateObject(device, swapchain, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, false, VALIDATION_ERROR_UNDEFINED,
+                               VALIDATION_ERROR_UNDEFINED);
+    }
+
+    if (!skip) {
+        result = get_dispatch_table(ot_device_table_map, device)
+                     ->GetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings);
+    }
+    return result;
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL GetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain,
+                                                             VkRefreshCycleDurationGOOGLE *pDisplayTimingProperties) {
+    VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
+    bool skip = false;
+    {
+        std::unique_lock<std::mutex> lock(global_lock);
+        skip |= ValidateObject(device, device, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, false, VALIDATION_ERROR_UNDEFINED,
+                               VALIDATION_ERROR_UNDEFINED);
+        skip |= ValidateObject(device, swapchain, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, false, VALIDATION_ERROR_UNDEFINED,
+                               VALIDATION_ERROR_UNDEFINED);
+    }
+
+    if (!skip) {
+        result = get_dispatch_table(ot_device_table_map, device)
+                     ->GetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties);
+    }
+    return result;
+}
+
+VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR *pSwapchains,
+                                             const VkHdrMetadataEXT *pMetadata) {
+    bool skip = false;
+    {
+        std::lock_guard<std::mutex> lock(global_lock);
+        if (pSwapchains) {
+            for (uint32_t idx0 = 0; idx0 < swapchainCount; ++idx0) {
+                skip |= ValidateObject(device, pSwapchains[idx0], VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, false,
+                                       VALIDATION_ERROR_UNDEFINED, VALIDATION_ERROR_UNDEFINED);
+            }
+        }
+        skip |= ValidateObject(device, device, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, false, VALIDATION_ERROR_UNDEFINED,
+                               VALIDATION_ERROR_UNDEFINED);
+    }
+    if (!skip) {
+        get_dispatch_table(ot_device_table_map, device)->SetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata);
+    }
+}
+
 static inline PFN_vkVoidFunction InterceptCoreDeviceCommand(const char *name) {
     if (!name || name[0] != 'v' || name[1] != 'k') return NULL;
 
@@ -5281,6 +5339,9 @@ static inline PFN_vkVoidFunction InterceptCoreDeviceCommand(const char *name) {
 #endif  // VK_USE_PLATFORM_WIN32_KHR
     if (!strcmp(name, "CmdDrawIndirectCountAMD")) return (PFN_vkVoidFunction)CmdDrawIndirectCountAMD;
     if (!strcmp(name, "CmdDrawIndexedIndirectCountAMD")) return (PFN_vkVoidFunction)CmdDrawIndexedIndirectCountAMD;
+    if (!strcmp(name, "GetPastPresentationTimingGOOGLE")) return (PFN_vkVoidFunction)GetPastPresentationTimingGOOGLE;
+    if (!strcmp(name, "GetRefreshCycleDurationGOOGLE")) return (PFN_vkVoidFunction)GetRefreshCycleDurationGOOGLE;
+    if (!strcmp(name, "SetHdrMetadataEXT")) return (PFN_vkVoidFunction)SetHdrMetadataEXT;
 
     return NULL;
 }

--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -6921,6 +6921,46 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceGeneratedCommandsPropertiesNVX(VkPhy
     }
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL GetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR swapchain,
+                                                               uint32_t *pPresentationTimingCount,
+                                                               VkPastPresentationTimingGOOGLE *pPresentationTimings) {
+    VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
+    bool skip = false;
+    auto my_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    assert(my_data != NULL);
+    skip |= parameter_validation_vkGetPastPresentationTimingGOOGLE(my_data->report_data, swapchain, pPresentationTimingCount,
+                                                                   pPresentationTimings);
+    if (!skip) {
+        result = my_data->dispatch_table.GetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount,
+                                                                         pPresentationTimings);
+    }
+    return result;
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL GetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain,
+                                                             VkRefreshCycleDurationGOOGLE *pDisplayTimingProperties) {
+    VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
+    bool skip = false;
+    auto my_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    assert(my_data != NULL);
+    skip |= parameter_validation_vkGetRefreshCycleDurationGOOGLE(my_data->report_data, swapchain, pDisplayTimingProperties);
+    if (!skip) {
+        result = my_data->dispatch_table.GetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties);
+    }
+    return result;
+}
+
+VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR *pSwapchains,
+                                             const VkHdrMetadataEXT *pMetadata) {
+    bool skip = false;
+    auto my_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    assert(my_data != NULL);
+    skip |= parameter_validation_vkSetHdrMetadataEXT(my_data->report_data, swapchainCount, pSwapchains, pMetadata);
+    if (!skip) {
+        my_data->dispatch_table.SetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata);
+    }
+}
+
 static inline PFN_vkVoidFunction layer_intercept_proc(const char *name) {
     for (unsigned int i = 0; i < sizeof(procmap) / sizeof(procmap[0]); i++) {
         if (!strcmp(name, procmap[i].name)) return procmap[i].pFunc;

--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -6228,39 +6228,6 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferPropertiesKHX(
     }
 }
 
-VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHX(VkPhysicalDevice physicalDevice,
-                                                           VkPhysicalDeviceProperties2KHX *pProperties) {
-    auto my_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), instance_layer_data_map);
-    assert(my_data != NULL);
-    bool skip = false;
-    skip |= require_instance_extension(physicalDevice, &instance_extension_enables::khx_external_memory_capabilities_enabled,
-                                       "vkGetPhysicalDeviceProperties2KHX", VK_KHX_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
-    skip |= parameter_validation_vkGetPhysicalDeviceProperties2KHX(my_data->report_data, pProperties);
-    if (!skip) {
-        my_data->dispatch_table.GetPhysicalDeviceProperties2KHX(physicalDevice, pProperties);
-    }
-}
-
-VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHX(
-    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2KHX *pImageFormatInfo,
-    VkImageFormatProperties2KHX *pImageFormatProperties) {
-    VkResult result = VK_ERROR_VALIDATION_FAILED_EXT;
-    auto my_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), instance_layer_data_map);
-    assert(my_data != NULL);
-    bool skip = false;
-    skip |= require_instance_extension(physicalDevice, &instance_extension_enables::khx_external_memory_capabilities_enabled,
-                                       "vkGetPhysicalDeviceImageFormatProperties2KHX",
-                                       VK_KHX_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
-    skip |= parameter_validation_vkGetPhysicalDeviceImageFormatProperties2KHX(my_data->report_data, pImageFormatInfo,
-                                                                              pImageFormatProperties);
-    if (!skip) {
-        result = my_data->dispatch_table.GetPhysicalDeviceImageFormatProperties2KHX(physicalDevice, pImageFormatInfo,
-                                                                                    pImageFormatProperties);
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceImageFormatProperties2KHX", result);
-    }
-    return result;
-}
-
 // Definitions for the VK_KHX_external_memory_fd extension
 
 VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHX(VkDevice device, VkDeviceMemory memory,

--- a/layers/windows/VkLayer_core_validation.json
+++ b/layers/windows/VkLayer_core_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_core_validation",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_core_validation.dll",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_object_tracker.json
+++ b/layers/windows/VkLayer_object_tracker.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_object_tracker",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_object_tracker.dll",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_parameter_validation.json
+++ b/layers/windows/VkLayer_parameter_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_parameter_validation",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_parameter_validation.dll",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_swapchain.json
+++ b/layers/windows/VkLayer_swapchain.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_swapchain",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_swapchain.dll",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_threading.json
+++ b/layers/windows/VkLayer_threading.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_threading",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_threading.dll",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "Google Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_unique_objects.json
+++ b/layers/windows/VkLayer_unique_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_unique_objects",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_unique_objects.dll",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "Google Validation Layer"
     }

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -132,7 +132,7 @@ else()
 
     add_library(${API_LOWERCASE} SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS})
     add_dependencies(${API_LOWERCASE} generate_helper_files loader_gen_files)
-    set_target_properties(${API_LOWERCASE} PROPERTIES SOVERSION "1" VERSION "1.0.42")
+    set_target_properties(${API_LOWERCASE} PROPERTIES SOVERSION "1" VERSION "1.0.43")
     target_link_libraries(${API_LOWERCASE} -ldl -lpthread -lm)
 
     install(TARGETS ${API_LOWERCASE} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/scripts/cgenerator.py
+++ b/scripts/cgenerator.py
@@ -268,7 +268,7 @@ class COutputGenerator(OutputGenerator):
         OutputGenerator.genGroup(self, groupinfo, groupName)
         groupElem = groupinfo.elem
 
-        expandName = re.sub(r'([0-9a-z_])([A-Z0-9][^A-Z0-9]?)',r'\1_\2',groupName).upper()
+        expandName = re.sub(r'([0-9a-z_])([A-Z0-9])',r'\1_\2',groupName).upper()
 
         expandPrefix = expandName
         expandSuffix = ''

--- a/scripts/vk.xml
+++ b/scripts/vk.xml
@@ -112,7 +112,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type category="define">// Vulkan 1.0 version number
 #define <name>VK_API_VERSION_1_0</name> <type>VK_MAKE_VERSION</type>(1, 0, 0)</type>    <!-- The patch version here should never be set to anything other than 0 -->
         <type category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 42</type>
+#define <name>VK_HEADER_VERSION</name> 43</type>
 
         <type category="define">
 #define <name>VK_DEFINE_HANDLE</name>(object) typedef struct object##_T* object;</type>
@@ -1474,7 +1474,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkDisplayPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
+            <member validextensionstructs="VkPresentTimesInfoGOOGLE">const <type>void</type>*  <name>pNext</name></member> <!-- Pointer to next structure -->
             <member><type>VkRect2D</type>                         <name>srcRect</name></member>                  <!-- Rectangle within the presentable image to read pixel data from when presenting to the display. -->
             <member><type>VkRect2D</type>                         <name>dstRect</name></member>                  <!-- Rectangle within the current display mode's visible region to display srcRectangle in. -->
             <member><type>VkBool32</type>                         <name>persistent</name></member>               <!-- For smart displays, use buffered mode.  If the display properties member "persistentMode" is VK_FALSE, this member must always be VK_FALSE. -->
@@ -1564,7 +1564,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member validextensionstructs="VkDeviceGroupPresentInfoKHX">const <type>void</type>*  <name>pNext</name></member> <!-- Pointer to next structure -->
+            <member validextensionstructs="VkDisplayPresentInfoKHR,VkDeviceGroupPresentInfoKHX,VkPresentTimesInfoGOOGLE">const <type>void</type>*  <name>pNext</name></member> <!-- Pointer to next structure -->
             <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreCount</name></member>       <!-- Number of semaphores to wait for before presenting -->
             <member optional="true" len="waitSemaphoreCount">const <type>VkSemaphore</type>* <name>pWaitSemaphores</name></member> <!-- Semaphores to wait for before presenting -->
             <member><type>uint32_t</type>                         <name>swapchainCount</name></member>           <!-- Number of swapchains to present in this call -->
@@ -1824,25 +1824,6 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member><type>void</type>*                            <name>pNext</name></member>                    <!-- Pointer to next structure -->
             <member><type>uint32_t</type>                         <name>maxPushDescriptors</name></member>
-        </type>
-        <type category="struct" name="VkPhysicalDeviceProperties2KHX" returnedonly="true">
-            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHX"><type>VkStructureType</type> <name>sType</name></member>
-            <member validextensionstructs="VkPhysicalDeviceIDPropertiesKHX"><type>void</type>*                            <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkPhysicalDeviceProperties</type>       <name>properties</name></member>
-        </type>
-        <type category="struct" name="VkImageFormatProperties2KHX" returnedonly="true">
-            <member values="VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHX"><type>VkStructureType</type> <name>sType</name></member>
-            <member validextensionstructs="VkExternalImageFormatPropertiesKHX"><type>void</type>* <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkImageFormatProperties</type>          <name>imageFormatProperties</name></member>
-        </type>
-        <type category="struct" name="VkPhysicalDeviceImageFormatInfo2KHX">
-            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHX"><type>VkStructureType</type> <name>sType</name></member>
-            <member validextensionstructs="VkPhysicalDeviceExternalImageFormatInfoKHX">const <type>void</type>* <name>pNext</name></member>                    <!-- Pointer to next structure -->
-            <member><type>VkFormat</type>                         <name>format</name></member>
-            <member><type>VkImageType</type>                      <name>type</name></member>
-            <member><type>VkImageTiling</type>                    <name>tiling</name></member>
-            <member><type>VkImageUsageFlags</type>                <name>usage</name></member>
-            <member optional="true"><type>VkImageCreateFlags</type> <name>flags</name></member>
         </type>
         <type category="struct" name="VkExternalMemoryPropertiesKHX" returnedonly="true">
             <member><type>VkExternalMemoryFeatureFlagsKHX</type>  <name>externalMemoryFeatures</name></member>
@@ -2168,14 +2149,40 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member><type>float</type>   <name>x</name></member>
             <member><type>float</type>   <name>y</name></member>
         </type>
-        <type category="struct" name="VkSMPTE2086MetadataEXT">
+        <type category="struct" name="VkHdrMetadataEXT">
             <!-- Display primary in chromaticity coordinates -->
-            <member><type>VkXYColorEXT</type>   <name>displayPrimaryRed</name></member>           <!-- Display primary's Red -->
-            <member><type>VkXYColorEXT</type>   <name>displayPrimaryGreen</name></member>         <!-- Display primary's Green -->
-            <member><type>VkXYColorEXT</type>   <name>displayPrimaryBlue</name></member>          <!-- Display primary's Blue -->
+            <member values="VK_STRUCTURE_TYPE_HDR_METADATA_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*    <name>pNext</name></member>
+            <!-- From SMPTE 2086 -->
+            <member><type>VkXYColorEXT</type>   <name>displayPrimaryRed</name></member>   <!-- Display primary's Red -->
+            <member><type>VkXYColorEXT</type>   <name>displayPrimaryGreen</name></member> <!-- Display primary's Green -->
+            <member><type>VkXYColorEXT</type>   <name>displayPrimaryBlue</name></member>  <!-- Display primary's Blue -->
             <member><type>VkXYColorEXT</type>   <name>whitePoint</name></member>          <!-- Display primary's Blue -->
-            <member><type>float</type>   <name>maxLuminance</name></member>          <!-- Display maximum luminance -->
-            <member><type>float</type>   <name>minLuminance</name></member>          <!-- Display minimum luminance -->
+            <member><type>float</type>          <name>maxLuminance</name></member>        <!-- Display maximum luminance -->
+            <member><type>float</type>          <name>minLuminance</name></member>        <!-- Display minimum luminance -->
+            <!-- From CTA 861.3 -->
+            <member><type>float</type>          <name>maxContentLightLevel</name></member><!-- Content maximum luminance -->
+            <member><type>float</type>          <name>maxFrameAverageLightLevel</name></member>
+        </type>
+        <type category="struct" name="VkRefreshCycleDurationGOOGLE">
+            <member><type>uint64_t</type>                         <name>refreshDuration</name></member>          <!-- Number of nanoseconds from the start of one refresh cycle to the next -->
+        </type>
+        <type category="struct" name="VkPastPresentationTimingGOOGLE">
+            <member><type>uint32_t</type>                         <name>presentID</name></member>                <!-- Application-provided identifier, previously given to vkQueuePresentKHR -->
+            <member><type>uint64_t</type>                         <name>desiredPresentTime</name></member>       <!-- Earliest time an image should have been presented, previously given to vkQueuePresentKHR -->
+            <member><type>uint64_t</type>                         <name>actualPresentTime</name></member>        <!-- Time the image was actually displayed -->
+            <member><type>uint64_t</type>                         <name>earliestPresentTime</name></member>      <!-- Earliest time the image could have been displayed -->
+            <member><type>uint64_t</type>                         <name>presentMargin</name></member>            <!-- How early vkQueuePresentKHR was processed vs. how soon it needed to be and make earliestPresentTime -->
+        </type>
+        <type category="struct" name="VkPresentTimesInfoGOOGLE">
+            <member values="VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE"><type>VkStructureType</type> <name>sType</name></member>
+            <member validextensionstructs="VkDisplayPresentInfoKHR">const <type>void</type>*  <name>pNext</name></member> <!-- Pointer to next structure -->
+            <member><type>uint32_t</type>                         <name>swapchainCount</name></member>           <!-- Copy of VkPresentInfoKHR::swapchainCount -->
+            <member len="swapchainCount" optional="true">const <type>VkPresentTimeGOOGLE</type>*   <name>pTimes</name></member> <!-- The earliest times to present images -->
+        </type>
+        <type category="struct" name="VkPresentTimeGOOGLE">
+            <member><type>uint32_t</type>                         <name>presentID</name></member>                <!-- Application-provided identifier -->
+            <member><type>uint64_t</type>                         <name>desiredPresentTime</name></member>       <!-- Earliest time an image should be presented -->
         </type>
         <type category="struct" name="VkIOSSurfaceCreateInfoMVK">
             <member values="VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK"><type>VkStructureType</type> <name>sType</name></member>
@@ -4519,17 +4526,6 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
              <param optional="true"><type>VkCommandPoolTrimFlagsKHR</type> <name>flags</name></param>
         </command>
         <command>
-            <proto><type>void</type> <name>vkGetPhysicalDeviceProperties2KHX</name></proto>
-            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
-            <param><type>VkPhysicalDeviceProperties2KHX</type>* <name>pProperties</name></param>
-        </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED">
-            <proto><type>VkResult</type> <name>vkGetPhysicalDeviceImageFormatProperties2KHX</name></proto>
-            <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
-            <param>const <type>VkPhysicalDeviceImageFormatInfo2KHX</type>* <name>pImageFormatInfo</name></param>
-            <param><type>VkImageFormatProperties2KHX</type>* <name>pImageFormatProperties</name></param>
-        </command>
-        <command>
             <proto><type>void</type> <name>vkGetPhysicalDeviceExternalBufferPropertiesKHX</name></proto>
             <param><type>VkPhysicalDevice</type> <name>physicalDevice</name></param>
             <param>const <type>VkPhysicalDeviceExternalBufferInfoKHX</type>* <name>pExternalBufferInfo</name></param>
@@ -4739,11 +4735,24 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <param>const <type>void</type>* <name>pData</name></param>
         </command>
         <command>
-            <proto><type>void</type> <name>vkSetSMPTE2086MetadataEXT</name></proto>
+            <proto><type>void</type> <name>vkSetHdrMetadataEXT</name></proto>
             <param><type>VkDevice</type> <name>device</name></param>
             <param><type>uint32_t</type> <name>swapchainCount</name></param>    <!-- Number of swap chains to update in this call -->
             <param len="swapchainCount">const <type>VkSwapchainKHR</type>* <name>pSwapchains</name></param>    <!-- Swapchains to present an image from -->
-            <param len="swapchainCount">const <type>VkSMPTE2086MetadataEXT</type>* <name>pMetadata</name></param>
+            <param len="swapchainCount">const <type>VkHdrMetadataEXT</type>* <name>pMetadata</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkGetRefreshCycleDurationGOOGLE</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+            <param><type>VkRefreshCycleDurationGOOGLE</type>* <name>pDisplayTimingProperties</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR">
+            <proto><type>VkResult</type> <name>vkGetPastPresentationTimingGOOGLE</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkSwapchainKHR</type> <name>swapchain</name></param>
+            <param optional="false,true"><type>uint32_t</type>* <name>pPresentationTimingCount</name></param>
+            <param optional="true" len="pPresentationTimingCount"><type>VkPastPresentationTimingGOOGLE</type>* <name>pPresentationTimings</name></param>
         </command>
         <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR">
             <proto><type>VkResult</type> <name>vkCreateIOSSurfaceMVK</name></proto>
@@ -5095,7 +5104,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </extension>
         <extension name="VK_KHR_wayland_surface" number="7" type="instance" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_WAYLAND_KHR" supported="vulkan">
             <require>
-                <enum value="5"                                         name="VK_KHR_WAYLAND_SURFACE_SPEC_VERSION"/>
+                <enum value="6"                                         name="VK_KHR_WAYLAND_SURFACE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_wayland_surface&quot;"        name="VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR"/>
                 <type name="VkWaylandSurfaceCreateFlagsKHR"/>
@@ -5221,7 +5230,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </extension>
         <extension name="VK_AMD_shader_explicit_vertex_parameter" number="22" type="device" author="AMD" contact="quentin.lin@amd.com" supported="vulkan">
             <require>
-                <enum value="1"                                                   name="VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_SPEC_VERSION"/>
+                <enum value="1"                                         name="VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_SPEC_VERSION"/>
                 <enum value="&quot;VK_AMD_shader_explicit_vertex_parameter&quot;" name="VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_EXTENSION_NAME"/>
             </require>
         </extension>
@@ -5257,14 +5266,14 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </extension>
         <extension name="VK_AMD_gcn_shader" number="26" type="device" author="AMD" contact="dominik.witczak@amd.com" supported="vulkan">
             <require>
-                <enum value="1"                                        name="VK_AMD_GCN_SHADER_SPEC_VERSION"/>
-                <enum value="&quot;VK_AMD_gcn_shader&quot;"            name="VK_AMD_GCN_SHADER_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_AMD_GCN_SHADER_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_gcn_shader&quot;"             name="VK_AMD_GCN_SHADER_EXTENSION_NAME"/>
             </require>
         </extension>
         <extension name="VK_NV_dedicated_allocation" number="27" type="device" author="NVIDIA" contact="Jeff Bolz @jbolz" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_NV_DEDICATED_ALLOCATION_SPEC_VERSION"/>
-                <enum value="&quot;VK_NV_dedicated_allocation&quot;" name="VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME"/>
+                <enum value="&quot;VK_NV_dedicated_allocation&quot;"    name="VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV"/>
                 <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV"/>
                 <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV"/>
@@ -5501,17 +5510,17 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </extension>
         <extension name="VK_KHR_get_physical_device_properties2" number="60" type="instance" author="KHR" contact="Jeff Bolz @jbolz" supported="vulkan">
             <require>
-                <enum value="1"                                           name="VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION"/>
+                <enum value="1"                                         name="VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_get_physical_device_properties2&quot;" name="VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR"/>
-                <enum offset="1" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR"/>
-                <enum offset="2" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR"/>
-                <enum offset="3" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHR"/>
-                <enum offset="4" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHR"/>
-                <enum offset="5" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR"/>
-                <enum offset="6" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR"/>
-                <enum offset="7" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2_KHR"/>
-                <enum offset="8" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2_KHR"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2_KHR"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHR"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHR"/>
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR"/>
+                <enum offset="6" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2_KHR"/>
+                <enum offset="7" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2_KHR"/>
+                <enum offset="8" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2_KHR"/>
                 <type name="VkPhysicalDeviceFeatures2KHR"/>
                 <type name="VkPhysicalDeviceProperties2KHR"/>
                 <type name="VkFormatProperties2KHR"/>
@@ -5585,7 +5594,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <extension name="VK_EXT_validation_flags" number="62" type="instance" author="Google, Inc." contact="Tobin Ehlis @tobine" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_EXT_VALIDATION_FLAGS_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_validation_flags&quot;"           name="VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME"/>
+                <enum value="&quot;VK_EXT_validation_flags&quot;"       name="VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT"/>
                 <type name="VkValidationFlagsEXT"/>
             </require>
@@ -5657,7 +5666,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <type name="VkPhysicalDeviceGroupPropertiesKHX"/>
                 <type name="VkDeviceGroupDeviceCreateInfoKHX"/>
                 <command name="vkEnumeratePhysicalDeviceGroupsKHX"/>
-                <enum bitpos="1" extends="VkMemoryHeapFlagBits"   name="VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHX"    comment="If set, heap allocations allocate multiple instances by default"/>
+                <enum bitpos="1" extends="VkMemoryHeapFlagBits"         name="VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHX" comment="If set, heap allocations allocate multiple instances by default"/>
             </require>
         </extension>
         <extension name="VK_KHX_external_memory_capabilities" number="72" type="instance" author="KHX" requires="VK_KHR_get_physical_device_properties2" contact="James Jones @cubanismo" supported="vulkan">
@@ -5670,8 +5679,8 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHX"/>
                 <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES_KHX"/>
                 <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHX"/> <!-- KHX-only.  Remove for KHR -->
-                <enum offset="6" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHX"/> <!-- KHX-only.  Remove for KHR -->
-                <enum offset="7" extends="VkStructureType"                name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHX"/> <!-- KHX-only.  Remove for KHR -->
+                <enum offset="6" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHX"/> <!-- KHX-only.  Remove for KHR -->
+                <enum offset="7" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2_KHX"/> <!-- KHX-only.  Remove for KHR -->
                 <enum name="VK_LUID_SIZE_KHX"/>
                 <type name="VkExternalMemoryHandleTypeFlagsKHX"/>
                 <type name="VkExternalMemoryHandleTypeFlagBitsKHX"/>
@@ -5683,12 +5692,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <type name="VkPhysicalDeviceExternalBufferInfoKHX"/>
                 <type name="VkExternalBufferPropertiesKHX"/>
                 <type name="VkPhysicalDeviceIDPropertiesKHX"/>
-                <type name="VkPhysicalDeviceProperties2KHX"/> <!-- KHX-only.  Remove for KHR -->
-                <type name="VkImageFormatProperties2KHX"/> <!-- KHX-only.  Remove for KHR -->
-                <type name="VkPhysicalDeviceImageFormatInfo2KHX"/> <!-- KHX-only.  Remove for KHR -->
                 <command name="vkGetPhysicalDeviceExternalBufferPropertiesKHX"/>
-                <command name="vkGetPhysicalDeviceProperties2KHX"/> <!-- KHX-only.  Remove for KHR -->
-                <command name="vkGetPhysicalDeviceImageFormatProperties2KHX"/> <!-- KHX-only.  Remove for KHR -->
             </require>
         </extension>
         <extension name="VK_KHX_external_memory" number="73" type="device" requires="VK_KHX_external_memory_capabilities" author="KHX" contact="James Jones @cubanismo" supported="vulkan">
@@ -5753,9 +5757,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <type name="VkPhysicalDeviceExternalSemaphoreInfoKHX"/>
                 <type name="VkExternalSemaphorePropertiesKHX"/>
                 <type name="VkPhysicalDeviceIDPropertiesKHX"/>
-                <type name="VkPhysicalDeviceProperties2KHX"/> <!-- KHX-only.  Remove for KHR -->
                 <command name="vkGetPhysicalDeviceExternalSemaphorePropertiesKHX"/>
-                <command name="vkGetPhysicalDeviceProperties2KHX"/> <!-- KHX-only.  Remove for KHR -->
             </require>
         </extension>
         <extension name="VK_KHX_external_semaphore" number="78" type="device" requires="VK_KHX_external_semaphore_capabilities" author="KHX" contact="James Jones @cubanismo" supported="vulkan">
@@ -5807,82 +5809,82 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             </require>
         </extension>
         <extension name="VK_KHR_extension_83" number="83" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_83_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_83&quot;"           name="VK_KHR_EXTENSION_83_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_84" number="84" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_84_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_84&quot;"           name="VK_KHR_EXTENSION_84_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_85" number="85" author="KHR" contact="Ian Elliott @ianelliott" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_85_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_85&quot;"           name="VK_KHR_EXTENSION_85_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_descriptor_update_template" number="86" type="device" author="KHR" contact="Markus Tavenrath @mtavenrath" supported="vulkan">
-              <require>
-                 <enum value="1"                                             name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_descriptor_update_template&quot;" name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME"/>
-                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR"/>
-                 <command name="vkCreateDescriptorUpdateTemplateKHR"/>
-                 <command name="vkDestroyDescriptorUpdateTemplateKHR"/>
-                 <command name="vkUpdateDescriptorSetWithTemplateKHR"/>
-                 <command name="vkCmdPushDescriptorSetWithTemplateKHR"/>
-                 <type name="VkDescriptorUpdateTemplateCreateFlagsKHR"/>
-                 <type name="VkDescriptorUpdateTemplateTypeKHR"/>
-                 <type name="VkDescriptorUpdateTemplateEntryKHR"/>
-                 <type name="VkDescriptorUpdateTemplateCreateInfoKHR"/>
-              </require>
-         </extension>
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_83_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_83&quot;"           name="VK_KHR_EXTENSION_83_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_84" number="84" author="KHR" contact="Jan-Harald Fredriksen @janharald" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_84_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_84&quot;"           name="VK_KHR_EXTENSION_84_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_85" number="85" author="KHR" contact="Ian Elliott @ianelliott" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_85_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_85&quot;"           name="VK_KHR_EXTENSION_85_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_descriptor_update_template" number="86" type="device" author="KHR" contact="Markus Tavenrath @mtavenrath" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_descriptor_update_template&quot;" name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR"/>
+                <command name="vkCreateDescriptorUpdateTemplateKHR"/>
+                <command name="vkDestroyDescriptorUpdateTemplateKHR"/>
+                <command name="vkUpdateDescriptorSetWithTemplateKHR"/>
+                <command name="vkCmdPushDescriptorSetWithTemplateKHR"/>
+                <type name="VkDescriptorUpdateTemplateCreateFlagsKHR"/>
+                <type name="VkDescriptorUpdateTemplateTypeKHR"/>
+                <type name="VkDescriptorUpdateTemplateEntryKHR"/>
+                <type name="VkDescriptorUpdateTemplateCreateInfoKHR"/>
+            </require>
+        </extension>
         <extension name="VK_NVX_device_generated_commands" number="87" type="device" author="NVIDIA" contact="Christoph Kubisch @pixeljetstream" supported="vulkan">
-          <require>
-              <enum value="1"                                               name="VK_NVX_DEVICE_GENERATED_COMMANDS_SPEC_VERSION"/>
-              <enum value="&quot;VK_NVX_device_generated_commands&quot;"    name="VK_NVX_DEVICE_GENERATED_COMMANDS_EXTENSION_NAME"/>
-              <enum offset="0" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_OBJECT_TABLE_CREATE_INFO_NVX"/>
-              <enum offset="1" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX"/>
-              <enum offset="2" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_CMD_PROCESS_COMMANDS_INFO_NVX"/>
-              <enum offset="3" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_CMD_RESERVE_SPACE_FOR_COMMANDS_INFO_NVX"/>
-              <enum offset="4" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_LIMITS_NVX"/>
-              <enum offset="5" extends="VkStructureType"                    name="VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_FEATURES_NVX"/>
-              <enum bitpos="17" extends="VkPipelineStageFlagBits"           name="VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX"/>
-              <enum bitpos="17" extends="VkAccessFlagBits"                  name="VK_ACCESS_COMMAND_PROCESS_READ_BIT_NVX"/>
-              <enum bitpos="18" extends="VkAccessFlagBits"                  name="VK_ACCESS_COMMAND_PROCESS_WRITE_BIT_NVX"/>
-              <type name="VkObjectTableNVX"/>
-              <type name="VkIndirectCommandsLayoutNVX"/>
-              <type name="VkIndirectCommandsLayoutUsageFlagsNVX"/>
-              <type name="VkObjectEntryUsageFlagsNVX"/>
-              <type name="VkIndirectCommandsLayoutUsageFlagBitsNVX"/>
-              <type name="VkIndirectCommandsTokenTypeNVX"/>
-              <type name="VkObjectEntryUsageFlagBitsNVX"/>
-              <type name="VkObjectEntryTypeNVX"/>
-              <type name="VkDeviceGeneratedCommandsFeaturesNVX"/>
-              <type name="VkDeviceGeneratedCommandsLimitsNVX"/>
-              <type name="VkIndirectCommandsTokenNVX"/>
-              <type name="VkIndirectCommandsLayoutTokenNVX"/>
-              <type name="VkIndirectCommandsLayoutCreateInfoNVX"/>
-              <type name="VkCmdProcessCommandsInfoNVX"/>
-              <type name="VkCmdReserveSpaceForCommandsInfoNVX"/>
-              <type name="VkObjectTableCreateInfoNVX"/>
-              <type name="VkObjectTableEntryNVX"/>
-              <type name="VkObjectTablePipelineEntryNVX"/>
-              <type name="VkObjectTableDescriptorSetEntryNVX"/>
-              <type name="VkObjectTableVertexBufferEntryNVX"/>
-              <type name="VkObjectTableIndexBufferEntryNVX"/>
-              <type name="VkObjectTablePushConstantEntryNVX"/>
-              <command name="vkCmdProcessCommandsNVX"/>
-              <command name="vkCmdReserveSpaceForCommandsNVX"/>
-              <command name="vkCreateIndirectCommandsLayoutNVX"/>
-              <command name="vkDestroyIndirectCommandsLayoutNVX"/>
-              <command name="vkCreateObjectTableNVX"/>
-              <command name="vkDestroyObjectTableNVX"/>
-              <command name="vkRegisterObjectsNVX"/>
-              <command name="vkUnregisterObjectsNVX"/>
-              <command name="vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX"/>
+            <require>
+                <enum value="1"                                         name="VK_NVX_DEVICE_GENERATED_COMMANDS_SPEC_VERSION"/>
+                <enum value="&quot;VK_NVX_device_generated_commands&quot;"    name="VK_NVX_DEVICE_GENERATED_COMMANDS_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_OBJECT_TABLE_CREATE_INFO_NVX"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_CMD_PROCESS_COMMANDS_INFO_NVX"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_CMD_RESERVE_SPACE_FOR_COMMANDS_INFO_NVX"/>
+                <enum offset="4" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_LIMITS_NVX"/>
+                <enum offset="5" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_FEATURES_NVX"/>
+                <enum bitpos="17" extends="VkPipelineStageFlagBits"     name="VK_PIPELINE_STAGE_COMMAND_PROCESS_BIT_NVX"/>
+                <enum bitpos="17" extends="VkAccessFlagBits"            name="VK_ACCESS_COMMAND_PROCESS_READ_BIT_NVX"/>
+                <enum bitpos="18" extends="VkAccessFlagBits"            name="VK_ACCESS_COMMAND_PROCESS_WRITE_BIT_NVX"/>
+                <type name="VkObjectTableNVX"/>
+                <type name="VkIndirectCommandsLayoutNVX"/>
+                <type name="VkIndirectCommandsLayoutUsageFlagsNVX"/>
+                <type name="VkObjectEntryUsageFlagsNVX"/>
+                <type name="VkIndirectCommandsLayoutUsageFlagBitsNVX"/>
+                <type name="VkIndirectCommandsTokenTypeNVX"/>
+                <type name="VkObjectEntryUsageFlagBitsNVX"/>
+                <type name="VkObjectEntryTypeNVX"/>
+                <type name="VkDeviceGeneratedCommandsFeaturesNVX"/>
+                <type name="VkDeviceGeneratedCommandsLimitsNVX"/>
+                <type name="VkIndirectCommandsTokenNVX"/>
+                <type name="VkIndirectCommandsLayoutTokenNVX"/>
+                <type name="VkIndirectCommandsLayoutCreateInfoNVX"/>
+                <type name="VkCmdProcessCommandsInfoNVX"/>
+                <type name="VkCmdReserveSpaceForCommandsInfoNVX"/>
+                <type name="VkObjectTableCreateInfoNVX"/>
+                <type name="VkObjectTableEntryNVX"/>
+                <type name="VkObjectTablePipelineEntryNVX"/>
+                <type name="VkObjectTableDescriptorSetEntryNVX"/>
+                <type name="VkObjectTableVertexBufferEntryNVX"/>
+                <type name="VkObjectTableIndexBufferEntryNVX"/>
+                <type name="VkObjectTablePushConstantEntryNVX"/>
+                <command name="vkCmdProcessCommandsNVX"/>
+                <command name="vkCmdReserveSpaceForCommandsNVX"/>
+                <command name="vkCreateIndirectCommandsLayoutNVX"/>
+                <command name="vkDestroyIndirectCommandsLayoutNVX"/>
+                <command name="vkCreateObjectTableNVX"/>
+                <command name="vkDestroyObjectTableNVX"/>
+                <command name="vkRegisterObjectsNVX"/>
+                <command name="vkUnregisterObjectsNVX"/>
+                <command name="vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX"/>
           </require>
         </extension>
         <extension name="VK_NV_clip_space_w_scaling" number="88" type="device" author="NV" contact="Eric Werness @ewerness" supported="vulkan">
@@ -5896,302 +5898,328 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <command name="vkCmdSetViewportWScalingNV"/>
             </require>
         </extension>
-         <extension name="VK_EXT_direct_mode_display" number="89" type="instance" requires="VK_KHR_display" author="NVIDIA" contact="James Jones @cubanismo" supported="vulkan">
-             <require>
-                 <enum value="1"                                         name="VK_EXT_DIRECT_MODE_DISPLAY_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_direct_mode_display&quot;"           name="VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME"/>
-                 <command name="vkReleaseDisplayEXT"/>
-             </require>
-         </extension>
-         <extension name="VK_EXT_acquire_xlib_display" number="90" type="instance" requires="VK_EXT_direct_mode_display,VK_KHR_display" author="NVIDIA" contact="James Jones @cubanismo" protect="VK_USE_PLATFORM_XLIB_XRANDR_EXT" supported="vulkan">
-             <require>
-                 <enum value="1"                                         name="VK_EXT_ACQUIRE_XLIB_DISPLAY_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_acquire_xlib_display&quot;"   name="VK_EXT_ACQUIRE_XLIB_DISPLAY_EXTENSION_NAME"/>
-                 <command name="vkAcquireXlibDisplayEXT"/>
-                 <command name="vkGetRandROutputDisplayEXT"/>
-             </require>
-         </extension>
-         <extension name="VK_EXT_display_surface_counter" number="91" type="instance" requires="VK_KHR_display" author="NVIDIA" contact="James Jones @cubanismo" supported="vulkan">
-             <require>
-                 <enum value="1"                                         name="VK_EXT_DISPLAY_SURFACE_COUNTER_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_display_surface_counter&quot;" name="VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME"/>
-                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES2_EXT"/>
-                 <type name="VkSurfaceCounterFlagsEXT"/>
-                 <type name="VkSurfaceCounterFlagBitsEXT"/>
-                 <type name="VkSurfaceCapabilities2EXT"/>
-                 <command name="vkGetPhysicalDeviceSurfaceCapabilities2EXT"/>
-             </require>
-         </extension>
-         <extension name="VK_EXT_display_control" number="92" type="device" requires="VK_KHR_display,VK_EXT_display_surface_counter,VK_KHR_swapchain" author="NVIDIA" contact="James Jones @cubanismo" supported="vulkan">
-             <require>
-                 <enum value="1"                                         name="VK_EXT_DISPLAY_CONTROL_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_display_control&quot;"        name="VK_EXT_DISPLAY_CONTROL_EXTENSION_NAME"/>
-                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DISPLAY_POWER_INFO_EXT"/>
-                 <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT"/>
-                 <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT"/>
-                 <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT"/>
-                 <type name="VkDisplayPowerStateEXT"/>
-                 <type name="VkDeviceEventTypeEXT"/>
-                 <type name="VkDisplayEventTypeEXT"/>
-                 <type name="VkDisplayPowerInfoEXT"/>
-                 <type name="VkDeviceEventInfoEXT"/>
-                 <type name="VkDisplayEventInfoEXT"/>
-                 <type name="VkSwapchainCounterCreateInfoEXT"/>
-                 <command name="vkDisplayPowerControlEXT"/>
-                 <command name="vkRegisterDeviceEventEXT"/>
-                 <command name="vkRegisterDisplayEventEXT"/>
-                 <command name="vkGetSwapchainCounterEXT"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_93" number="93" author="GOOGLE" contact="Ian Elliott @ianelliott" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_GOOGLE_EXTENSION_93_SPEC_VERSION"/>
-                 <enum value="&quot;VK_GOOGLE_extension_93&quot;"        name="VK_GOOGLE_EXTENSION_93_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_94" number="94" author="Codeplay" contact="Neil Henning @neil_henning" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_94_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_94&quot;"           name="VK_KHR_EXTENSION_94_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_sample_mask_override_coverage" number="95" type="device" author="NVIDIA" contact="Piers Daniell @pdaniell" supported="vulkan">
-             <require>
-                 <enum value="1"                                               name="VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_sample_mask_override_coverage&quot;" name="VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_geometry_shader_passthrough" number="96" type="device" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="vulkan">
-             <require>
-                 <enum value="1"                                             name="VK_NV_GEOMETRY_SHADER_PASSTHROUGH_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_geometry_shader_passthrough&quot;" name="VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_viewport_array2" number="97" type="device" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="vulkan">
-             <require>
-                 <enum value="1"                                         name="VK_NV_VIEWPORT_ARRAY2_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_viewport_array2&quot;"         name="VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NVX_multiview_per_view_attributes" number="98" type="device" author="NVIDIA" contact="Jeff Bolz @jbolz" supported="vulkan">
-             <require>
-                 <enum value="1"                                         name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NVX_multiview_per_view_attributes&quot;"  name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_EXTENSION_NAME"/>
-                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX"/>
-                 <enum bitpos="0" extends="VkSubpassDescriptionFlagBits" name="VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX"/>
-                 <enum bitpos="1" extends="VkSubpassDescriptionFlagBits" name="VK_SUBPASS_DESCRIPTION_PER_VIEW_POSITION_X_ONLY_BIT_NVX"/>
-                 <type name="VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_viewport_swizzle" number="99" type="device" author="NVIDIA" contact="Piers Daniell @pdaniell" supported="vulkan">
-             <require>
-                 <enum value="1"                                         name="VK_NV_VIEWPORT_SWIZZLE_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_viewport_swizzle&quot;"        name="VK_NV_VIEWPORT_SWIZZLE_EXTENSION_NAME"/>
-                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV"/>
-                 <type name="VkViewportSwizzleNV"/>
-                 <type name="VkViewportCoordinateSwizzleNV"/>
-                 <type name="VkPipelineViewportSwizzleStateCreateInfoNV"/>
-                 <type name="VkPipelineViewportSwizzleStateCreateFlagsNV"/>
-             </require>
-         </extension>
-         <extension name="VK_EXT_discard_rectangles" number="100" type="device" requires="VK_KHR_get_physical_device_properties2" author="NVIDIA" contact="Piers Daniell @pdaniell" supported="vulkan">
-             <require>
-                 <enum value="1"                                         name="VK_EXT_DISCARD_RECTANGLES_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_discard_rectangles&quot;"     name="VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME"/>
-                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT"/>
-                 <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT"/>
-                 <enum offset="0" extends="VkDynamicState"               name="VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT"/>
-                 <type name="VkPhysicalDeviceDiscardRectanglePropertiesEXT"/>
-                 <type name="VkPipelineDiscardRectangleStateCreateInfoEXT"/>
-                 <type name="VkPipelineDiscardRectangleStateCreateFlagsEXT"/>
-                 <type name="VkDiscardRectangleModeEXT"/>
-                 <command name="vkCmdSetDiscardRectangleEXT"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_101" number="101" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_101_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_101&quot;"           name="VK_NV_EXTENSION_101_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_102" number="102" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_102_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_102&quot;"           name="VK_NV_EXTENSION_102_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_103" number="103" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_103_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_103&quot;"           name="VK_NV_EXTENSION_103_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_NV_extension_104" number="104" author="NVIDIA" contact="Mathias Schott @mschott" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_NV_EXTENSION_104_SPEC_VERSION"/>
-                 <enum value="&quot;VK_NV_extension_104&quot;"           name="VK_NV_EXTENSION_104_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_EXT_swapchain_colorspace" number="105" type="device" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtneygo" requires="VK_KHR_surface" supported="disabled">
-             <require>
-                 <enum value="1"                                         name="VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_swapchain_colorspace&quot;"   name="VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME"/>
-                 <enum offset="1" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT"/>
-                 <enum offset="2" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT"/>
-                 <enum offset="3" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_SCRGB_LINEAR_EXT"/>
-                 <enum offset="4" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_SCRGB_NONLINEAR_EXT"/>
-                 <enum offset="5" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DCI_P3_LINEAR_EXT"/>
-                 <enum offset="6" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT"/>
-                 <enum offset="7" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_BT709_LINEAR_EXT"/>
-                 <enum offset="8" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_BT709_NONLINEAR_EXT"/>
-                 <enum offset="9" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_BT2020_LINEAR_EXT"/>
-                 <enum offset="10" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_BT2020_NONLINEAR_EXT"/>
-                 <enum offset="11" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_ADOBERGB_LINEAR_EXT"/>
-                 <enum offset="12" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT"/>
-             </require>
-         </extension>
-         <extension name="VK_EXT_SMPTE2086_metadata" number="106" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtneygo" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_EXT_SMPTE2086_METADATA_SPEC_VERSION"/>
-                 <enum value="&quot;VK_EXT_SMPTE2086_metadata&quot;"     name="VK_EXT_SMPTE2086_METADATA_EXTENSION_NAME"/>
-                 <type name="VkSMPTE2086MetadataEXT"/>
-                 <type name="VkXYColorEXT"/>
-                 <command name="vkSetSMPTE2086MetadataEXT"/>
-             </require>
-         </extension>
-         <extension name="VK_IMG_extension_107" number="107" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_IMG_EXTENSION_107_SPEC_VERSION"/>
-                 <enum value="&quot;VK_IMG_extension_107&quot;"           name="VK_IMG_EXTENSION_107_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_IMG_extension_108" number="108" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_IMG_EXTENSION_108_SPEC_VERSION"/>
-                 <enum value="&quot;VK_IMG_extension_108&quot;"           name="VK_IMG_EXTENSION_108_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_IMG_extension_109" number="109" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_IMG_EXTENSION_109_SPEC_VERSION"/>
-                 <enum value="&quot;VK_IMG_extension_109&quot;"           name="VK_IMG_EXTENSION_109_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_IMG_extension_110" number="110" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_IMG_EXTENSION_110_SPEC_VERSION"/>
-                 <enum value="&quot;VK_IMG_extension_110&quot;"           name="VK_IMG_EXTENSION_110_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_IMG_extension_111" number="111" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_IMG_EXTENSION_111_SPEC_VERSION"/>
-                 <enum value="&quot;VK_IMG_extension_111&quot;"           name="VK_IMG_EXTENSION_111_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_112" number="112" author="KHR" contact="Alon Or-bach @alonorbach" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_112_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_112&quot;"           name="VK_KHR_EXTENSION_112_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_113" number="113" author="KHX" contact="Cass Everitt @casseveritt" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_113_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_113&quot;"           name="VK_KHR_EXTENSION_113_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_114" number="114" author="KHX" contact="Cass Everitt @casseveritt" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_114_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_114&quot;"           name="VK_KHR_EXTENSION_114_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_115" number="115" author="KHX" contact="Cass Everitt @casseveritt" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_115_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_115&quot;"           name="VK_KHR_EXTENSION_115_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_116" number="116" author="KHX" contact="Cass Everitt @casseveritt" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_116_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_116&quot;"           name="VK_KHR_EXTENSION_116_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_117" number="117" author="KHR" contact="Kenneth Benzie @kbenzie" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_117_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_117&quot;"           name="VK_KHR_EXTENSION_117_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_118" number="118" author="KHR" contact="Michael Worcester @michaelworcester" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_118_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_118&quot;"           name="VK_KHR_EXTENSION_118_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_119" number="119" author="KHR" contact="Michael Worcester @michaelworcester" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_119_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_119&quot;"           name="VK_KHR_EXTENSION_119_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_120" number="120" author="KHR" contact="James Jones @cubanismo" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_120_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_120&quot;"          name="VK_KHR_EXTENSION_120_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_variable_pointers" number="121" author="KHR" contact="John Kessenich @johnk" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_variable_pointers_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_variable_pointers&quot;"      name="VK_KHR_variable_pointers_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_KHR_extension_122" number="122" author="KHR" contact="James Jones @cubanismo" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_KHR_EXTENSION_122_SPEC_VERSION"/>
-                 <enum value="&quot;VK_KHR_extension_122&quot;"          name="VK_KHR_EXTENSION_122_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_MVK_ios_surface" number="123" type="instance" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_IOS_MVK" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings">
-             <require>
-                 <enum value="1"                                         name="VK_MVK_IOS_SURFACE_SPEC_VERSION"/>
-                 <enum value="&quot;VK_MVK_ios_surface&quot;"            name="VK_MVK_IOS_SURFACE_EXTENSION_NAME"/>
-                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK"/>
-                 <type name="VkIOSSurfaceCreateFlagsMVK"/>
-                 <type name="VkIOSSurfaceCreateInfoMVK"/>
-                 <command name="vkCreateIOSSurfaceMVK"/>
-             </require>
-         </extension>
-         <extension name="VK_MVK_macos_surface" number="124" type="instance" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_MACOS_MVK" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings">
-             <require>
-                 <enum value="1"                                         name="VK_MVK_MACOS_SURFACE_SPEC_VERSION"/>
-                 <enum value="&quot;VK_MVK_macos_surface&quot;"          name="VK_MVK_MACOS_SURFACE_EXTENSION_NAME"/>
-                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK"/>
-                 <type name="VkMacOSSurfaceCreateFlagsMVK"/>
-                 <type name="VkMacOSSurfaceCreateInfoMVK"/>
-                 <command name="vkCreateMacOSSurfaceMVK"/>
-             </require>
-         </extension>
-         <extension name="VK_MVK_moltenvk" number="125" type="instance" author="MVK" contact="Bill Hollings @billhollings" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_MVK_MOLTENVK_SPEC_VERSION"/>
-                 <enum value="&quot;VK_MVK_moltenvk&quot;"               name="VK_MVK_MOLTENVK_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_MESA_extension_126" number="126" author="MESA" contact="Chad Versace @chadversary" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_MESA_EXTENSION_126_SPEC_VERSION"/>
-                 <enum value="&quot;VK_MESA_extension_126&quot;"         name="VK_MESA_EXTENSION_126_EXTENSION_NAME"/>
-             </require>
-         </extension>
-         <extension name="VK_MESA_extension_127" number="127" author="MESA" contact="Chad Versace @chadversary" supported="disabled">
-             <require>
-                 <enum value="0"                                         name="VK_MESA_EXTENSION_127_SPEC_VERSION"/>
-                 <enum value="&quot;VK_MESA_extension_127&quot;"         name="VK_MESA_EXTENSION_127_EXTENSION_NAME"/>
-             </require>
-         </extension>
+        <extension name="VK_EXT_direct_mode_display" number="89" type="instance" requires="VK_KHR_display" author="NVIDIA" contact="James Jones @cubanismo" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_DIRECT_MODE_DISPLAY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_direct_mode_display&quot;"    name="VK_EXT_DIRECT_MODE_DISPLAY_EXTENSION_NAME"/>
+                <command name="vkReleaseDisplayEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_acquire_xlib_display" number="90" type="instance" requires="VK_EXT_direct_mode_display,VK_KHR_display" author="NVIDIA" contact="James Jones @cubanismo" protect="VK_USE_PLATFORM_XLIB_XRANDR_EXT" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_ACQUIRE_XLIB_DISPLAY_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_acquire_xlib_display&quot;"   name="VK_EXT_ACQUIRE_XLIB_DISPLAY_EXTENSION_NAME"/>
+                <command name="vkAcquireXlibDisplayEXT"/>
+                <command name="vkGetRandROutputDisplayEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_display_surface_counter" number="91" type="instance" requires="VK_KHR_display" author="NVIDIA" contact="James Jones @cubanismo" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_DISPLAY_SURFACE_COUNTER_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_display_surface_counter&quot;" name="VK_EXT_DISPLAY_SURFACE_COUNTER_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES2_EXT"/>
+                <type name="VkSurfaceCounterFlagsEXT"/>
+                <type name="VkSurfaceCounterFlagBitsEXT"/>
+                <type name="VkSurfaceCapabilities2EXT"/>
+                <command name="vkGetPhysicalDeviceSurfaceCapabilities2EXT"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_display_control" number="92" type="device" requires="VK_KHR_display,VK_EXT_display_surface_counter,VK_KHR_swapchain" author="NVIDIA" contact="James Jones @cubanismo" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_DISPLAY_CONTROL_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_display_control&quot;"        name="VK_EXT_DISPLAY_CONTROL_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DISPLAY_POWER_INFO_EXT"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT"/>
+                <enum offset="2" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT"/>
+                <enum offset="3" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT"/>
+                <type name="VkDisplayPowerStateEXT"/>
+                <type name="VkDeviceEventTypeEXT"/>
+                <type name="VkDisplayEventTypeEXT"/>
+                <type name="VkDisplayPowerInfoEXT"/>
+                <type name="VkDeviceEventInfoEXT"/>
+                <type name="VkDisplayEventInfoEXT"/>
+                <type name="VkSwapchainCounterCreateInfoEXT"/>
+                <command name="vkDisplayPowerControlEXT"/>
+                <command name="vkRegisterDeviceEventEXT"/>
+                <command name="vkRegisterDisplayEventEXT"/>
+                <command name="vkGetSwapchainCounterEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_GOOGLE_display_timing" number="93" type="device" author="GOOGLE" requires="VK_KHR_swapchain" contact="Ian Elliott ianelliott@google.com" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_GOOGLE_DISPLAY_TIMING_SPEC_VERSION"/>
+                <enum value="&quot;VK_GOOGLE_display_timing&quot;"      name="VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME"/>
+                <enum offset="0"         extends="VkStructureType"      name="VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE"/>
+                <type name="VkRefreshCycleDurationGOOGLE"/>
+                <type name="VkPastPresentationTimingGOOGLE"/>
+                <type name="VkPresentTimesInfoGOOGLE"/>
+                <type name="VkPresentTimeGOOGLE"/>
+                <command name="vkGetRefreshCycleDurationGOOGLE"/>
+                <command name="vkGetPastPresentationTimingGOOGLE"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_94" number="94" author="Codeplay" contact="Neil Henning @neil_henning" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_94_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_94&quot;"           name="VK_KHR_EXTENSION_94_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_sample_mask_override_coverage" number="95" type="device" author="NVIDIA" contact="Piers Daniell @pdaniell" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_sample_mask_override_coverage&quot;" name="VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_geometry_shader_passthrough" number="96" type="device" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NV_GEOMETRY_SHADER_PASSTHROUGH_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_geometry_shader_passthrough&quot;" name="VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_viewport_array2" number="97" type="device" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NV_VIEWPORT_ARRAY2_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_viewport_array2&quot;"         name="VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NVX_multiview_per_view_attributes" number="98" type="device" author="NVIDIA" contact="Jeff Bolz @jbolz" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_SPEC_VERSION"/>
+                <enum value="&quot;VK_NVX_multiview_per_view_attributes&quot;"  name="VK_NVX_MULTIVIEW_PER_VIEW_ATTRIBUTES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX"/>
+                <enum bitpos="0" extends="VkSubpassDescriptionFlagBits" name="VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX"/>
+                <enum bitpos="1" extends="VkSubpassDescriptionFlagBits" name="VK_SUBPASS_DESCRIPTION_PER_VIEW_POSITION_X_ONLY_BIT_NVX"/>
+                <type name="VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_viewport_swizzle" number="99" type="device" author="NVIDIA" contact="Piers Daniell @pdaniell" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_NV_VIEWPORT_SWIZZLE_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_viewport_swizzle&quot;"        name="VK_NV_VIEWPORT_SWIZZLE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV"/>
+                <type name="VkViewportSwizzleNV"/>
+                <type name="VkViewportCoordinateSwizzleNV"/>
+                <type name="VkPipelineViewportSwizzleStateCreateInfoNV"/>
+                <type name="VkPipelineViewportSwizzleStateCreateFlagsNV"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_discard_rectangles" number="100" type="device" requires="VK_KHR_get_physical_device_properties2" author="NVIDIA" contact="Piers Daniell @pdaniell" supported="vulkan">
+            <require>
+                <enum value="1"                                         name="VK_EXT_DISCARD_RECTANGLES_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_discard_rectangles&quot;"     name="VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT"/>
+                <enum offset="1" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT"/>
+                <enum offset="0" extends="VkDynamicState"               name="VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT"/>
+                <type name="VkPhysicalDeviceDiscardRectanglePropertiesEXT"/>
+                <type name="VkPipelineDiscardRectangleStateCreateInfoEXT"/>
+                <type name="VkPipelineDiscardRectangleStateCreateFlagsEXT"/>
+                <type name="VkDiscardRectangleModeEXT"/>
+                <command name="vkCmdSetDiscardRectangleEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_101" number="101" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_101_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_101&quot;"           name="VK_NV_EXTENSION_101_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_102" number="102" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_102_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_102&quot;"           name="VK_NV_EXTENSION_102_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_103" number="103" author="NVIDIA" contact="Daniel Koch @dgkoch" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_103_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_103&quot;"           name="VK_NV_EXTENSION_103_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_NV_extension_104" number="104" author="NVIDIA" contact="Mathias Schott @mschott" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_NV_EXTENSION_104_SPEC_VERSION"/>
+                <enum value="&quot;VK_NV_extension_104&quot;"           name="VK_NV_EXTENSION_104_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_swapchain_colorspace" number="105" type="device" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtneygo" requires="VK_KHR_surface" supported="disabled">
+            <require>
+                <enum value="1"                                         name="VK_EXT_SWAPCHAIN_COLOR_SPACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_swapchain_colorspace&quot;"   name="VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME"/>
+                <enum offset="1" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT"/>
+                <enum offset="2" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT"/>
+                <enum offset="3" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_SCRGB_LINEAR_EXT"/>
+                <enum offset="4" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_SCRGB_NONLINEAR_EXT"/>
+                <enum offset="5" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DCI_P3_LINEAR_EXT"/>
+                <enum offset="6" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT"/>
+                <enum offset="7" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_BT709_LINEAR_EXT"/>
+                <enum offset="8" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_BT709_NONLINEAR_EXT"/>
+                <enum offset="9" extends="VkColorSpaceKHR"              name="VK_COLOR_SPACE_BT2020_LINEAR_EXT"/>
+                <enum offset="10" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_BT2020_NONLINEAR_EXT"/>
+                <enum offset="11" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_ADOBERGB_LINEAR_EXT"/>
+                <enum offset="12" extends="VkColorSpaceKHR"             name="VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_hdr_metadata" number="106" type="device" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtneygo" supported="vulkan">
+            <require>
+                <enum value="0"                                         name="VK_EXT_HDR_METADATA_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_hdr_metadata&quot;"           name="VK_EXT_HDR_METADATA_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_HDR_METADATA_EXT"/>
+                <type name="VkHdrMetadataEXT"/>
+                <type name="VkXYColorEXT"/>
+                <command name="vkSetHdrMetadataEXT"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_107" number="107" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_107_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_107&quot;"          name="VK_IMG_EXTENSION_107_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_108" number="108" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_108_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_108&quot;"          name="VK_IMG_EXTENSION_108_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_109" number="109" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_109_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_109&quot;"          name="VK_IMG_EXTENSION_109_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_110" number="110" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_110_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_110&quot;"          name="VK_IMG_EXTENSION_110_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_IMG_extension_111" number="111" author="IMG" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_IMG_EXTENSION_111_SPEC_VERSION"/>
+                <enum value="&quot;VK_IMG_extension_111&quot;"          name="VK_IMG_EXTENSION_111_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_112" number="112" author="KHR" contact="Alon Or-bach @alonorbach" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_112_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_112&quot;"          name="VK_KHR_EXTENSION_112_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_113" number="113" author="KHX" contact="Cass Everitt @casseveritt" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_113_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_113&quot;"          name="VK_KHR_EXTENSION_113_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_114" number="114" author="KHX" contact="Cass Everitt @casseveritt" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_114_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_114&quot;"          name="VK_KHR_EXTENSION_114_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_115" number="115" author="KHX" contact="Cass Everitt @casseveritt" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_115_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_115&quot;"          name="VK_KHR_EXTENSION_115_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_116" number="116" author="KHX" contact="Cass Everitt @casseveritt" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_116_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_116&quot;"          name="VK_KHR_EXTENSION_116_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_117" number="117" author="KHR" contact="Kenneth Benzie @kbenzie" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_117_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_117&quot;"          name="VK_KHR_EXTENSION_117_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_118" number="118" author="KHR" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_118_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_118&quot;"          name="VK_KHR_EXTENSION_118_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_119" number="119" author="KHR" contact="Michael Worcester @michaelworcester" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_119_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_119&quot;"          name="VK_KHR_EXTENSION_119_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_120" number="120" author="KHR" contact="James Jones @cubanismo" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_120_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_120&quot;"          name="VK_KHR_EXTENSION_120_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_variable_pointers" number="121" author="KHR" contact="John Kessenich @johnk" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_variable_pointers_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_variable_pointers&quot;"      name="VK_KHR_variable_pointers_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_122" number="122" author="KHR" contact="James Jones @cubanismo" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_122_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_122&quot;"          name="VK_KHR_EXTENSION_122_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_MVK_ios_surface" number="123" type="instance" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_IOS_MVK" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings">
+            <require>
+                <enum value="2"                                         name="VK_MVK_IOS_SURFACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_MVK_ios_surface&quot;"            name="VK_MVK_IOS_SURFACE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK"/>
+                <type name="VkIOSSurfaceCreateFlagsMVK"/>
+                <type name="VkIOSSurfaceCreateInfoMVK"/>
+                <command name="vkCreateIOSSurfaceMVK"/>
+            </require>
+        </extension>
+        <extension name="VK_MVK_macos_surface" number="124" type="instance" requires="VK_KHR_surface" protect="VK_USE_PLATFORM_MACOS_MVK" supported="vulkan" author="MVK" contact="Bill Hollings @billhollings">
+            <require>
+                <enum value="2"                                         name="VK_MVK_MACOS_SURFACE_SPEC_VERSION"/>
+                <enum value="&quot;VK_MVK_macos_surface&quot;"          name="VK_MVK_MACOS_SURFACE_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK"/>
+                <type name="VkMacOSSurfaceCreateFlagsMVK"/>
+                <type name="VkMacOSSurfaceCreateInfoMVK"/>
+                <command name="vkCreateMacOSSurfaceMVK"/>
+            </require>
+        </extension>
+        <extension name="VK_MVK_moltenvk" number="125" type="instance" author="MVK" contact="Bill Hollings @billhollings" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_MVK_MOLTENVK_SPEC_VERSION"/>
+                <enum value="&quot;VK_MVK_moltenvk&quot;"               name="VK_MVK_MOLTENVK_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_MESA_extension_126" number="126" author="MESA" contact="Chad Versace @chadversary" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_MESA_EXTENSION_126_SPEC_VERSION"/>
+                <enum value="&quot;VK_MESA_extension_126&quot;"         name="VK_MESA_EXTENSION_126_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_MESA_extension_127" number="127" author="MESA" contact="Chad Versace @chadversary" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_MESA_EXTENSION_127_SPEC_VERSION"/>
+                <enum value="&quot;VK_MESA_extension_127&quot;"         name="VK_MESA_EXTENSION_127_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_128" number="128" author="KHR" contact="James Jones @cubanismo" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_128_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_128&quot;"          name="VK_KHR_EXTENSION_128_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_EXT_extension_129" number="129" author="LUNARG" contact="Mark Young @MarkY_LunarG" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_129_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_extension_129&quot;"          name="VK_KHR_EXTENSION_129_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_130" number="130" author="KHR" contact="Jesse Hall @jessehall" supported="disabled">
+            <require>
+                <enum value="0"                                         name="VK_KHR_EXTENSION_130_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_130&quot;"          name="VK_KHR_EXTENSION_130_EXTENSION_NAME"/>
+            </require>
+        </extension>
     </extensions>
 </registry>

--- a/tests/layers/linux/VkLayer_test.json
+++ b/tests/layers/linux/VkLayer_test.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_test",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_test.so",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Test Layer",
         "enable_environment": {

--- a/tests/layers/linux/VkLayer_wrap_objects.json
+++ b/tests/layers/linux/VkLayer_wrap_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_wrap_objects",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_wrap_objects.so",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Dispatchable Object Wrapping Layer"
     }

--- a/tests/layers/windows/VkLayer_test.json
+++ b/tests/layers/windows/VkLayer_test.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_test",
         "type": "GLOBAL",
         "library_path": ".\\libVkLayer_test.dll",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Test Layer",
         "enable_environment": {

--- a/tests/layers/windows/VkLayer_wrap_objects.json
+++ b/tests/layers/windows/VkLayer_wrap_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_wrap_objects",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_wrap_objects.dll",
-        "api_version": "1.0.42",
+        "api_version": "1.0.43",
         "implementation_version": "1",
         "description": "LunarG Dispatchable Object Wrapping Layer"
     }


### PR DESCRIPTION
This update killed a couple of KHX extension APIs and added three new APIs from two new extensions.

