### PR TITLE
tests:Disable maintenance1_ext by default

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -355,7 +355,7 @@ class VkLayerTest : public VkRenderFramework {
    protected:
     ErrorMonitor *m_errorMonitor;
     bool m_enableWSI;
-    bool m_enable_maintenance1_ext;
+    bool m_enable_maintenance1_ext = false;
 
     virtual void SetUp() {
         std::vector<const char *> instance_layer_names;


### PR DESCRIPTION
Tests on some devices are incorrectly attempting to enable maintenance1
extension. Make sure it's set to off by default.