### PR TITLE
cube: Use VK_KHR_incremental_present extension

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -1075,19 +1075,6 @@ static void demo_draw(struct demo *demo) {
             .pRegions = &region,
         };
         present.pNext = &regions;
-        DbgMsg("present = %p, present.pNext = %p, regions = %p, regions.pNext = %p\n",
-               &present,
-               present.pNext,
-               &regions,
-               regions.pNext);
-        DbgMsg("Present Rectangle has offset: (%d, %d) and extent: (%d, %d)\n",
-               regions.pRegions->pRectangles->offset.x,
-               regions.pRegions->pRectangles->offset.y,
-               regions.pRegions->pRectangles->extent.width,
-               regions.pRegions->pRectangles->extent.height);
-        DbgMsg("regions = %p, regions.pRegions = %p, "
-               "regions.pRegions->pRectangles = %p\n",
-               &regions, regions.pRegions, regions.pRegions->pRectangles);
     }
 
     if (demo->VK_GOOGLE_display_timing_enabled) {


### PR DESCRIPTION
Show how to use the VK_KHR_incremental_present extension.  Other notes:

- There are a few diagnostic DbgMsg()'s, which can help show the usage.
- Added a "--incremental_present" command-line option to turn on use of VK_KHR_incremental_present
- Should compile and run on Windows, Linux, and Android, but the feature will only really be used on systems that support the extension.