### PR TITLE
Update to 1.0.46 Header PLUS Incremental_Present extension updates

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -1075,19 +1075,6 @@ static void demo_draw(struct demo *demo) {
             .pRegions = &region,
         };
         present.pNext = &regions;
-        DbgMsg("present = %p, present.pNext = %p, regions = %p, regions.pNext = %p\n",
-               &present,
-               present.pNext,
-               &regions,
-               regions.pNext);
-        DbgMsg("Present Rectangle has offset: (%d, %d) and extent: (%d, %d)\n",
-               regions.pRegions->pRectangles->offset.x,
-               regions.pRegions->pRectangles->offset.y,
-               regions.pRegions->pRectangles->extent.width,
-               regions.pRegions->pRectangles->extent.height);
-        DbgMsg("regions = %p, regions.pRegions = %p, "
-               "regions.pRegions->pRectangles = %p\n",
-               &regions, regions.pRegions, regions.pRegions->pRectangles);
     }
 
     if (demo->VK_GOOGLE_display_timing_enabled) {

--- a/include/vulkan/vulkan.h
+++ b/include/vulkan/vulkan.h
@@ -43,7 +43,7 @@ extern "C" {
 #define VK_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3ff)
 #define VK_VERSION_PATCH(version) ((uint32_t)(version) & 0xfff)
 // Version of this file
-#define VK_HEADER_VERSION 45
+#define VK_HEADER_VERSION 46
 
 
 #define VK_NULL_HANDLE 0
@@ -281,6 +281,7 @@ typedef enum VkStructureType {
     VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHX = 1000078002,
     VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHX = 1000079000,
     VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR = 1000080000,
+    VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR = 1000084000,
     VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR = 1000085000,
     VK_STRUCTURE_TYPE_OBJECT_TABLE_CREATE_INFO_NVX = 1000086000,
     VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX = 1000086001,
@@ -4004,6 +4005,30 @@ VKAPI_ATTR void VKAPI_CALL vkCmdPushDescriptorSetKHR(
     const VkWriteDescriptorSet*                 pDescriptorWrites);
 #endif
 
+#define VK_KHR_incremental_present 1
+#define VK_KHR_INCREMENTAL_PRESENT_SPEC_VERSION 1
+#define VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME "VK_KHR_incremental_present"
+
+typedef struct VkRectLayerKHR {
+    VkOffset2D    offset;
+    VkExtent2D    extent;
+    uint32_t      layer;
+} VkRectLayerKHR;
+
+typedef struct VkPresentRegionKHR {
+    uint32_t                 rectangleCount;
+    const VkRectLayerKHR*    pRectangles;
+} VkPresentRegionKHR;
+
+typedef struct VkPresentRegionsKHR {
+    VkStructureType              sType;
+    const void*                  pNext;
+    uint32_t                     swapchainCount;
+    const VkPresentRegionKHR*    pRegions;
+} VkPresentRegionsKHR;
+
+
+
 #define VK_KHR_descriptor_update_template 1
 VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkDescriptorUpdateTemplateKHR)
 
@@ -4079,7 +4104,7 @@ VKAPI_ATTR void VKAPI_CALL vkCmdPushDescriptorSetWithTemplateKHR(
 #define VK_EXT_debug_report 1
 VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkDebugReportCallbackEXT)
 
-#define VK_EXT_DEBUG_REPORT_SPEC_VERSION  5
+#define VK_EXT_DEBUG_REPORT_SPEC_VERSION  6
 #define VK_EXT_DEBUG_REPORT_EXTENSION_NAME "VK_EXT_debug_report"
 #define VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT
 
@@ -4118,6 +4143,7 @@ typedef enum VkDebugReportObjectTypeEXT {
     VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT = 30,
     VK_DEBUG_REPORT_OBJECT_TYPE_OBJECT_TABLE_NVX_EXT = 31,
     VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT = 32,
+    VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR_EXT = 1000085000,
     VK_DEBUG_REPORT_OBJECT_TYPE_BEGIN_RANGE_EXT = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,
     VK_DEBUG_REPORT_OBJECT_TYPE_END_RANGE_EXT = VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT,
     VK_DEBUG_REPORT_OBJECT_TYPE_RANGE_SIZE_EXT = (VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT - VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT + 1),
@@ -4899,7 +4925,7 @@ typedef struct VkExportMemoryAllocateInfoKHX {
 
 
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHX
 #define VK_KHX_external_memory_win32 1
 #define VK_KHX_EXTERNAL_MEMORY_WIN32_SPEC_VERSION 1
 #define VK_KHX_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME "VK_KHX_external_memory_win32"
@@ -4942,7 +4968,7 @@ VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandlePropertiesKHX(
     HANDLE                                      handle,
     VkMemoryWin32HandlePropertiesKHX*           pMemoryWin32HandleProperties);
 #endif
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
+#endif /* VK_USE_PLATFORM_WIN32_KHX */
 
 #define VK_KHX_external_memory_fd 1
 #define VK_KHX_EXTERNAL_MEMORY_FD_SPEC_VERSION 1
@@ -5676,7 +5702,7 @@ typedef VkFlags VkPipelineDiscardRectangleStateCreateFlagsEXT;
 
 typedef struct VkPhysicalDeviceDiscardRectanglePropertiesEXT {
     VkStructureType    sType;
-    const void*        pNext;
+    void*              pNext;
     uint32_t           maxDiscardRectangles;
 } VkPhysicalDeviceDiscardRectanglePropertiesEXT;
 

--- a/include/vulkan/vulkan.hpp
+++ b/include/vulkan/vulkan.hpp
@@ -42,7 +42,7 @@
 # include <vector>
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-static_assert( VK_HEADER_VERSION ==  45 , "Wrong VK_HEADER_VERSION!" );
+static_assert( VK_HEADER_VERSION ==  46 , "Wrong VK_HEADER_VERSION!" );
 
 // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
 // To enable this feature on 32-bit platforms please define VULKAN_HPP_TYPESAFE_CONVERSION
@@ -4788,6 +4788,119 @@ namespace vk
   };
   static_assert( sizeof( DisplayModePropertiesKHR ) == sizeof( VkDisplayModePropertiesKHR ), "struct and wrapper have different size!" );
 
+  struct RectLayerKHR
+  {
+    RectLayerKHR( Offset2D offset_ = Offset2D(), Extent2D extent_ = Extent2D(), uint32_t layer_ = 0 )
+      : offset( offset_ )
+      , extent( extent_ )
+      , layer( layer_ )
+    {
+    }
+
+    RectLayerKHR( VkRectLayerKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(RectLayerKHR) );
+    }
+
+    RectLayerKHR& operator=( VkRectLayerKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(RectLayerKHR) );
+      return *this;
+    }
+
+    RectLayerKHR& setOffset( Offset2D offset_ )
+    {
+      offset = offset_;
+      return *this;
+    }
+
+    RectLayerKHR& setExtent( Extent2D extent_ )
+    {
+      extent = extent_;
+      return *this;
+    }
+
+    RectLayerKHR& setLayer( uint32_t layer_ )
+    {
+      layer = layer_;
+      return *this;
+    }
+
+    operator const VkRectLayerKHR&() const
+    {
+      return *reinterpret_cast<const VkRectLayerKHR*>(this);
+    }
+
+    bool operator==( RectLayerKHR const& rhs ) const
+    {
+      return ( offset == rhs.offset )
+          && ( extent == rhs.extent )
+          && ( layer == rhs.layer );
+    }
+
+    bool operator!=( RectLayerKHR const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+    Offset2D offset;
+    Extent2D extent;
+    uint32_t layer;
+  };
+  static_assert( sizeof( RectLayerKHR ) == sizeof( VkRectLayerKHR ), "struct and wrapper have different size!" );
+
+  struct PresentRegionKHR
+  {
+    PresentRegionKHR( uint32_t rectangleCount_ = 0, const RectLayerKHR* pRectangles_ = nullptr )
+      : rectangleCount( rectangleCount_ )
+      , pRectangles( pRectangles_ )
+    {
+    }
+
+    PresentRegionKHR( VkPresentRegionKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PresentRegionKHR) );
+    }
+
+    PresentRegionKHR& operator=( VkPresentRegionKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PresentRegionKHR) );
+      return *this;
+    }
+
+    PresentRegionKHR& setRectangleCount( uint32_t rectangleCount_ )
+    {
+      rectangleCount = rectangleCount_;
+      return *this;
+    }
+
+    PresentRegionKHR& setPRectangles( const RectLayerKHR* pRectangles_ )
+    {
+      pRectangles = pRectangles_;
+      return *this;
+    }
+
+    operator const VkPresentRegionKHR&() const
+    {
+      return *reinterpret_cast<const VkPresentRegionKHR*>(this);
+    }
+
+    bool operator==( PresentRegionKHR const& rhs ) const
+    {
+      return ( rectangleCount == rhs.rectangleCount )
+          && ( pRectangles == rhs.pRectangles );
+    }
+
+    bool operator!=( PresentRegionKHR const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+    uint32_t rectangleCount;
+    const RectLayerKHR* pRectangles;
+  };
+  static_assert( sizeof( PresentRegionKHR ) == sizeof( VkPresentRegionKHR ), "struct and wrapper have different size!" );
+
   struct XYColorEXT
   {
     XYColorEXT( float x_ = 0, float y_ = 0 )
@@ -6249,6 +6362,7 @@ namespace vk
     eD3D12FenceSubmitInfoKHX = VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHX,
     eImportSemaphoreFdInfoKHX = VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHX,
     ePhysicalDevicePushDescriptorPropertiesKHR = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR,
+    ePresentRegionsKHR = VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR,
     eDescriptorUpdateTemplateCreateInfoKHR = VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR,
     eObjectTableCreateInfoNVX = VK_STRUCTURE_TYPE_OBJECT_TABLE_CREATE_INFO_NVX,
     eIndirectCommandsLayoutCreateInfoNVX = VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NVX,
@@ -10030,6 +10144,73 @@ namespace vk
   };
   static_assert( sizeof( PhysicalDevicePushDescriptorPropertiesKHR ) == sizeof( VkPhysicalDevicePushDescriptorPropertiesKHR ), "struct and wrapper have different size!" );
 
