### PR TITLE
layers: Update VU1426 test conditions

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3035,6 +3035,8 @@ static bool verifyPipelineCreateState(layer_data *dev_data, std::vector<PIPELINE
     }
 
     if (pPipeline->graphicsPipelineCI.pTessellationState &&
+        (pPipeline->active_shaders & VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT) &&
+        (pPipeline->active_shaders & VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) &&
         ((pPipeline->graphicsPipelineCI.pTessellationState->patchControlPoints == 0) ||
          (pPipeline->graphicsPipelineCI.pTessellationState->patchControlPoints >
           dev_data->phys_dev_properties.properties.limits.maxTessellationPatchSize))) {


### PR DESCRIPTION
The 1.0.47 spec added language to clarify that pTessellationState is ignored
in pipelines where tess control/eval stages are inactive. See issue #1411
for details.