### PR TITLE
Update android packaging

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -225,30 +225,42 @@ This specification describes both how ICDs and layers should be properly
 packaged, and how developers can point to ICDs and layers within their builds.
 
 ## Android Build
-Install the required tools for Linux and Windows covered above, then add the
-following.
+Install the required tools for Linux and Windows covered above, then add the following.
 ### Android Studio
-- Install [Android Studio 2.1](http://tools.android.com/download/studio/canary), latest Preview (tested with 4):
+- Install [Android Studio 2.3](https://developer.android.com/studio/index.html) or later.
 - From the "Welcome to Android Studio" splash screen, add the following components using Configure > SDK Manager:
-  - SDK Platforms > Android N Preview
+  - SDK Platforms > Android 6.0 and newer
+  - SDK Tools > Android SDK Build-Tools
+  - SDK Tools > Android SDK Platform-Tools
+  - SDK Tools > Android SDK Tools
   - SDK Tools > Android NDK
 
-#### Add NDK to path
+#### Add Android specifics to environment
 
 On Linux:
 ```
-export PATH=$HOME/Android/sdk/ndk-bundle:$PATH
+export ANDROID_SDK_HOME=$HOME/Android/sdk
+export ANDROID_NDK_HOME=$HOME/Android/sdk/ndk-bundle
+export PATH=$ANDROID_SDK_HOME:$PATH
+export PATH=$ANDROID_NDK_HOME:$PATH
+export PATH=$ANDROID_SDK_HOME/build-tools/23.0.3:$PATH
 ```
 On Windows:
 ```
+set ANDROID_SDK_HOME=%LOCALAPPDATA%\Android\sdk
+set ANDROID_NDK_HOME=%LOCALAPPDATA%\Android\sdk\ndk-bundle
 set PATH=%LOCALAPPDATA%\Android\sdk\ndk-bundle;%PATH%
 ```
 On OSX:
 ```
-export PATH=$HOME/Library/Android/sdk/ndk-bundle:$PATH
+export ANDROID_SDK_HOME=$HOME/Library/Android/sdk
+export ANDROID_NDK_HOME=$HOME/Library/Android/sdk/ndk-bundle
+export PATH=$ANDROID_NDK_PATH:$PATH
+export PATH=$ANDROID_SDK_HOME/build-tools/23.0.3:$PATH
 ```
+Note: If jarsigner is missing from your platform, you can find it in the Android Studio install.
 ### Additional OSX System Requirements
-Tested on OSX version 10.11.4
+Tested on OSX version 10.12.4
 
  Setup Homebrew and components
 - Follow instructions on [brew.sh](http://brew.sh) to get homebrew installed.
@@ -264,7 +276,18 @@ export PATH=/usr/local/bin:$PATH
 brew install cmake python python3 git
 ```
 ### Build steps for Android
-Use the following to ensure the Android build works.
+Use the following script to build everything in the repo for Android, including validation layers, tests, demos, and APK packaging:
+```
+cd build-android
+./build_all.sh
+```
+Resulting validation layer binaries will be in build-android/libs.
+Test and demo APKs can be installed on production devices with:
+```
+./install_all.sh -s <serial number>
+```
+Note that there are no equivalent scripts on Windows yet, that work needs to be completed.
+The following per platform commands can be used for layer only builds:
 #### Linux and OSX
 Follow the setup steps for Linux or OSX above, then from your terminal:
 ```
@@ -281,23 +304,32 @@ update_external_sources_android.bat
 android-generate.bat
 ndk-build
 ```
-#### Android demos
-Use the following steps to build, install, and run Cube and Tri for Android:
+#### Android tests
+Use the following steps to build, install, and run the layer validation tests for Android:
 ```
-cd demos/android
-android update project -s -p . -t "android-23"
-ndk-build
-ant -buildfile cube debug
-adb install ./cube/bin/NativeActivity-debug.apk
+cd build-android
+./build_all.sh
+adb install -r bin/VulkanLayerValidationTests.apk
+adb shell am start com.example.VulkanLayerValidationTests/android.app.NativeActivity
+
+Alternatively, you can use the test_APK script to install and run the layer validation tests:
+```
+test_APK.sh -s <serial number> -p <plaform name> -f <gtest_filter>
+```
+#### Android demos
+Use the following steps to build, install, and run Cube and Smoke for Android:
+```
+cd build-android
+./build_all.sh
+adb install -r ../demos/android/cube/bin/cube.apk
 adb shell am start com.example.Cube/android.app.NativeActivity
 ```
 To build, install, and run Cube with validation layers, first build layers using steps above, then run:
 ```
-cd demos/android
-android update project -s -p . -t "android-23"
-ndk-build -j
-ant -buildfile cube-with-layers debug
-adb install ./cube-with-layers/bin/NativeActivity-debug.apk
+cd build-android
+./build_all.sh
+adb install -r ../demos/android/cube-with-layers/bin/cube-with-layers.apk
+adb shell am start com.example.CubeWithLayers/android.app.NativeActivity
 adb shell am start -a android.intent.action.MAIN -c android-intent.category.LAUNCH -n com.example.CubeWithLayers/android.app.NativeActivity --es args "--validate"
 ```
 

--- a/build-android/build_all.sh
+++ b/build-android/build_all.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Copyright 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "${ANDROID_SDK_HOME}" ];
+then echo "Please set ANDROID_SDK_HOME, exiting"; exit 1;
+else echo "ANDROID_SDK_HOME is ${ANDROID_SDK_HOME}";
+fi
+
+if [ -z "${ANDROID_NDK_HOME}" ];
+then echo "Please set ANDROID_NDK_HOME, exiting"; exit 1;
+else echo "ANDROID_NDK_HOME is ${ANDROID_NDK_HOME}";
+fi
+
+if [[ $(uname) == "Linux" ]]; then
+    cores=$(nproc) || echo 4
+elif [[ $(uname) == "Darwin" ]]; then
+    cores=$(sysctl -n hw.ncpu) || echo 4
+fi
+
+function findtool() {
+    if [[ ! $(type -t $1) ]]; then
+        echo Command $1 not found, see ../BUILD.md;
+        exit 1;
+    fi
+}
+
+# Check for dependencies
+findtool aapt
+findtool zipalign
+findtool jarsigner
+
+set -ev
+
+LAYER_BUILD_DIR=$PWD
+DEMO_BUILD_DIR=$PWD/../demos/android
+echo LAYER_BUILD_DIR="${LAYER_BUILD_DIR}"
+echo DEMO_BUILD_DIR="${DEMO_BUILD_DIR}"
+
+function create_APK() {
+    aapt package -f -M AndroidManifest.xml -I "$ANDROID_SDK_HOME/platforms/android-23/android.jar" -S res -F bin/$1-unaligned.apk bin/libs
+    # update this logic to detect if key is already there.  If so, use it, otherwise create it.
+    jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android  bin/$1-unaligned.apk androiddebugkey
+    zipalign -f 4 bin/$1-unaligned.apk bin/$1.apk
+}
+
+#
+# build layers
+#
+./update_external_sources_android.sh
+./android-generate.sh
+ndk-build -j $cores
+
+#
+# build VulkanLayerValidationTests APK
+#
+mkdir -p bin/libs/lib
+cp -r $LAYER_BUILD_DIR/libs/* $LAYER_BUILD_DIR/bin/libs/lib/
+create_APK VulkanLayerValidationTests
+
+#
+# build cube APKs (with and without layers)
+#
+(
+pushd $DEMO_BUILD_DIR
+ndk-build -j $cores
+# Package one APK without validation layers
+mkdir -p $DEMO_BUILD_DIR/cube/bin/libs/lib
+cp -r $DEMO_BUILD_DIR/libs/* $DEMO_BUILD_DIR/cube/bin/libs/lib/
+cd $DEMO_BUILD_DIR/cube
+create_APK cube
+# And one with validation layers
+mkdir -p $DEMO_BUILD_DIR/cube-with-layers/bin/libs/lib
+cp -r $DEMO_BUILD_DIR/libs/* $DEMO_BUILD_DIR/cube-with-layers/bin/libs/lib/
+cp -r $LAYER_BUILD_DIR/libs/* $DEMO_BUILD_DIR/cube-with-layers/bin/libs/lib/
+cd $DEMO_BUILD_DIR/cube-with-layers
+create_APK cube-with-layers
+popd
+)
+
+#
+# build Smoke with layers
+#
+# TODO
+
+echo Builds succeeded
+exit 0

--- a/build-android/install_all.sh
+++ b/build-android/install_all.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Copyright 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+#
+# Parse parameters
+#
+
+function printUsage {
+   echo "Supported parameters are:"
+   echo "    -s|--serial <target device serial number> (optional)"
+   echo
+   echo "i.e. ${0##*/} -s <serial number>"
+   exit 1
+}
+
+if [[ $(($# % 2)) -ne 0 ]]
+then
+    echo Parameters must be provided in pairs.
+    echo parameter count = $#
+    echo
+    printUsage
+    exit 1
+fi
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -s|--serial)
+            # include the flag, because we need to leave it off if not provided
+            serial="$2"
+            shift 2
+            ;;
+        -*)
+            # unknown option
+            echo Unknown option: $1
+            echo
+            printUsage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ $serial ]]; then
+    echo serial = "${serial}"
+    serialFlag="-s $serial"
+    if [[ $(adb devices) != *"$serial"* ]]
+    then
+        echo Device not found: "${serial}"
+        echo
+        printUsage
+        exit 1
+    fi
+else
+    echo Using device $(adb get-serialno)
+fi
+
+# Install everything built by build_all.sh
+echo "adb $serialFlag install -r bin/VulkanLayerValidationTests.apk"
+adb $serialFlag install -r bin/VulkanLayerValidationTests.apk
+echo "adb $serialFlag install -r ../demos/android/cube/bin/cube.apk"
+adb $serialFlag install -r ../demos/android/cube/bin/cube.apk
+echo "adb $serialFlag install -r ../demos/android/cube-with-layers/bin/cube-with-layers.apk"
+adb $serialFlag install -r ../demos/android/cube-with-layers/bin/cube-with-layers.apk
+
+exit $?

