### PR TITLE
Layers: Add check for cyclic pNext chains, and duplicate pNext structures

### DIFF
--- a/layers/parameter_validation_utils.h
+++ b/layers/parameter_validation_utils.h
@@ -491,12 +491,17 @@ static bool validate_struct_pnext(debug_report_data *report_data, const char *ap
                                   const char *allowed_struct_names, const void *next, size_t allowed_type_count,
                                   const VkStructureType *allowed_types, uint32_t header_version) {
     bool skip_call = false;
+    std::unordered_set<const void *> cycle_check;
+    std::unordered_set<VkStructureType, std::hash<int>> unique_stype_check;
+
     const char disclaimer[] =
         "This warning is based on the Valid Usage documentation for version %d of the Vulkan header.  It "
         "is possible that you are using a struct from a private extension or an extension that was added "
         "to a later version of the Vulkan header, in which case your use of %s is perfectly valid but "
         "is not guaranteed to work correctly with validation enabled";
 
+    // TODO: The valid pNext structure types are not recursive. Each structure has its own list of valid sTypes for pNext.
+    // Codegen a map of vectors containing the allowable pNext types for each struct and use that here -- also simplifies parms.
     if (next != NULL) {
         if (allowed_type_count == 0) {
             std::string message = "%s: value of %s must be NULL.  ";
@@ -509,10 +514,31 @@ static bool validate_struct_pnext(debug_report_data *report_data, const char *ap
             const VkStructureType *end = allowed_types + allowed_type_count;
             const GenericHeader *current = reinterpret_cast<const GenericHeader *>(next);
 
-            while (current != NULL) {
-                if (std::find(start, end, current->sType) == end) {
-                    std::string type_name = string_VkStructureType(current->sType);
+            cycle_check.insert(next);
 
+
+            while (current != NULL) {
+                if (cycle_check.find(current->pNext) != cycle_check.end()) {
+                    std::string message = "%s: %s chain contains a cycle -- pNext pointer " PRIx64 " is repeated.";
+                    skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                                         __LINE__, INVALID_STRUCT_PNEXT, LayerName, message.c_str(), api_name,
+                                         parameter_name.get_name().c_str(), reinterpret_cast<uint64_t>(next));
+                    break;
+                } else {
+                    cycle_check.insert(current->pNext);
+                }
+
+                std::string type_name = string_VkStructureType(current->sType);
+                if (unique_stype_check.find(current->sType) != unique_stype_check.end()) {
+                    std::string message = "%s: %s chain contains duplicate structure types: %s appears multiple times.";
+                    skip_call |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                                         __LINE__, INVALID_STRUCT_PNEXT, LayerName, message.c_str(), api_name,
+                                         parameter_name.get_name().c_str(), type_name.c_str());
+                } else {
+                    unique_stype_check.insert(current->sType);
+                }
+
+                if (std::find(start, end, current->sType) == end) {
                     if (type_name == UnsupportedStructureTypeString) {
                         std::string message =
                             "%s: %s chain includes a structure with unexpected VkStructureType (%d); Allowed "
@@ -532,7 +558,6 @@ static bool validate_struct_pnext(debug_report_data *report_data, const char *ap
                                              header_version, parameter_name.get_name().c_str());
                     }
                 }
-
                 current = reinterpret_cast<const GenericHeader *>(current->pNext);
             }
         }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -22818,6 +22818,51 @@ TEST_F(VkPositiveLayerTest, Maintenance1Tests) {
     m_errorMonitor->VerifyNotFound();
 }
 
+TEST_F(VkLayerTest, DuplicateValidPNextStructures) {
+    TEST_DESCRIPTION("Create a pNext chain containing valid strutures, but with a duplicate structure type");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    uint32_t extension_count = 0;
+    VkResult err = vkEnumerateDeviceExtensionProperties(gpu(), nullptr, &extension_count, nullptr);
+    ASSERT_VK_SUCCESS(err);
+
+    if (extension_count > 0) {
+        std::vector<VkExtensionProperties> available_extensions(extension_count);
+        err = vkEnumerateDeviceExtensionProperties(gpu(), nullptr, &extension_count, &available_extensions[0]);
+        ASSERT_VK_SUCCESS(err);
+
+        for (const auto &extension_props : available_extensions) {
+            if (strcmp(extension_props.extensionName, VK_NV_DEDICATED_ALLOCATION_EXTENSION_NAME) == 0) {
+                // Create two pNext structures which by themselves would be valid
+                VkDedicatedAllocationBufferCreateInfoNV dedicated_buffer_create_info = {};
+                VkDedicatedAllocationBufferCreateInfoNV dedicated_buffer_create_info_2 = {};
+                dedicated_buffer_create_info.sType = VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV;
+                dedicated_buffer_create_info.pNext = &dedicated_buffer_create_info_2;
+                dedicated_buffer_create_info.dedicatedAllocation = VK_TRUE;
+
+                dedicated_buffer_create_info_2.sType = VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV;
+                dedicated_buffer_create_info_2.pNext = nullptr;
+                dedicated_buffer_create_info_2.dedicatedAllocation = VK_TRUE;
+
+                uint32_t queue_family_index = 0;
+                VkBufferCreateInfo buffer_create_info = {};
+                buffer_create_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+                buffer_create_info.pNext = &dedicated_buffer_create_info;
+                buffer_create_info.size = 1024;
+                buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+                buffer_create_info.queueFamilyIndexCount = 1;
+                buffer_create_info.pQueueFamilyIndices = &queue_family_index;
+
+                m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "chain contains duplicate structure types");
+                VkBuffer buffer;
+                err = vkCreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
+                m_errorMonitor->VerifyFound();
+            }
+        }
+    }
+}
+
 TEST_F(VkPositiveLayerTest, ValidStructPNext) {
     TEST_DESCRIPTION("Verify that a valid pNext value is handled correctly");
 


### PR DESCRIPTION
Fixes #1621.  Cyclic pNext chain errors would crash/lock up the layers.  Added check, error message and early exit.  Also plumbed in similar check for duplicates in the pNext chain, which is about to be added to the spec, along with a matching test.