### PR TITLE
Tobin val flags piping

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -729,6 +729,8 @@ struct CHECK_DISABLED {
     bool get_query_pool_results;
     bool destroy_buffer;
     bool shader_validation;         // Skip validation for shaders
+
+    void SetAll(bool value) { std::fill(&command_buffer_state, &shader_validation + 1, value); }
 };
 
 struct MT_FB_ATTACHMENT_INFO {
@@ -804,7 +806,7 @@ const VkFormatProperties *GetFormatProperties(core_validation::layer_data *devic
 const VkImageFormatProperties *GetImageFormatProperties(core_validation::layer_data *device_data, VkFormat format,
                                                         VkImageType image_type, VkImageTiling tiling, VkImageUsageFlags usage,
                                                         VkImageCreateFlags flags);
-const debug_report_data *GetReportData(layer_data *);
+const debug_report_data *GetReportData(const layer_data *);
 const VkPhysicalDeviceProperties *GetPhysicalDeviceProperties(layer_data *);
 const CHECK_DISABLED *GetDisables(layer_data *);
 std::unordered_map<VkImage, std::unique_ptr<IMAGE_STATE>> *GetImageMap(core_validation::layer_data *);

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -290,9 +290,12 @@ void PerformUpdateDescriptorSets(const core_validation::layer_data *, uint32_t, 
 // Similar to PerformUpdateDescriptorSets, this function will do the same for updating via templates
 void PerformUpdateDescriptorSetsWithTemplateKHR(layer_data *, VkDescriptorSet, std::unique_ptr<TEMPLATE_STATE> const &,
                                                 const void *);
+// Update the common AllocateDescriptorSetsData struct which can then be shared between Validate* and Perform* funcs below
+void UpdateAllocateDescriptorSetsData(const layer_data *dev_data, const VkDescriptorSetAllocateInfo *,
+                                      AllocateDescriptorSetsData *);
 // Validate that Allocation state is ok
-bool ValidateAllocateDescriptorSets(const debug_report_data *, const VkDescriptorSetAllocateInfo *,
-                                    const core_validation::layer_data *, AllocateDescriptorSetsData *);
+bool ValidateAllocateDescriptorSets(const core_validation::layer_data *, const VkDescriptorSetAllocateInfo *,
+                                    const AllocateDescriptorSetsData *);
 // Update state based on allocating new descriptorsets
 void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const VkDescriptorSet *, const AllocateDescriptorSetsData *,
                                    std::unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_STATE *> *,


### PR DESCRIPTION
Finally getting around to piping this in. Only current option is to disable all of the flags that are present in validation which don't cover all of the validation checks, but is a nice POC to at least have something working. Tested with an update to cube that turns on validation and sets the VK_VALIDATION_CHECK_ALL_EXT enum of VK_EXT_validation_flags.