### PR TITLE
Add extension shader caps coverage to core validation

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2536,6 +2536,11 @@ static bool validate_shader_capabilities(layer_data *dev_data, shader_module con
                                               VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME);
                     break;
 
+                case spv::CapabilitySampleMaskOverrideCoverageNV:
+                    pass &= require_extension(report_data, dev_data->device_extensions.nv_sample_mask_override_coverage_enabled,
+                                              VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME);
+                    break;
+
                 default:
                     // Spirv-validator should catch these errors
                     break;
@@ -3848,6 +3853,7 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
     dev_data->device_extensions.khr_shader_draw_parameters_enabled = false;
     dev_data->device_extensions.khr_maintenance1_enabled = false;
     dev_data->device_extensions.nv_geometry_shader_passthrough_enabled = false;
+    dev_data->device_extensions.nv_sample_mask_override_coverage_enabled = false;
 
     for (i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
@@ -3870,6 +3876,9 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
         }
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME) == 0) {
             dev_data->device_extensions.nv_geometry_shader_passthrough_enabled = true;
+        }
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME) == 0) {
+            dev_data->device_extensions.nv_sample_mask_override_coverage_enabled = true;
         }
     }
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2531,6 +2531,11 @@ static bool validate_shader_capabilities(layer_data *dev_data, shader_module con
                                               VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
                     break;
 
+                case spv::CapabilityGeometryShaderPassthroughNV:
+                    pass &= require_extension(report_data, dev_data->device_extensions.nv_geometry_shader_passthrough_enabled,
+                                              VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME);
+                    break;
+
                 default:
                     // Spirv-validator should catch these errors
                     break;
@@ -3842,6 +3847,7 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
     dev_data->device_extensions.khr_descriptor_update_template_enabled = false;
     dev_data->device_extensions.khr_shader_draw_parameters_enabled = false;
     dev_data->device_extensions.khr_maintenance1_enabled = false;
+    dev_data->device_extensions.nv_geometry_shader_passthrough_enabled = false;
 
     for (i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
@@ -3861,6 +3867,9 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
         }
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_MAINTENANCE1_EXTENSION_NAME) == 0) {
             dev_data->device_extensions.khr_maintenance1_enabled = true;
+        }
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NV_GEOMETRY_SHADER_PASSTHROUGH_EXTENSION_NAME) == 0) {
+            dev_data->device_extensions.nv_geometry_shader_passthrough_enabled = true;
         }
     }
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2552,6 +2552,11 @@ static bool validate_shader_capabilities(layer_data *dev_data, shader_module con
                                               VK_EXT_SHADER_SUBGROUP_BALLOT_EXTENSION_NAME);
                     break;
 
+                case spv::CapabilitySubgroupVoteKHR:
+                    pass &= require_extension(report_data, dev_data->device_extensions.khr_subgroup_vote_enabled,
+                                              VK_EXT_SHADER_SUBGROUP_VOTE_EXTENSION_NAME);
+                    break;
+
                 default:
                     // Spirv-validator should catch these errors
                     break;
@@ -3867,7 +3872,7 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
     dev_data->device_extensions.nv_sample_mask_override_coverage_enabled = false;
     dev_data->device_extensions.nv_viewport_array2_enabled = false;
     dev_data->device_extensions.khr_subgroup_ballot_enabled = false;
-
+    dev_data->device_extensions.khr_subgroup_vote_enabled = false;
 
     for (i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
@@ -3900,6 +3905,10 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_SHADER_SUBGROUP_BALLOT_EXTENSION_NAME) == 0) {
             dev_data->device_extensions.khr_subgroup_ballot_enabled = true;
         }
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_SHADER_SUBGROUP_VOTE_EXTENSION_NAME) == 0) {
+            dev_data->device_extensions.khr_subgroup_vote_enabled = true;
+        }
+
     }
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2547,6 +2547,11 @@ static bool validate_shader_capabilities(layer_data *dev_data, shader_module con
                                               VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME);
                     break;
 
+                case spv::CapabilitySubgroupBallotKHR:
+                    pass &= require_extension(report_data, dev_data->device_extensions.khr_subgroup_ballot_enabled,
+                                              VK_EXT_SHADER_SUBGROUP_BALLOT_EXTENSION_NAME);
+                    break;
+
                 default:
                     // Spirv-validator should catch these errors
                     break;
