### PR TITLE
cube: Throttle rendering rather than presentation

### DIFF
--- a/demos/cube.cpp
+++ b/demos/cube.cpp
@@ -434,13 +434,13 @@ struct Demo {
     }
 
     void draw() {
-        // Ensure no more than FRAME_LAG presentations are outstanding
+        // Ensure no more than FRAME_LAG renderings are outstanding
         device.waitForFences(1, &fences[frame_index], VK_TRUE, UINT64_MAX);
         device.resetFences(1, &fences[frame_index]);
 
         // Get the index of the next available swapchain image:
-        auto result = device.acquireNextImageKHR(swapchain, UINT64_MAX, image_acquired_semaphores[frame_index], fences[frame_index],
-                                                 &current_buffer);
+        auto result = device.acquireNextImageKHR(swapchain, UINT64_MAX, image_acquired_semaphores[frame_index],
+                                                 vk::Fence(), &current_buffer);
         if (result == vk::Result::eErrorOutOfDateKHR) {
             // swapchain is out of date (e.g. the window was resized) and
             // must be recreated:
@@ -471,7 +471,7 @@ struct Demo {
                                      .setSignalSemaphoreCount(1)
                                      .setPSignalSemaphores(&draw_complete_semaphores[frame_index]);
 
-        result = graphics_queue.submit(1, &submit_info, vk::Fence());
+        result = graphics_queue.submit(1, &submit_info, fences[frame_index]);
         VERIFY(result == vk::Result::eSuccess);
 
         if (separate_present_queue) {


### PR DESCRIPTION
It is currently impossible to reliably throttle presentation per the
Vulkan spec.

The previous code was relying on fences returned by
vkAcquireNextImageKHR() to throttle.  The only information this fence
holds is whether it is possible to render to that image since the *last
time* it was presented, which could have happened several frames ago.

Instead, we can throttle the rendering by passing a fence to
vkQueueSubmit().

The previous code (only the cube.c version) was using a fence there to
synchronize a vkMapMemory() in demo_update_data_buffer(), which doesn't
seem necessary.

Before this commit, we were effectively throttling to the number of
frames in the swapchain rather than on FRAME_LAG.

In the FIFO present mode, this could schedule too much work in the
presentation channel (since we have to account for VBLANK events)
and thus causing undesired side effects, such as stutters when trying
to move the cube window on a desktop, which is I assume why the
throttle code was added in the first place.