### PR TITLE
Add code generation for internal layer object type definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,7 @@ add_custom_target(generate_helper_files DEPENDS
     vk_struct_size_helper.c
     vk_safe_struct.h
     vk_safe_struct.cpp
+    vk_object_types.h
     vk_layer_dispatch_table.h
     vk_dispatch_table_helper.h
     )
@@ -291,6 +292,7 @@ run_vk_xml_generate(helper_file_generator.py vk_safe_struct.cpp)
 run_vk_xml_generate(helper_file_generator.py vk_struct_size_helper.h)
 run_vk_xml_generate(helper_file_generator.py vk_struct_size_helper.c)
 run_vk_xml_generate(helper_file_generator.py vk_enum_string_helper.h)
+run_vk_xml_generate(helper_file_generator.py vk_object_types.h)
 
 if(NOT WIN32)
     include(GNUInstallDirs)

--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -25,6 +25,7 @@ py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_safe_st
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_struct_size_helper.h
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_struct_size_helper.c
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_enum_string_helper.h
+py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_object_types.h
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_dispatch_table_helper.h
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml thread_check.h
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml parameter_validation.h

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -26,6 +26,7 @@ mkdir -p generated/include generated/common
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_struct_size_helper.h )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_struct_size_helper.c )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_enum_string_helper.h )
+( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_object_types.h )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_dispatch_table_helper.h )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml thread_check.h )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml parameter_validation.h )

--- a/scripts/lvl_genvk.py
+++ b/scripts/lvl_genvk.py
@@ -357,6 +357,29 @@ def makeGenOpts(extensions = [], removeExtensions = [], protect = True, director
             helper_file_type  = 'safe_struct_source')
         ]
 
+    # Helper file generator options for vk_object_types.h
+    genOpts['vk_object_types.h'] = [
+          HelperFileOutputGenerator,
+          HelperFileOutputGeneratorOptions(
+            filename          = 'vk_object_types.h',
+            directory         = directory,
+            apiname           = 'vulkan',
+            profile           = None,
+            versions          = allVersions,
+            emitversions      = allVersions,
+            defaultExtensions = 'vulkan',
+            addExtensions     = addExtensions,
+            removeExtensions  = removeExtensions,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            protectFeature    = False,
+            apicall           = 'VKAPI_ATTR ',
+            apientry          = 'VKAPI_CALL ',
+            apientryp         = 'VKAPI_PTR *',
+            alignFuncParam    = 48,
+            helper_file_type  = 'object_types_header')
+        ]
+
+
 # Generate a target based on the options in the matching genOpts{} object.
 # This is encapsulated in a function so it can be profiled and/or timed.
 # The args parameter is an parsed argument object containing the following


### PR DESCRIPTION
We have been using the DebugReportObjectType enums in the layers to handle object types.  This worked fine until extensions began adding new objects.  New object type enum entries are added via the 'extends' mechanism in the spec generator, meaning that the integer values for the new types start in the billion-range leading to very sparse arrays and greatly complication their usage for validation layers.

The purpose of this PR is to have the build generate a header file containing the definition of a packed enumerated type covering all of the defined Vulkan Objects, along with a conversion routine which will translate one of these enums to the corresponding Vulkan Debug Report object type. These will not/should not be shared among a layer and any other layer, loader, driver, etc. and are to be used inside validation layers for uses other than log_msg calls.

The code-gen will produce the following file:

