### PR TITLE
Remove VK_KHR_maintenence1 false positives

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -102,16 +102,6 @@ static const VkDeviceMemory MEMORY_UNBOUND = VkDeviceMemory(~((uint64_t)(0)) - 1
 // by the extent of a swapchain targeting the surface.
 static const uint32_t kSurfaceSizeFromSwapchain = 0xFFFFFFFFu;
 
-struct devExts {
-    bool wsi_enabled;
-    bool wsi_display_swapchain_enabled;
-    bool nv_glsl_shader_enabled;
-    bool khr_descriptor_update_template_enabled;
-    bool khr_shader_draw_parameters_enabled;
-    unordered_map<VkSwapchainKHR, unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
-    unordered_map<VkImage, VkSwapchainKHR> imageToSwapchainMap;
-};
-
 // fwd decls
 struct shader_module;
 
@@ -3854,6 +3844,7 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
     dev_data->device_extensions.nv_glsl_shader_enabled = false;
     dev_data->device_extensions.khr_descriptor_update_template_enabled = false;
     dev_data->device_extensions.khr_shader_draw_parameters_enabled = false;
+    dev_data->device_extensions.khr_maintenance1_enabled = false;
 
     for (i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
@@ -3870,6 +3861,9 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
         }
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME) == 0) {
             dev_data->device_extensions.khr_shader_draw_parameters_enabled = true;
+        }
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_MAINTENANCE1_EXTENSION_NAME) == 0) {
+            dev_data->device_extensions.khr_maintenance1_enabled = true;
         }
     }
 }
@@ -6188,6 +6182,8 @@ const PHYS_DEV_PROPERTIES_NODE *GetPhysDevProperties(const layer_data *device_da
 const VkPhysicalDeviceFeatures *GetEnabledFeatures(const layer_data *device_data) {
     return &device_data->enabled_features;
 }
+
+const devExts *GetDeviceExtensions(const layer_data *device_data) { return &device_data->device_extensions; }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
                                            const VkAllocationCallbacks *pAllocator, VkImage *pImage) {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -783,6 +783,18 @@ public:
 // Fwd declarations of layer_data and helpers to look-up/validate state from layer_data maps
 namespace core_validation {
 struct layer_data;
+
+struct devExts {
+    bool wsi_enabled;
+    bool wsi_display_swapchain_enabled;
+    bool nv_glsl_shader_enabled;
+    bool khr_descriptor_update_template_enabled;
+    bool khr_shader_draw_parameters_enabled;
+    bool khr_maintenance1_enabled;
+    std::unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
+    std::unordered_map<VkImage, VkSwapchainKHR> imageToSwapchainMap;
+};
+
 cvdescriptorset::DescriptorSet *GetSetNode(const layer_data *, VkDescriptorSet);
 cvdescriptorset::DescriptorSetLayout const *GetDescriptorSetLayout(layer_data const *, VkDescriptorSetLayout);
 DESCRIPTOR_POOL_STATE *GetDescriptorPoolState(const layer_data *, const VkDescriptorPool);
@@ -847,6 +859,7 @@ std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> *GetImageLayoutMap(l
 std::unordered_map<VkBuffer, std::unique_ptr<BUFFER_STATE>> *GetBufferMap(layer_data *device_data);
 std::unordered_map<VkBufferView, std::unique_ptr<BUFFER_VIEW_STATE>> *GetBufferViewMap(layer_data *device_data);
 std::unordered_map<VkImageView, std::unique_ptr<IMAGE_VIEW_STATE>> *GetImageViewMap(layer_data *device_data);
+const devExts *GetDeviceExtensions(const layer_data *);
 }
 
 #endif  // CORE_VALIDATION_TYPES_H_

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1642,26 +1642,28 @@ bool cvdescriptorset::ValidateAllocateDescriptorSets(const core_validation::laye
                         reinterpret_cast<const uint64_t &>(p_alloc_info->pSetLayouts[i]));
         }
     }
-    auto pool_state = GetDescriptorPoolState(dev_data, p_alloc_info->descriptorPool);
-    // Track number of descriptorSets allowable in this pool
-    if (pool_state->availableSets < p_alloc_info->descriptorSetCount) {
-        skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,
-                             reinterpret_cast<uint64_t &>(pool_state->pool), __LINE__, VALIDATION_ERROR_00911, "DS",
-                             "Unable to allocate %u descriptorSets from pool 0x%" PRIxLEAST64
-                             ". This pool only has %d descriptorSets remaining. %s",
-                             p_alloc_info->descriptorSetCount, reinterpret_cast<uint64_t &>(pool_state->pool),
-                             pool_state->availableSets, validation_error_map[VALIDATION_ERROR_00911]);
-    }
-    // Determine whether descriptor counts are satisfiable
-    for (uint32_t i = 0; i < VK_DESCRIPTOR_TYPE_RANGE_SIZE; i++) {
-        if (ds_data->required_descriptors_by_type[i] > pool_state->availableDescriptorTypeCount[i]) {
+    if (!GetDeviceExtensions(dev_data)->khr_maintenance1_enabled) {
+        auto pool_state = GetDescriptorPoolState(dev_data, p_alloc_info->descriptorPool);
+        // Track number of descriptorSets allowable in this pool
+        if (pool_state->availableSets < p_alloc_info->descriptorSetCount) {
             skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,
-                                 reinterpret_cast<const uint64_t &>(pool_state->pool), __LINE__, VALIDATION_ERROR_00912, "DS",
-                                 "Unable to allocate %u descriptors of type %s from pool 0x%" PRIxLEAST64
-                                 ". This pool only has %d descriptors of this type remaining. %s",
-                                 ds_data->required_descriptors_by_type[i], string_VkDescriptorType(VkDescriptorType(i)),
-                                 reinterpret_cast<uint64_t &>(pool_state->pool), pool_state->availableDescriptorTypeCount[i],
-                                 validation_error_map[VALIDATION_ERROR_00912]);
+                                 reinterpret_cast<uint64_t &>(pool_state->pool), __LINE__, VALIDATION_ERROR_00911, "DS",
+                                 "Unable to allocate %u descriptorSets from pool 0x%" PRIxLEAST64
+                                 ". This pool only has %d descriptorSets remaining. %s",
+                                 p_alloc_info->descriptorSetCount, reinterpret_cast<uint64_t &>(pool_state->pool),
+                                 pool_state->availableSets, validation_error_map[VALIDATION_ERROR_00911]);
+        }
+        // Determine whether descriptor counts are satisfiable
+        for (uint32_t i = 0; i < VK_DESCRIPTOR_TYPE_RANGE_SIZE; i++) {
+            if (ds_data->required_descriptors_by_type[i] > pool_state->availableDescriptorTypeCount[i]) {
+                skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,
+                                     reinterpret_cast<const uint64_t &>(pool_state->pool), __LINE__, VALIDATION_ERROR_00912, "DS",
+                                     "Unable to allocate %u descriptors of type %s from pool 0x%" PRIxLEAST64
+                                     ". This pool only has %d descriptors of this type remaining. %s",
+                                     ds_data->required_descriptors_by_type[i], string_VkDescriptorType(VkDescriptorType(i)),
+                                     reinterpret_cast<uint64_t &>(pool_state->pool), pool_state->availableDescriptorTypeCount[i],
+                                     validation_error_map[VALIDATION_ERROR_00912]);
+            }
         }
     }
 


### PR DESCRIPTION
Skip checks that are no longer valid if the VK_KHR_maintenence1 extension is enabled.  Additional validation checks required for VK_KHR_maintenence1 will be provided in a later patch set.