@@ -3861,6 +3866,7 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
     dev_data->device_extensions.nv_geometry_shader_passthrough_enabled = false;
     dev_data->device_extensions.nv_sample_mask_override_coverage_enabled = false;
     dev_data->device_extensions.nv_viewport_array2_enabled = false;
+    dev_data->device_extensions.khr_subgroup_ballot_enabled = false;
 
 
     for (i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
@@ -3890,6 +3896,9 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
         }
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME) == 0) {
             dev_data->device_extensions.nv_viewport_array2_enabled = true;
+        }
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_EXT_SHADER_SUBGROUP_BALLOT_EXTENSION_NAME) == 0) {
+            dev_data->device_extensions.khr_subgroup_ballot_enabled = true;
         }
     }
 }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2541,6 +2541,12 @@ static bool validate_shader_capabilities(layer_data *dev_data, shader_module con
                                               VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME);
                     break;
 
+                case spv::CapabilityShaderViewportIndexLayerNV:
+                case spv::CapabilityShaderViewportMaskNV:
+                    pass &= require_extension(report_data, dev_data->device_extensions.nv_viewport_array2_enabled,
+                                              VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME);
+                    break;
+
                 default:
                     // Spirv-validator should catch these errors
                     break;
@@ -3854,6 +3860,8 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
     dev_data->device_extensions.khr_maintenance1_enabled = false;
     dev_data->device_extensions.nv_geometry_shader_passthrough_enabled = false;
     dev_data->device_extensions.nv_sample_mask_override_coverage_enabled = false;
+    dev_data->device_extensions.nv_viewport_array2_enabled = false;
+
 
     for (i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
@@ -3879,6 +3887,9 @@ static void checkDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
         }
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NV_SAMPLE_MASK_OVERRIDE_COVERAGE_EXTENSION_NAME) == 0) {
             dev_data->device_extensions.nv_sample_mask_override_coverage_enabled = true;
+        }
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME) == 0) {
+            dev_data->device_extensions.nv_viewport_array2_enabled = true;
         }
     }
 }

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -793,6 +793,7 @@ struct devExts {
     bool khr_maintenance1_enabled;
     bool nv_geometry_shader_passthrough_enabled;
     bool nv_sample_mask_override_coverage_enabled;
+    bool nv_viewport_array2_enabled;
     std::unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
     std::unordered_map<VkImage, VkSwapchainKHR> imageToSwapchainMap;
 };

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -794,6 +794,7 @@ struct devExts {
     bool nv_geometry_shader_passthrough_enabled;
     bool nv_sample_mask_override_coverage_enabled;
     bool nv_viewport_array2_enabled;
+    bool khr_subgroup_ballot_enabled;
     std::unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
     std::unordered_map<VkImage, VkSwapchainKHR> imageToSwapchainMap;
 };

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -795,6 +795,8 @@ struct devExts {
     bool nv_sample_mask_override_coverage_enabled;
     bool nv_viewport_array2_enabled;
     bool khr_subgroup_ballot_enabled;
+    bool khr_subgroup_vote_enabled;
+
     std::unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
     std::unordered_map<VkImage, VkSwapchainKHR> imageToSwapchainMap;
 };

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -792,6 +792,7 @@ struct devExts {
     bool khr_shader_draw_parameters_enabled;
     bool khr_maintenance1_enabled;
     bool nv_geometry_shader_passthrough_enabled;
+    bool nv_sample_mask_override_coverage_enabled;
     std::unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
     std::unordered_map<VkImage, VkSwapchainKHR> imageToSwapchainMap;
 };

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -791,6 +791,7 @@ struct devExts {
     bool khr_descriptor_update_template_enabled;
     bool khr_shader_draw_parameters_enabled;
     bool khr_maintenance1_enabled;
+    bool nv_geometry_shader_passthrough_enabled;
     std::unordered_map<VkSwapchainKHR, std::unique_ptr<SWAPCHAIN_NODE>> swapchainMap;
     std::unordered_map<VkImage, VkSwapchainKHR> imageToSwapchainMap;
 };


### PR DESCRIPTION
Using any of these extensions resulted in incorrect validation errors. 