### PR TITLE
build: Add pkgconfig file for the Vulkan loader

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -11,6 +11,15 @@ CHECK_FUNCTION_EXISTS(secure_getenv HAVE_SECURE_GETENV)
 CHECK_FUNCTION_EXISTS(__secure_getenv HAVE___SECURE_GETENV)
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/loader_cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/loader_cmake_config.h)
 
+# Fetch header version from vulkan.h
+file(STRINGS "../include/vulkan/vulkan.h" lines REGEX "^#define VK_HEADER_VERSION [0-9]+")
+list(LENGTH lines len)
+if(${len} EQUAL 1)
+    string(REGEX MATCHALL "[0-9]+" vk_header_version ${lines})
+else()
+    MESSAGE(FATAL_ERROR "Unable to fetch version from vulkan.h")
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DWIN32_LEAN_AND_MEAN)
     set(DisplayServer Win32)
@@ -132,8 +141,20 @@ else()
 
     add_library(${API_LOWERCASE} SHARED ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS})
     add_dependencies(${API_LOWERCASE} generate_helper_files loader_gen_files)
-    set_target_properties(${API_LOWERCASE} PROPERTIES SOVERSION "1" VERSION "1.0.43")
+    set_target_properties(${API_LOWERCASE} PROPERTIES SOVERSION "1" VERSION "1.0.${vk_header_version}")
     target_link_libraries(${API_LOWERCASE} -ldl -lpthread -lm)
 
     install(TARGETS ${API_LOWERCASE} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+    # Generate pkg-config file.
+    include(FindPkgConfig QUIET)
+    if(PKG_CONFIG_FOUND)
+        set(VK_API_VERSION "1.0.${vk_header_version}")
+        foreach(LIB ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES} ${PLATFORM_LIBS})
+            set(PRIVATE_LIBS "${PRIVATE_LIBS} -l${LIB}")
+        endforeach()
+        configure_file("vulkan.pc.in" "vulkan.pc" @ONLY)
+        install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/vulkan.pc"
+                DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+    endif()
 endif()

--- a/loader/vulkan.pc.in
+++ b/loader/vulkan.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/vulkan
+
+Name: @CMAKE_PROJECT_NAME@
+Description: Vulkan Loader
+Version: @VK_API_VERSION@
+Libs: -L${libdir} -lvulkan @PRIVATE_LIBS@
+Cflags: -I${includedir}
+


### PR DESCRIPTION
Fixes #757
On Linux, the build configures a vulkan.pc pkgconfig
file, writing it to <build_dir>/loader.  The make 'install'
target then installs this file along with the others so that
it can be found with pkg-config.  Then, issuing:
$ pkg-config --libs --cflags vulkan
emits compilation flags for vulkan programs.

Since retrieving the header version from vulkan.h was needed in
order to put the Version in the pc file, this commit also uses
the header version to specify the SO version, so it no longer needs
to be changed for every release.

Change-Id: If83c17bfbb59f2ee05d5f86f5e957fc11871546b