+  struct PresentRegionsKHR
+  {
+    PresentRegionsKHR( uint32_t swapchainCount_ = 0, const PresentRegionKHR* pRegions_ = nullptr )
+      : sType( StructureType::ePresentRegionsKHR )
+      , pNext( nullptr )
+      , swapchainCount( swapchainCount_ )
+      , pRegions( pRegions_ )
+    {
+    }
+
+    PresentRegionsKHR( VkPresentRegionsKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PresentRegionsKHR) );
+    }
+
+    PresentRegionsKHR& operator=( VkPresentRegionsKHR const & rhs )
+    {
+      memcpy( this, &rhs, sizeof(PresentRegionsKHR) );
+      return *this;
+    }
+
+    PresentRegionsKHR& setPNext( const void* pNext_ )
+    {
+      pNext = pNext_;
+      return *this;
+    }
+
+    PresentRegionsKHR& setSwapchainCount( uint32_t swapchainCount_ )
+    {
+      swapchainCount = swapchainCount_;
+      return *this;
+    }
+
+    PresentRegionsKHR& setPRegions( const PresentRegionKHR* pRegions_ )
+    {
+      pRegions = pRegions_;
+      return *this;
+    }
+
+    operator const VkPresentRegionsKHR&() const
+    {
+      return *reinterpret_cast<const VkPresentRegionsKHR*>(this);
+    }
+
+    bool operator==( PresentRegionsKHR const& rhs ) const
+    {
+      return ( sType == rhs.sType )
+          && ( pNext == rhs.pNext )
+          && ( swapchainCount == rhs.swapchainCount )
+          && ( pRegions == rhs.pRegions );
+    }
+
+    bool operator!=( PresentRegionsKHR const& rhs ) const
+    {
+      return !operator==( rhs );
+    }
+
+  private:
+    StructureType sType;
+
+  public:
+    const void* pNext;
+    uint32_t swapchainCount;
+    const PresentRegionKHR* pRegions;
+  };
+  static_assert( sizeof( PresentRegionsKHR ) == sizeof( VkPresentRegionsKHR ), "struct and wrapper have different size!" );
+
   struct PhysicalDeviceIDPropertiesKHX
   {
     operator const VkPhysicalDeviceIDPropertiesKHX&() const
@@ -10064,7 +10245,7 @@ namespace vk
   };
   static_assert( sizeof( PhysicalDeviceIDPropertiesKHX ) == sizeof( VkPhysicalDeviceIDPropertiesKHX ), "struct and wrapper have different size!" );
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHX
   struct ExportMemoryWin32HandleInfoKHX
   {
     ExportMemoryWin32HandleInfoKHX( const SECURITY_ATTRIBUTES* pAttributes_ = nullptr, DWORD dwAccess_ = 0, LPCWSTR name_ = 0 )
@@ -10140,9 +10321,9 @@ namespace vk
     LPCWSTR name;
   };
   static_assert( sizeof( ExportMemoryWin32HandleInfoKHX ) == sizeof( VkExportMemoryWin32HandleInfoKHX ), "struct and wrapper have different size!" );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#endif /*VK_USE_PLATFORM_WIN32_KHX*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHX
   struct MemoryWin32HandlePropertiesKHX
   {
     operator const VkMemoryWin32HandlePropertiesKHX&() const
@@ -10170,7 +10351,7 @@ namespace vk
     uint32_t memoryTypeBits;
   };
   static_assert( sizeof( MemoryWin32HandlePropertiesKHX ) == sizeof( VkMemoryWin32HandlePropertiesKHX ), "struct and wrapper have different size!" );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#endif /*VK_USE_PLATFORM_WIN32_KHX*/
 
   struct MemoryFdPropertiesKHX
   {
@@ -11839,7 +12020,7 @@ namespace vk
       return *this;
     }
 
