### PR TITLE
layers: Fix extension func/core struct codegen

### DIFF
--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -581,6 +581,45 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(VkDevice device, const VkSwapc
     return result;
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
+                                                         const VkSwapchainCreateInfoKHR *pCreateInfos,
+                                                         const VkAllocationCallbacks *pAllocator, VkSwapchainKHR *pSwapchains) {
+    layer_data *dev_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
+    safe_VkSwapchainCreateInfoKHR *local_pCreateInfos = NULL;
+    {
+        std::lock_guard<std::mutex> lock(global_lock);
+        if (pCreateInfos) {
+            // Need to pull surface mapping from the instance-level map
+            layer_data *instance_data = GetLayerDataPtr(get_dispatch_key(dev_data->gpu), layer_data_map);
+            local_pCreateInfos = new safe_VkSwapchainCreateInfoKHR[swapchainCount];
+            for (uint32_t i = 0; i < swapchainCount; ++i) {
+                local_pCreateInfos[i].initialize(&pCreateInfos[i]);
+                if (pCreateInfos[i].surface) {
+                    local_pCreateInfos[i].surface =
+                        (VkSurfaceKHR)instance_data->unique_id_mapping[reinterpret_cast<const uint64_t &>(pCreateInfos[i].surface)];
+                }
+                if (pCreateInfos[i].oldSwapchain) {
+                    local_pCreateInfos[i].oldSwapchain =
+                        (VkSwapchainKHR)
+                            dev_data->unique_id_mapping[reinterpret_cast<const uint64_t &>(pCreateInfos[i].oldSwapchain)];
+                }
+            }
+        }
+    }
+    VkResult result = dev_data->device_dispatch_table->CreateSharedSwapchainsKHR(
+        device, swapchainCount, (const VkSwapchainCreateInfoKHR *)local_pCreateInfos, pAllocator, pSwapchains);
+    if (local_pCreateInfos) delete[] local_pCreateInfos;
+    if (VK_SUCCESS == result) {
+        std::lock_guard<std::mutex> lock(global_lock);
+        for (uint32_t i = 0; i < swapchainCount; i++) {
+            uint64_t unique_id = global_unique_id++;
+            dev_data->unique_id_mapping[unique_id] = reinterpret_cast<uint64_t &>(pSwapchains[i]);
+            pSwapchains[i] = reinterpret_cast<VkSwapchainKHR &>(unique_id);
+        }
+    }
+    return result;
+}
+
 VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
                                                      VkImage *pSwapchainImages) {
     layer_data *my_device_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -238,7 +238,6 @@ class ParamCheckerOutputGenerator(OutputGenerator):
         self.structTypes = dict()
         self.commands = []
         self.structMembers = []
-        self.validatedStructs = dict()
         self.newFlags = set()
     def endFeature(self):
         # C-specific

--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -136,6 +136,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             'vkCreateComputePipelines',
             'vkCreateGraphicsPipelines',
             'vkCreateSwapchainKHR',
+            'vkCreateSharedSwapchainsKHR',
             'vkGetSwapchainImagesKHR',
             'vkEnumerateInstanceLayerProperties',
             'vkEnumerateDeviceLayerProperties',
@@ -162,16 +163,9 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
         self.headerVersion = None
         # Internal state - accumulators for different inner block text
         self.sections = dict([(section, []) for section in self.ALL_SECTIONS])
-        self.structNames = []                             # List of Vulkan struct typenames
-        self.structTypes = dict()                         # Map of Vulkan struct typename to required VkStructureType
-        self.handleTypes = set()                          # Set of handle type names
-        self.commands = []                                # List of CommandData records for all Vulkan commands
         self.structMembers = []                           # List of StructMemberData records for all Vulkan structs
-        self.flags = set()                                # Map of flags typenames
         # Named tuples to store struct and command data
-        self.StructType = namedtuple('StructType', ['name', 'value'])
         self.CommandParam = namedtuple('CommandParam', ['type', 'name', 'ispointer', 'isconst', 'iscount', 'len', 'extstructs', 'cdecl', 'islocal', 'iscreate', 'isdestroy'])
-        self.CommandData = namedtuple('CommandData', ['name', 'return_type', 'params', 'cdecl'])
         self.StructMemberData = namedtuple('StructMemberData', ['name', 'members'])
     #
     def incIndent(self, indent):
@@ -236,14 +230,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
         OutputGenerator.beginFeature(self, interface, emit)
         self.headerVersion = None
         self.sections = dict([(section, []) for section in self.ALL_SECTIONS])
-        self.structNames = []
-        self.structTypes = dict()
-        self.handleTypes = set()
-        self.commands = []
-        self.structMembers = []
         self.cmdMembers = []
-        self.flags = set()
-        self.StructMemberData = namedtuple('StructMemberData', ['name', 'members'])
         self.CmdMemberData = namedtuple('CmdMemberData', ['name', 'members'])
         if self.featureName != 'VK_VERSION_1_0':
             white_list_entry = []
@@ -284,7 +271,6 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
         # Otherwise, emit the tag text.
         category = typeElem.get('category')
         if (category == 'struct' or category == 'union'):
-            self.structNames.append(name)
             self.genStruct(typeinfo, name)
     #
     # Append a definition to the specified section
@@ -383,8 +369,6 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
                     value = result.group(0)
                 else:
                     value = self.genVkStructureType(typeName)
-                # Store the required type value
-                self.structTypes[typeName] = self.StructType(name=name, value=value)
             # Store pointer/array/string info
             membersInfo.append(self.CommandParam(type=type,
                                                  name=name,


### PR DESCRIPTION
Fix code generation for extension functions receiving struct parameter types defined by core Vulkan.  

Extensions are processed as separate features by the code generator, and the type info required for struct processing was not being shared across features.  The code generator has been modified to share type info across features so that the validation code generated for extension functions includes validation for core structures:
 - Prevent unique objects and parameter validation code generators from
   clearing struct type info data structures at the start of feature
   processing.
 - Remove unused data structures from unique objects code generator.
 - Adds handle unwrapping and parameter validation for elements in the
   vkCmdPushDescriptorSetKHR pDescriptorWrites parameter.
 - Adds handle unwrapping and parameter validation for elements in the
   vkCreateSharedSwapCHainsKHR pCreateInfos parameter.
 - Adds VkAllocationCallback parameter validation to the WSI and
   descriptor update template extension functions.