--- a/build-android/test_APK.sh
+++ b/build-android/test_APK.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+
+# Copyright 2017 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Parse parameters
+#
+
+function printUsage {
+   echo "Supported parameters are:"
+   echo "    -p|--platform <platform> (optional)"
+   echo "    -f|--filter <gtest filter list> (optional)"
+   echo "    -s|--serial <target device serial number> (optional)"
+   echo
+   echo "i.e. ${0##*/} -p <platform> -f <test filter> -s <serial number>"
+   exit 1
+}
+
+if [[ $(($# % 2)) -ne 0 ]]
+then
+    echo Parameters must be provided in pairs.
+    echo parameter count = $#
+    echo
+    printUsage
+    exit 1
+fi
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -p|--platform)
+            platform="$2"
+            shift 2
+            ;;
+        -f|--filter)
+            filter="$2"
+            shift 2
+            ;;
+        -s|--serial)
+            serial="$2"
+            shift 2
+            ;;
+        -*)
+            # unknown option
+            echo Unknown option: $1
+            echo
+            printUsage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ $serial ]]; then
+    serialFlag="-s $serial"
+    if [[ $(adb devices) != *"$serial"* ]]
+    then
+        echo Device not found: "${serial}"
+        echo
+        printUsage
+        exit 1
+    fi
+else
+    echo Using device $(adb get-serialno)
+fi
+
+if [[ -z $platform ]]
+then
+    echo No platform specified.
+    platform="UnspecifiedPlatform"
+fi
+
+if [[ -z $filter ]]
+then
+    echo No filter specified, running all tests.
+    filter="*"
+fi
+
+if [[ $platform ]]; then echo platform = "${platform}"; fi
+if [[ $filter ]]; then echo filter = "${filter}"; fi
+if [[ $serial ]]; then echo serial = "${serial}"; fi
+
+set -ev
+
+#
+# Start up
+#
+
+# Wake up the device
+adb $serialFlag shell input keyevent "KEYCODE_MENU"
+adb $serialFlag shell input keyevent "KEYCODE_HOME"
+
+# Grab our Android test mutex
+# Wait for any existing test runs on the devices
+
+# Blow away the lock if tests run too long, avoiding infinite loop
+lock_seconds=1200                                # Duration in seconds.
+lock_end_time=$(( $(date +%s) + lock_seconds ))  # Calculate end time.
+
+until mkdir /var/tmp/VkLayerValidationTests.$serial.lock
+do
+    sleep 5
+    echo "Waiting for existing Android test to complete on $serial"
+
+    if [ $(date +%s) -gt $lock_end_time ]
+    then
+        echo "Lock timeout reached: $lock_seconds seconds"
+        echo "Deleting /var/tmp/VkLayerValidationTests.$serial.lock"
+        rm -r /var/tmp/VkLayerValidationTests.$serial.lock
+    fi
+done
+
+# Clean up our lock on any exit condition
+function finish {
+   rm -r /var/tmp/VkLayerValidationTests.$serial.lock
+}
+trap finish EXIT
+
+# Clear the log
+adb $serialFlag logcat -c
+
+# Ensure any previous activity has stopped, otherwise it won't run tests
+adb $serialFlag shell am force-stop com.example.VulkanLayerValidationTests
+
+# Remove any existing APK that may have been installed from another host
+# Disable exit on error in case the APK is not present
+set +e
+adb $serialFlag shell pm list packages | grep com.example.VulkanLayerValidationTests
+if [ $? -eq 0 ]
+then
+    adb $serialFlag uninstall com.example.VulkanLayerValidationTests
+fi
+# Re-enable exit on error
+set -e
+
+# Install the current build
+adb $serialFlag install -r bin/VulkanLayerValidationTests.apk
+
+# Kick off the tests with known expection list
+adb $serialFlag shell am start -a android.intent.action.MAIN -c android-intent.category.LAUNCH -n com.example.VulkanLayerValidationTests/android.app.NativeActivity --es args --gtest_filter="${filter}"
+
+#
+# Scrape the log until we get pass/fail/crash
+#
+
+# The following loop will give tests 20 minutes to pass/fail/crash
+seconds=1200                          # Duration in seconds.
+endTime=$(( $(date +%s) + seconds ))  # Calculate end time.
+
+exitCode=-1;
+
+# Disable exit on error, we expect grep to fail multiple times in this loop
+set +e
+
+while [ $(date +%s) -lt $endTime ]; do  # Loop until interval has elapsed.
+
+    # The following line is printed from android_main on success
+    adb $serialFlag logcat -d | grep "==== Tests PASSED ===="
+    if [ $? -eq 0 ]
+    then
+        echo VulkanLayerValidationTests PASSED!
+        exitCode=0
+        break
+    fi
+
+    # The following line is printed from android_main on failure
+    adb $serialFlag logcat -d | grep "==== Tests FAILED ===="
+    if [ $? -eq 0 ]
+    then
+        echo VulkanLayerValidationTests FAILED!
+        exitCode=1
+        break
+    fi
+
+    # developer.android.com recommends searching for the following string to detect native crash
+    adb $serialFlag logcat -d | grep "\*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\* \*\*\*"
+    if [ $? -eq 0 ]
+    then
+        exitCode=2
+        echo VulkanLayerValidationTests CRASHED!
+        break
+    fi
+
+    sleep 5
+
+done
+
+# Re-enable exit on error
+set -e
+
+if [ $exitCode -eq -1 ]
+then
+    echo "VulkanLayerValidationTests hasn't completed in $seconds seconds. Script exiting."
+fi
+
+#
+# Cleanup
+#
+
+# Return to home screen to clear any error pop-ups
+adb $serialFlag shell input keyevent "KEYCODE_HOME"
+
+# Stop the activity
+adb $serialFlag shell am force-stop com.example.VulkanLayerValidationTests
+
+today=$(date +%Y-%m-%d.%H:%M:%S)
+outFile="VulkanLayerValidationTests.$platform.$today.out.txt"
+errFile="VulkanLayerValidationTests.$platform.$today.err.txt"
+adb $serialFlag pull /sdcard/Android/data/com.example.VulkanLayerValidationTests/files/out.txt VulkanLayerValidationTests.$platform.$today.out.txt
+adb $serialFlag pull /sdcard/Android/data/com.example.VulkanLayerValidationTests/files/err.txt VulkanLayerValidationTests.$platform.$today.err.txt
+
+if [ -f $outFile ]; then
+    echo $outFile size $(wc -c < $outFile)
+fi
+
+if [ -f $errFile ]; then
+    echo $errFile size $(wc -c < $errFile)
+fi
+
+echo
+echo ===== Dumping logcat of VulkanLayerValidationTests =====
+echo If the test is crashing, be sure to inspect full log for complete stack trace.
+echo "adb $serialFlag logcat -d | grep VulkanLayerValidationTests"
+echo ========================================================
+echo
+adb $serialFlag logcat -d | grep VulkanLayerValidationTests
+
+exit $exitCode


### PR DESCRIPTION
This Android series:

- Adds a new script that handles APK packaging with the latest Android SDK, addressing issue #1551 (build_all.sh)
- Adds a script that we've used internally to validate layers on production devices (test_APK.sh)
- Adds a convenience script that installs test and Cube APKs (install_all.sh)
- Updates documentation for Android builds.