-    PhysicalDeviceDiscardRectanglePropertiesEXT& setPNext( const void* pNext_ )
+    PhysicalDeviceDiscardRectanglePropertiesEXT& setPNext( void* pNext_ )
     {
       pNext = pNext_;
       return *this;
@@ -11872,7 +12053,7 @@ namespace vk
     StructureType sType;
 
   public:
-    const void* pNext;
+    void* pNext;
     uint32_t maxDiscardRectangles;
   };
   static_assert( sizeof( PhysicalDeviceDiscardRectanglePropertiesEXT ) == sizeof( VkPhysicalDeviceDiscardRectanglePropertiesEXT ), "struct and wrapper have different size!" );
@@ -17780,7 +17961,8 @@ namespace vk
     eDisplayKhr = VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT,
     eDisplayModeKhr = VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT,
     eObjectTableNvx = VK_DEBUG_REPORT_OBJECT_TYPE_OBJECT_TABLE_NVX_EXT,
-    eIndirectCommandsLayoutNvx = VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT
+    eIndirectCommandsLayoutNvx = VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT,
+    eDescriptorUpdateTemplateKhrKHR = VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR_EXT
   };
 
   struct DebugMarkerObjectNameInfoEXT
@@ -19607,7 +19789,7 @@ namespace vk
   };
   static_assert( sizeof( ExportMemoryAllocateInfoKHX ) == sizeof( VkExportMemoryAllocateInfoKHX ), "struct and wrapper have different size!" );
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHX
   struct ImportMemoryWin32HandleInfoKHX
   {
     ImportMemoryWin32HandleInfoKHX( ExternalMemoryHandleTypeFlagBitsKHX handleType_ = ExternalMemoryHandleTypeFlagBitsKHX::eOpaqueFd, HANDLE handle_ = 0 )
@@ -19674,7 +19856,7 @@ namespace vk
     HANDLE handle;
   };
   static_assert( sizeof( ImportMemoryWin32HandleInfoKHX ) == sizeof( VkImportMemoryWin32HandleInfoKHX ), "struct and wrapper have different size!" );
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#endif /*VK_USE_PLATFORM_WIN32_KHX*/
 
   struct ImportMemoryFdInfoKHX
   {
@@ -23280,19 +23462,19 @@ namespace vk
     void trimCommandPoolKHR( CommandPool commandPool, CommandPoolTrimFlagsKHR flags = CommandPoolTrimFlagsKHR() ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHX
     Result getMemoryWin32HandleKHX( DeviceMemory memory, ExternalMemoryHandleTypeFlagBitsKHX handleType, HANDLE* pHandle ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     ResultValueType<HANDLE>::type getMemoryWin32HandleKHX( DeviceMemory memory, ExternalMemoryHandleTypeFlagBitsKHX handleType ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#endif /*VK_USE_PLATFORM_WIN32_KHX*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHX
     Result getMemoryWin32HandlePropertiesKHX( ExternalMemoryHandleTypeFlagBitsKHX handleType, HANDLE handle, MemoryWin32HandlePropertiesKHX* pMemoryWin32HandleProperties ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     ResultValueType<MemoryWin32HandlePropertiesKHX>::type getMemoryWin32HandlePropertiesKHX( ExternalMemoryHandleTypeFlagBitsKHX handleType, HANDLE handle ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#endif /*VK_USE_PLATFORM_WIN32_KHX*/
 
     Result getMemoryFdKHX( DeviceMemory memory, ExternalMemoryHandleTypeFlagBitsKHX handleType, int* pFd ) const;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -25231,7 +25413,7 @@ namespace vk
     vkTrimCommandPoolKHR( m_device, static_cast<VkCommandPool>( commandPool ), static_cast<VkCommandPoolTrimFlagsKHR>( flags ) );
   }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHX
   VULKAN_HPP_INLINE Result Device::getMemoryWin32HandleKHX( DeviceMemory memory, ExternalMemoryHandleTypeFlagBitsKHX handleType, HANDLE* pHandle ) const
   {
     return static_cast<Result>( vkGetMemoryWin32HandleKHX( m_device, static_cast<VkDeviceMemory>( memory ), static_cast<VkExternalMemoryHandleTypeFlagBitsKHX>( handleType ), pHandle ) );
@@ -25244,9 +25426,9 @@ namespace vk
     return createResultValue( result, handle, "vk::Device::getMemoryWin32HandleKHX" );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#endif /*VK_USE_PLATFORM_WIN32_KHX*/
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHX
   VULKAN_HPP_INLINE Result Device::getMemoryWin32HandlePropertiesKHX( ExternalMemoryHandleTypeFlagBitsKHX handleType, HANDLE handle, MemoryWin32HandlePropertiesKHX* pMemoryWin32HandleProperties ) const
   {
     return static_cast<Result>( vkGetMemoryWin32HandlePropertiesKHX( m_device, static_cast<VkExternalMemoryHandleTypeFlagBitsKHX>( handleType ), handle, reinterpret_cast<VkMemoryWin32HandlePropertiesKHX*>( pMemoryWin32HandleProperties ) ) );
@@ -25259,7 +25441,7 @@ namespace vk
     return createResultValue( result, memoryWin32HandleProperties, "vk::Device::getMemoryWin32HandlePropertiesKHX" );
   }
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#endif /*VK_USE_PLATFORM_WIN32_KHX*/
 
   VULKAN_HPP_INLINE Result Device::getMemoryFdKHX( DeviceMemory memory, ExternalMemoryHandleTypeFlagBitsKHX handleType, int* pFd ) const
   {
@@ -28641,6 +28823,7 @@ namespace vk
     case StructureType::eD3D12FenceSubmitInfoKHX: return "D3D12FenceSubmitInfoKHX";
     case StructureType::eImportSemaphoreFdInfoKHX: return "ImportSemaphoreFdInfoKHX";
     case StructureType::ePhysicalDevicePushDescriptorPropertiesKHR: return "PhysicalDevicePushDescriptorPropertiesKHR";
+    case StructureType::ePresentRegionsKHR: return "PresentRegionsKHR";
     case StructureType::eDescriptorUpdateTemplateCreateInfoKHR: return "DescriptorUpdateTemplateCreateInfoKHR";
     case StructureType::eObjectTableCreateInfoNVX: return "ObjectTableCreateInfoNVX";
     case StructureType::eIndirectCommandsLayoutCreateInfoNVX: return "IndirectCommandsLayoutCreateInfoNVX";
@@ -29625,6 +29808,7 @@ namespace vk
     case DebugReportObjectTypeEXT::eDisplayModeKhr: return "DisplayModeKhr";
     case DebugReportObjectTypeEXT::eObjectTableNvx: return "ObjectTableNvx";
     case DebugReportObjectTypeEXT::eIndirectCommandsLayoutNvx: return "IndirectCommandsLayoutNvx";
+    case DebugReportObjectTypeEXT::eDescriptorUpdateTemplateKhrKHR: return "DescriptorUpdateTemplateKhrKHR";
     default: return "invalid";
     }
   }

--- a/layers/linux/VkLayer_core_validation.json
+++ b/layers/linux/VkLayer_core_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_core_validation",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_core_validation.so",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_object_tracker.json
+++ b/layers/linux/VkLayer_object_tracker.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_object_tracker",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_object_tracker.so",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_parameter_validation.json
+++ b/layers/linux/VkLayer_parameter_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_parameter_validation",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_parameter_validation.so",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_swapchain.json
+++ b/layers/linux/VkLayer_swapchain.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_swapchain",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_swapchain.so",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_threading.json
+++ b/layers/linux/VkLayer_threading.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_threading",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_threading.so",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "Google Validation Layer",
         "instance_extensions": [

--- a/layers/linux/VkLayer_unique_objects.json
+++ b/layers/linux/VkLayer_unique_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_unique_objects",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_unique_objects.so",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "Google Validation Layer"
     }

--- a/layers/object_tracker.cpp
+++ b/layers/object_tracker.cpp
@@ -3403,11 +3403,11 @@ static void CheckDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHX_EXTERNAL_MEMORY_FD_EXTENSION_NAME) == 0) {
             device_data->enables.khx_external_memory_fd = true;
         }
-#ifdef VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHX
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHX_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME) == 0) {
             device_data->enables.khx_external_memory_win32 = true;
         }
-#endif  // VK_USE_PLATFORM_WIN32_KHR
+#endif  // VK_USE_PLATFORM_WIN32_KHX
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHX_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME) == 0) {
             device_data->enables.khx_external_semaphore_fd = true;
         }