```
// *** THIS FILE IS GENERATED - DO NOT EDIT ***
// See helper_file_generator.py for modifications


/***************************************************************************
 *
 * Copyright (c) 2015-2017 The Khronos Group Inc.
 * Copyright (c) 2015-2017 Valve Corporation
 * Copyright (c) 2015-2017 LunarG, Inc.
 * Copyright (c) 2015-2017 Google Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *
 * Author: Mark Lobodzinski <mark@lunarg.com>
 * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
 * Author: Tobin Ehlis <tobine@google.com>
 *
 ****************************************************************************/


#pragma once

#include <vulkan/vulkan.h>

// Object Type enum for validation layer internal object handling
typedef enum VulkanObjectType {
    kVulkanObjectTypeUnknown = 0,
    kVulkanObjectTypeInstance = 1,
    kVulkanObjectTypePhysicalDevice = 2,
    kVulkanObjectTypeDevice = 3,
    kVulkanObjectTypeQueue = 4,
    kVulkanObjectTypeSemaphore = 5,
    kVulkanObjectTypeCommandBuffer = 6,
    kVulkanObjectTypeFence = 7,
    kVulkanObjectTypeDeviceMemory = 8,
    kVulkanObjectTypeBuffer = 9,
    kVulkanObjectTypeImage = 10,
    kVulkanObjectTypeEvent = 11,
    kVulkanObjectTypeQueryPool = 12,
    kVulkanObjectTypeBufferView = 13,
    kVulkanObjectTypeImageView = 14,
    kVulkanObjectTypeShaderModule = 15,
    kVulkanObjectTypePipelineCache = 16,
    kVulkanObjectTypePipelineLayout = 17,
    kVulkanObjectTypeRenderPass = 18,
    kVulkanObjectTypePipeline = 19,
    kVulkanObjectTypeDescriptorSetLayout = 20,
    kVulkanObjectTypeSampler = 21,
    kVulkanObjectTypeDescriptorPool = 22,
    kVulkanObjectTypeDescriptorSet = 23,
    kVulkanObjectTypeFramebuffer = 24,
    kVulkanObjectTypeCommandPool = 25,
    kVulkanObjectTypeSurfaceKHR = 26,
    kVulkanObjectTypeSwapchainKHR = 27,
    kVulkanObjectTypeDisplayKHR = 28,
    kVulkanObjectTypeDisplayModeKHR = 29,
    kVulkanObjectTypeDescriptorUpdateTemplateKHR = 30,
    kVulkanObjectTypeDebugReportCallbackEXT = 31,
    kVulkanObjectTypeObjectTableNVX = 32,
    kVulkanObjectTypeIndirectCommandsLayoutNVX = 33,
    kVulkanObjectTypeMax = 34,
} VulkanObjectType;


// Helper function to get Official Vulkan object type enum from the internal layers version
VkDebugReportObjectTypeEXT GetDebugReportEnum(VulkanObjectType object_type) {

    switch (object_type) {
        case kVulkanObjectTypeUnknown:
            return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;

        case kVulkanObjectTypeInstance:
            return VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT;

        case kVulkanObjectTypePhysicalDevice:
            return VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT;

        case kVulkanObjectTypeDevice:
            return VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT;

        case kVulkanObjectTypeQueue:
            return VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT;

        case kVulkanObjectTypeSemaphore:
            return VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT;

        case kVulkanObjectTypeCommandBuffer:
            return VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT;

        case kVulkanObjectTypeFence:
            return VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT;

        case kVulkanObjectTypeDeviceMemory:
            return VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT;

        case kVulkanObjectTypeBuffer:
            return VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT;

        case kVulkanObjectTypeImage:
            return VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT;

        case kVulkanObjectTypeEvent:
            return VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT;

        case kVulkanObjectTypeQueryPool:
            return VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT;

        case kVulkanObjectTypeBufferView:
            return VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT;

        case kVulkanObjectTypeImageView:
            return VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT;

        case kVulkanObjectTypeShaderModule:
            return VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT;

        case kVulkanObjectTypePipelineCache:
            return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT;

        case kVulkanObjectTypePipelineLayout:
            return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT;

        case kVulkanObjectTypeRenderPass:
            return VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT;

        case kVulkanObjectTypePipeline:
            return VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT;

        case kVulkanObjectTypeDescriptorSetLayout:
            return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT;

        case kVulkanObjectTypeSampler:
            return VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT;

        case kVulkanObjectTypeDescriptorPool:
            return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT;

        case kVulkanObjectTypeDescriptorSet:
            return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT;

        case kVulkanObjectTypeFramebuffer:
            return VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT;

        case kVulkanObjectTypeCommandPool:
            return VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT;

        case kVulkanObjectTypeSurfaceKHR:
            return VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT;

        case kVulkanObjectTypeSwapchainKHR:
            return VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT;

        case kVulkanObjectTypeDisplayKHR:
            return VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT;

        case kVulkanObjectTypeDisplayModeKHR:
            return VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT;

        case kVulkanObjectTypeDescriptorUpdateTemplateKHR:
            return VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_KHR_EXT;

        case kVulkanObjectTypeDebugReportCallbackEXT:
            return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;

        case kVulkanObjectTypeObjectTableNVX:
            return VK_DEBUG_REPORT_OBJECT_TYPE_OBJECT_TABLE_NVX_EXT;

        case kVulkanObjectTypeIndirectCommandsLayoutNVX:
            return VK_DEBUG_REPORT_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NVX_EXT;

        default:
            return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;

    }
}
```