### PR TITLE
loader: Initialize json_version

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -2204,7 +2204,7 @@ static void loader_add_layer_properties(const struct loader_instance *inst, stru
     //     required
 
     cJSON *item, *layers_node, *layer_node;
-    layer_json_version json_version;
+    layer_json_version json_version = {0, 0, 0};
     char *vers_tok;
     cJSON *disable_environment = NULL;
     item = cJSON_GetObjectItem(json, "file_format_version");


### PR DESCRIPTION
Fields of json_version were left uninitialized if file_format_version
in a layer json file was incomplete.  Initialize them to 0.