--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -98,6 +98,7 @@ struct layer_data {
             bool nv_external_memory : 1;
             bool nv_external_memory_win32 : 1;
             bool nvx_device_generated_commands : 1;
+            bool incremental_present : 1;
         };
         uint64_t padding[4];
     } enables;
@@ -1675,6 +1676,8 @@ static void CheckDeviceRegisterExtensions(const VkDeviceCreateInfo *pCreateInfo,
 #endif
         } else if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_NVX_DEVICE_GENERATED_COMMANDS_EXTENSION_NAME) == 0) {
             device_data->enables.nvx_device_generated_commands = true;
+        } else if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME) == 0) {
+            device_data->enables.incremental_present = true;
         }
     }
 }
@@ -5180,6 +5183,42 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInf
                                      VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
     skip |= parameter_validation_vkQueuePresentKHR(my_data->report_data, pPresentInfo);
+
+    if (pPresentInfo && pPresentInfo->pNext) {
+        // Verify ext struct
+        struct std_header {
+            VkStructureType sType;
+            const void *pNext;
+        };
+        std_header *pnext = (std_header *)pPresentInfo->pNext;
+        while (pnext) {
+            if (VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR == pnext->sType) {
+                skip |= require_device_extension(my_data, my_data->enables.incremental_present, "vkQueuePresentKHR",
+                                                 VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME);
+                VkPresentRegionsKHR *present_regions = (VkPresentRegionsKHR *)pnext;
+                if (present_regions->swapchainCount != pPresentInfo->swapchainCount) {
+                    skip |= log_msg(my_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0,
+                                    __LINE__, INVALID_USAGE, LayerName,
+                                    "QueuePresentKHR(): pPresentInfo->swapchainCount has a value of %i"
+                                    " but VkPresentRegionsKHR extension swapchainCount is %i. These values must be equal.",
+                                    pPresentInfo->swapchainCount, present_regions->swapchainCount);
+                }
+                skip |= validate_struct_pnext(my_data->report_data, "QueuePresentKHR", "pCreateInfo->pNext->pNext", NULL,
+                                              present_regions->pNext, 0, NULL, GeneratedHeaderVersion);
+                skip |= validate_array(my_data->report_data, "QueuePresentKHR", "pCreateInfo->pNext->swapchainCount",
+                                       "pCreateInfo->pNext->pRegions", present_regions->swapchainCount, present_regions->pRegions,
+                                       true, false);
+                for (uint32_t i = 0; i < present_regions->swapchainCount; ++i) {
+                    skip |=
+                        validate_array(my_data->report_data, "QueuePresentKHR", "pCreateInfo->pNext->pRegions[].rectangleCount",
+                                       "pCreateInfo->pNext->pRegions[].pRectangles", present_regions->pRegions[i].rectangleCount,
+                                       present_regions->pRegions[i].pRectangles, true, false);
+                }
+            }
+            pnext = (std_header *)pnext->pNext;
+        }
+    }
+
     if (!skip) {
         result = my_data->dispatch_table.QueuePresentKHR(queue, pPresentInfo);
 

--- a/layers/windows/VkLayer_core_validation.json
+++ b/layers/windows/VkLayer_core_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_core_validation",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_core_validation.dll",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_object_tracker.json
+++ b/layers/windows/VkLayer_object_tracker.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_object_tracker",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_object_tracker.dll",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_parameter_validation.json
+++ b/layers/windows/VkLayer_parameter_validation.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_parameter_validation",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_parameter_validation.dll",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_swapchain.json
+++ b/layers/windows/VkLayer_swapchain.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_swapchain",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_swapchain.dll",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_threading.json
+++ b/layers/windows/VkLayer_threading.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_threading",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_threading.dll",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "Google Validation Layer",
         "instance_extensions": [

--- a/layers/windows/VkLayer_unique_objects.json
+++ b/layers/windows/VkLayer_unique_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_GOOGLE_unique_objects",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_unique_objects.dll",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "Google Validation Layer"
     }

--- a/scripts/vk.xml
+++ b/scripts/vk.xml
@@ -112,7 +112,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         <type category="define">// Vulkan 1.0 version number
 #define <name>VK_API_VERSION_1_0</name> <type>VK_MAKE_VERSION</type>(1, 0, 0)</type>    <!-- The patch version here should never be set to anything other than 0 -->
         <type category="define">// Version of this file
-#define <name>VK_HEADER_VERSION</name> 45</type>
+#define <name>VK_HEADER_VERSION</name> 46</type>
 
         <type category="define">
 #define <name>VK_DEFINE_HANDLE</name>(object) typedef struct object##_T* object;</type>
@@ -1564,7 +1564,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkPresentInfoKHR">
             <member values="VK_STRUCTURE_TYPE_PRESENT_INFO_KHR"><type>VkStructureType</type> <name>sType</name></member>
-            <member validextensionstructs="VkDisplayPresentInfoKHR,VkDeviceGroupPresentInfoKHX,VkPresentTimesInfoGOOGLE">const <type>void</type>*  <name>pNext</name></member> <!-- Pointer to next structure -->
+            <member validextensionstructs="VkDisplayPresentInfoKHR,VkPresentRegionsKHR,VkDeviceGroupPresentInfoKHX,VkPresentTimesInfoGOOGLE">const <type>void</type>*  <name>pNext</name></member> <!-- Pointer to next structure -->
             <member optional="true"><type>uint32_t</type>         <name>waitSemaphoreCount</name></member>       <!-- Number of semaphores to wait for before presenting -->
             <member optional="true" len="waitSemaphoreCount">const <type>VkSemaphore</type>* <name>pWaitSemaphores</name></member> <!-- Semaphores to wait for before presenting -->
             <member><type>uint32_t</type>                         <name>swapchainCount</name></member>           <!-- Number of swapchains to present in this call -->
@@ -1580,7 +1580,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member optional="true"><type>void</type>*            <name>pUserData</name></member>                <!-- User data provided to callback function -->
         </type>
         <type category="struct" name="VkValidationFlagsEXT">
-            <member><type>VkStructureType</type>                  <name>sType</name></member>                    <!-- Must be VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT -->
+            <member values="VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT"><type>VkStructureType</type>                  <name>sType</name></member>                    <!-- Must be VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT -->
             <member>const <type>void</type>*                      <name>pNext</name></member>                    <!-- Pointer to next structure -->
             <member><type>uint32_t</type>                         <name>disabledValidationCheckCount</name></member>   <!-- Number of validation checks to disable -->
             <member len="disabledValidationCheckCount"><type>VkValidationCheckEXT</type>* <name>pDisabledValidationChecks</name></member>   <!-- Validation checks to disable -->
@@ -1768,7 +1768,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member><type>VkShaderStageFlags</type>           <name>stageFlags</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceFeatures2KHR">
-            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR"><type>VkStructureType</type><name>sType</name></member>
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member validextensionstructs="VkPhysicalDeviceMultiviewFeaturesKHX"><type>void</type>*                            <name>pNext</name></member>                    <!-- Pointer to next structure -->
             <member><type>VkPhysicalDeviceFeatures</type>         <name>features</name></member>
         </type>
@@ -1824,6 +1824,21 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR"><type>VkStructureType</type> <name>sType</name></member>
             <member><type>void</type>*                            <name>pNext</name></member>                    <!-- Pointer to next structure -->
             <member><type>uint32_t</type>                         <name>maxPushDescriptors</name></member>
+        </type>
+        <type category="struct" name="VkPresentRegionsKHR">
+            <member values="VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR"><type>VkStructureType</type> <name>sType</name></member>
+            <member validextensionstructs="VkPresentRegionsKHR,VkDeviceGroupPresentInfoKHX,VkPresentTimesInfoGOOGLE">const <type>void</type>*  <name>pNext</name></member> <!-- Pointer to next structure -->
+            <member><type>uint32_t</type>                         <name>swapchainCount</name></member>           <!-- Copy of VkPresentInfoKHR::swapchainCount -->
+            <member len="swapchainCount" optional="true">const <type>VkPresentRegionKHR</type>*   <name>pRegions</name></member>       <!-- The regions that have changed -->
+        </type>
+        <type category="struct" name="VkPresentRegionKHR">
+            <member optional="true"><type>uint32_t</type>         <name>rectangleCount</name></member>           <!-- Number of rectangles in pRectangles -->
+            <member optional="true" len="rectangleCount">const <type>VkRectLayerKHR</type>*   <name>pRectangles</name></member>  <!-- Array of rectangles that have changed in a swapchain's image(s) -->
+        </type>
+        <type category="struct" name="VkRectLayerKHR">
+            <member><type>VkOffset2D</type>                       <name>offset</name></member>                   <!-- upper-left corner of a rectangle that has not changed, in pixels of a presentation images -->
+            <member><type>VkExtent2D</type>                       <name>extent</name></member>                   <!-- Dimensions of a rectangle that has not changed, in pixels of a presentation images -->
+            <member><type>uint32_t</type>                         <name>layer</name></member>                    <!-- Layer of a swapchain's image(s), for stereoscopic-3D images -->
         </type>
         <type category="struct" name="VkExternalMemoryPropertiesKHX" returnedonly="true">
             <member><type>VkExternalMemoryFeatureFlagsKHX</type>  <name>externalMemoryFeatures</name></member>
@@ -2222,7 +2237,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </type>
         <type category="struct" name="VkPhysicalDeviceDiscardRectanglePropertiesEXT">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member>const <type>void</type>*            <name>pNext</name></member>                          <!-- Pointer to next structure -->
+            <member><type>void</type>*                  <name>pNext</name></member>                          <!-- Pointer to next structure -->
             <member><type>uint32_t</type>               <name>maxDiscardRectangles</name></member>           <!-- max number of active discard rectangles -->
         </type>
         <type category="struct" name="VkPipelineDiscardRectangleStateCreateInfoEXT">
@@ -4520,10 +4535,10 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <param len="descriptorWriteCount">const <type>VkWriteDescriptorSet</type>* <name>pDescriptorWrites</name></param>
         </command>
         <command>
-             <proto><type>void</type> <name>vkTrimCommandPoolKHR</name></proto>
-             <param><type>VkDevice</type> <name>device</name></param>
-             <param externsync="true"><type>VkCommandPool</type> <name>commandPool</name></param>
-             <param optional="true"><type>VkCommandPoolTrimFlagsKHR</type> <name>flags</name></param>
+            <proto><type>void</type> <name>vkTrimCommandPoolKHR</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param externsync="true"><type>VkCommandPool</type> <name>commandPool</name></param>
+            <param optional="true"><type>VkCommandPoolTrimFlagsKHR</type> <name>flags</name></param>
         </command>
         <command>
             <proto><type>void</type> <name>vkGetPhysicalDeviceExternalBufferPropertiesKHX</name></proto>
@@ -4769,11 +4784,11 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <param><type>VkSurfaceKHR</type>* <name>pSurface</name></param>
         </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary">
-          <proto><type>void</type> <name>vkCmdSetViewportWScalingNV</name></proto>
-          <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
-          <param><type>uint32_t</type> <name>firstViewport</name></param>
-          <param><type>uint32_t</type> <name>viewportCount</name></param>
-          <param len="viewportCount" noautovalidity="true">const <type>VkViewportWScalingNV</type>* <name>pViewportWScalings</name></param>
+            <proto><type>void</type> <name>vkCmdSetViewportWScalingNV</name></proto>
+            <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
+            <param><type>uint32_t</type> <name>firstViewport</name></param>
+            <param><type>uint32_t</type> <name>viewportCount</name></param>
+            <param len="viewportCount" noautovalidity="true">const <type>VkViewportWScalingNV</type>* <name>pViewportWScalings</name></param>
         </command>
         <command queues="graphics" renderpass="both" cmdbufferlevel="primary,secondary">
             <proto><type>void</type> <name>vkCmdSetDiscardRectangleEXT</name></proto>
@@ -5154,7 +5169,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
         </extension>
         <extension name="VK_EXT_debug_report" number="12" type="instance" author="GOOGLE" contact="Courtney Goeltzenleuchter @courtney" supported="vulkan">
             <require>
-                <enum value="5"                                         name="VK_EXT_DEBUG_REPORT_SPEC_VERSION"/>
+                <enum value="6"                                         name="VK_EXT_DEBUG_REPORT_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_debug_report&quot;"           name="VK_EXT_DEBUG_REPORT_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT"/>
                 <enum offset="1" dir="-" extends="VkResult"             name="VK_ERROR_VALIDATION_FAILED_EXT"/>
@@ -5709,7 +5724,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <type name="VkExportMemoryAllocateInfoKHX"/>
             </require>
         </extension>
-        <extension name="VK_KHX_external_memory_win32" number="74" type="device" requires="VK_KHX_external_memory_capabilities,VK_KHX_external_memory" author="KHX" contact="James Jones @cubanismo" protect="VK_USE_PLATFORM_WIN32_KHR" supported="vulkan">
+        <extension name="VK_KHX_external_memory_win32" number="74" type="device" requires="VK_KHX_external_memory_capabilities,VK_KHX_external_memory" author="KHX" contact="James Jones @cubanismo" protect="VK_USE_PLATFORM_WIN32_KHX" supported="vulkan">
             <require>
                 <enum value="1"                                         name="VK_KHX_EXTERNAL_MEMORY_WIN32_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHX_external_memory_win32&quot;"  name="VK_KHX_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME"/>
@@ -5820,10 +5835,14 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum value="&quot;VK_KHR_extension_84&quot;"           name="VK_KHR_EXTENSION_84_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_KHR_extension_85" number="85" author="KHR" contact="Ian Elliott @ianelliott" supported="disabled">
+        <extension name="VK_KHR_incremental_present" number="85" type="device" author="KHR" requires="VK_KHR_swapchain" contact="Ian Elliott ianelliott@google.com" supported="vulkan">
             <require>
-                <enum value="0"                                         name="VK_KHR_EXTENSION_85_SPEC_VERSION"/>
-                <enum value="&quot;VK_KHR_extension_85&quot;"           name="VK_KHR_EXTENSION_85_EXTENSION_NAME"/>
+                <enum value="1"                                         name="VK_KHR_INCREMENTAL_PRESENT_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_incremental_present&quot;"    name="VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME"/>
+                <enum offset="0"         extends="VkStructureType"      name="VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR"/>
+                <type name="VkPresentRegionsKHR"/>
+                <type name="VkPresentRegionKHR"/>
+                <type name="VkRectLayerKHR"/>
             </require>
         </extension>
         <extension name="VK_KHR_descriptor_update_template" number="86" type="device" author="KHR" contact="Markus Tavenrath @mtavenrath" supported="vulkan">
@@ -5831,10 +5850,12 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <enum value="1"                                         name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_descriptor_update_template&quot;" name="VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"              name="VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO_KHR"/>
+                <enum offset="0" extends="VkDebugReportObjectTypeEXT"   name="VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR_EXT"/>
                 <command name="vkCreateDescriptorUpdateTemplateKHR"/>
                 <command name="vkDestroyDescriptorUpdateTemplateKHR"/>
                 <command name="vkUpdateDescriptorSetWithTemplateKHR"/>
                 <command name="vkCmdPushDescriptorSetWithTemplateKHR"/>
+                <type name="VkDescriptorUpdateTemplateKHR"/>
                 <type name="VkDescriptorUpdateTemplateCreateFlagsKHR"/>
                 <type name="VkDescriptorUpdateTemplateTypeKHR"/>
                 <type name="VkDescriptorUpdateTemplateEntryKHR"/>
@@ -5885,7 +5906,7 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
                 <command name="vkRegisterObjectsNVX"/>
                 <command name="vkUnregisterObjectsNVX"/>
                 <command name="vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX"/>
-          </require>
+            </require>
         </extension>
         <extension name="VK_NV_clip_space_w_scaling" number="88" type="device" author="NV" contact="Eric Werness @ewerness" supported="vulkan">
             <require>
@@ -6232,6 +6253,96 @@ maintained in the master branch of the Khronos Vulkan GitHub project.
             <require>
                 <enum value="0"                                         name="VK_KHR_EXTENSION_132_SPEC_VERSION"/>
                 <enum value="&quot;VK_KHR_extension_132&quot;"          name="VK_KHR_EXTENSION_132_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_133" number="133" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_133_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_133&quot;"           name="VK_AMD_EXTENSION_133_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_134" number="134" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_134_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_134&quot;"           name="VK_AMD_EXTENSION_134_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_135" number="135" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_135_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_135&quot;"           name="VK_AMD_EXTENSION_135_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_136" number="136" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_136_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_136&quot;"           name="VK_AMD_EXTENSION_136_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_137" number="137" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_137_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_137&quot;"           name="VK_AMD_EXTENSION_137_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_138" number="138" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_138_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_138&quot;"           name="VK_AMD_EXTENSION_138_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_139" number="139" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_139_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_139&quot;"           name="VK_AMD_EXTENSION_139_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_140" number="140" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_140_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_140&quot;"           name="VK_AMD_EXTENSION_140_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_141" number="141" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_141_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_141&quot;"           name="VK_AMD_EXTENSION_141_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_142" number="142" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_142_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_142&quot;"           name="VK_AMD_EXTENSION_142_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_143" number="143" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_143_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_143&quot;"           name="VK_AMD_EXTENSION_143_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_AMD_extension_144" number="144" author="AMD" contact="Mais Alnasser @malnasse" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_AMD_EXTENSION_144_SPEC_VERSION"/>
+                <enum value="&quot;VK_AMD_extension_144&quot;"           name="VK_AMD_EXTENSION_144_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_relaxed_block_layout" number="145" author="KHR" contact="John Kessenich @johnk" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_KHR_relaxed_block_layout_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_relaxed_block_layout&quot;"    name="VK_KHR_relaxed_block_layout_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_146" number="146" author="KHR" contact="Bill Licea-Kane @billl" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_KHR_extension_146_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_146&quot;"    name="VK_KHR_extension_146_EXTENSION_NAME"/>
+            </require>
+        </extension>
+        <extension name="VK_KHR_extension_147" number="147" author="KHR" contact="Jason Ekstrand @jekstrand" supported="disabled">
+            <require>
+                <enum value="0"                                          name="VK_KHR_extension_147_SPEC_VERSION"/>
+                <enum value="&quot;VK_KHR_extension_147&quot;"           name="VK_KHR_extension_147_EXTENSION_NAME"/>
             </require>
         </extension>
     </extensions>

--- a/tests/layers/linux/VkLayer_test.json
+++ b/tests/layers/linux/VkLayer_test.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_test",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_test.so",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Test Layer",
         "enable_environment": {

--- a/tests/layers/linux/VkLayer_wrap_objects.json
+++ b/tests/layers/linux/VkLayer_wrap_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_wrap_objects",
         "type": "GLOBAL",
         "library_path": "./libVkLayer_wrap_objects.so",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Dispatchable Object Wrapping Layer"
     }

--- a/tests/layers/windows/VkLayer_test.json
+++ b/tests/layers/windows/VkLayer_test.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_test",
         "type": "GLOBAL",
         "library_path": ".\\libVkLayer_test.dll",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Test Layer",
         "enable_environment": {

--- a/tests/layers/windows/VkLayer_wrap_objects.json
+++ b/tests/layers/windows/VkLayer_wrap_objects.json
@@ -4,7 +4,7 @@
         "name": "VK_LAYER_LUNARG_wrap_objects",
         "type": "GLOBAL",
         "library_path": ".\\VkLayer_wrap_objects.dll",
-        "api_version": "1.0.45",
+        "api_version": "1.0.46",
         "implementation_version": "1",
         "description": "LunarG Dispatchable Object Wrapping Layer"
     }


### PR DESCRIPTION
Moved to 1.0.46 version of the header, pulled in new validation checks for the `VK_KHR_incremental_present` extension as well as related demo changes.

This supersedes #1643. 