### PR TITLE
Suppress Errors/Warnings for GetPhysDevFormatProperties calls returning INVALID_FORMAT

### DIFF
--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -1404,7 +1404,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(VkInstance instance, uin
 
     if (!skip) {
         result = my_data->dispatch_table.EnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices);
-        validate_result(my_data->report_data, "vkEnumeratePhysicalDevices", result);
+        validate_result(my_data->report_data, "vkEnumeratePhysicalDevices", {}, result);
     }
     return result;
 }
@@ -1450,7 +1450,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties(VkPhysical
         result = my_data->dispatch_table.GetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags,
                                                                                 pImageFormatProperties);
 
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceImageFormatProperties", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceImageFormatProperties", {}, result);
     }
 
     return result;
@@ -1644,7 +1644,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevice, con
 
         result = fpCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice);
 
-        validate_result(my_instance_data->report_data, "vkCreateDevice", result);
+        validate_result(my_instance_data->report_data, "vkCreateDevice", {}, result);
 
         if (result == VK_SUCCESS) {
             layer_data *my_device_data = GetLayerDataPtr(get_dispatch_key(*pDevice), layer_data_map);
@@ -1745,7 +1745,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(VkQueue queue, uint32_t submitCount, 
     if (!skip) {
         result = my_data->dispatch_table.QueueSubmit(queue, submitCount, pSubmits, fence);
 
-        validate_result(my_data->report_data, "vkQueueSubmit", result);
+        validate_result(my_data->report_data, "vkQueueSubmit", {}, result);
     }
 
     return result;
@@ -1757,7 +1757,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueWaitIdle(VkQueue queue) {
 
     VkResult result = my_data->dispatch_table.QueueWaitIdle(queue);
 
-    validate_result(my_data->report_data, "vkQueueWaitIdle", result);
+    validate_result(my_data->report_data, "vkQueueWaitIdle", {}, result);
 
     return result;
 }
@@ -1768,7 +1768,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DeviceWaitIdle(VkDevice device) {
 
     VkResult result = my_data->dispatch_table.DeviceWaitIdle(device);
 
-    validate_result(my_data->report_data, "vkDeviceWaitIdle", result);
+    validate_result(my_data->report_data, "vkDeviceWaitIdle", {}, result);
 
     return result;
 }
@@ -1785,7 +1785,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateMemory(VkDevice device, const VkMemoryAll
     if (!skip) {
         result = my_data->dispatch_table.AllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
 
-        validate_result(my_data->report_data, "vkAllocateMemory", result);
+        validate_result(my_data->report_data, "vkAllocateMemory", {}, result);
     }
 
     return result;
@@ -1815,7 +1815,7 @@ VKAPI_ATTR VkResult VKAPI_CALL MapMemory(VkDevice device, VkDeviceMemory memory,
     if (!skip) {
         result = my_data->dispatch_table.MapMemory(device, memory, offset, size, flags, ppData);
 
-        validate_result(my_data->report_data, "vkMapMemory", result);
+        validate_result(my_data->report_data, "vkMapMemory", {}, result);
     }
 
     return result;
@@ -1845,7 +1845,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FlushMappedMemoryRanges(VkDevice device, uint32_t
     if (!skip) {
         result = my_data->dispatch_table.FlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges);
 
-        validate_result(my_data->report_data, "vkFlushMappedMemoryRanges", result);
+        validate_result(my_data->report_data, "vkFlushMappedMemoryRanges", {}, result);
     }
 
     return result;
@@ -1863,7 +1863,7 @@ VKAPI_ATTR VkResult VKAPI_CALL InvalidateMappedMemoryRanges(VkDevice device, uin
     if (!skip) {
         result = my_data->dispatch_table.InvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges);
 
-        validate_result(my_data->report_data, "vkInvalidateMappedMemoryRanges", result);
+        validate_result(my_data->report_data, "vkInvalidateMappedMemoryRanges", {}, result);
     }
 
     return result;
@@ -1894,7 +1894,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory(VkDevice device, VkBuffer buffer
     if (!skip) {
         result = my_data->dispatch_table.BindBufferMemory(device, buffer, memory, memoryOffset);
 
-        validate_result(my_data->report_data, "vkBindBufferMemory", result);
+        validate_result(my_data->report_data, "vkBindBufferMemory", {}, result);
     }
 
     return result;
@@ -1911,7 +1911,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory(VkDevice device, VkImage image, V
     if (!skip) {
         result = my_data->dispatch_table.BindImageMemory(device, image, memory, memoryOffset);
 
-        validate_result(my_data->report_data, "vkBindImageMemory", result);
+        validate_result(my_data->report_data, "vkBindImageMemory", {}, result);
     }
 
     return result;
@@ -2029,7 +2029,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueBindSparse(VkQueue queue, uint32_t bindInfoC
     if (!skip) {
         result = my_data->dispatch_table.QueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
 
-        validate_result(my_data->report_data, "vkQueueBindSparse", result);
+        validate_result(my_data->report_data, "vkQueueBindSparse", {}, result);
     }
 
     return result;
@@ -2047,7 +2047,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(VkDevice device, const VkFenceCreateI
     if (!skip) {
         result = my_data->dispatch_table.CreateFence(device, pCreateInfo, pAllocator, pFence);
 
-        validate_result(my_data->report_data, "vkCreateFence", result);
+        validate_result(my_data->report_data, "vkCreateFence", {}, result);
     }
 
     return result;
@@ -2076,7 +2076,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetFences(VkDevice device, uint32_t fenceCount,
     if (!skip) {
         result = my_data->dispatch_table.ResetFences(device, fenceCount, pFences);
 
-        validate_result(my_data->report_data, "vkResetFences", result);
+        validate_result(my_data->report_data, "vkResetFences", {}, result);
     }
 
     return result;
@@ -2093,7 +2093,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceStatus(VkDevice device, VkFence fence) {
     if (!skip) {
         result = my_data->dispatch_table.GetFenceStatus(device, fence);
 
-        validate_result(my_data->report_data, "vkGetFenceStatus", result);
+        validate_result(my_data->report_data, "vkGetFenceStatus", {}, result);
     }
 
     return result;
@@ -2111,7 +2111,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitForFences(VkDevice device, uint32_t fenceCoun
     if (!skip) {
         result = my_data->dispatch_table.WaitForFences(device, fenceCount, pFences, waitAll, timeout);
 
-        validate_result(my_data->report_data, "vkWaitForFences", result);
+        validate_result(my_data->report_data, "vkWaitForFences", {}, result);
     }
 
     return result;
@@ -2129,7 +2129,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(VkDevice device, const VkSemaphor
     if (!skip) {
         result = my_data->dispatch_table.CreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore);
 
-        validate_result(my_data->report_data, "vkCreateSemaphore", result);
+        validate_result(my_data->report_data, "vkCreateSemaphore", {}, result);
     }
 
     return result;
@@ -2159,7 +2159,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(VkDevice device, const VkEventCreateI
     if (!skip) {
         result = my_data->dispatch_table.CreateEvent(device, pCreateInfo, pAllocator, pEvent);
 
-        validate_result(my_data->report_data, "vkCreateEvent", result);
+        validate_result(my_data->report_data, "vkCreateEvent", {}, result);
     }
 
     return result;
@@ -2188,7 +2188,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetEventStatus(VkDevice device, VkEvent event) {
     if (!skip) {
         result = my_data->dispatch_table.GetEventStatus(device, event);
 
-        validate_result(my_data->report_data, "vkGetEventStatus", result);
+        validate_result(my_data->report_data, "vkGetEventStatus", {}, result);
     }
 
     return result;
@@ -2205,7 +2205,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetEvent(VkDevice device, VkEvent event) {
     if (!skip) {
         result = my_data->dispatch_table.SetEvent(device, event);
 
-        validate_result(my_data->report_data, "vkSetEvent", result);
+        validate_result(my_data->report_data, "vkSetEvent", {}, result);
     }
 
     return result;
@@ -2222,7 +2222,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetEvent(VkDevice device, VkEvent event) {
     if (!skip) {
         result = my_data->dispatch_table.ResetEvent(device, event);
 
-        validate_result(my_data->report_data, "vkResetEvent", result);
+        validate_result(my_data->report_data, "vkResetEvent", {}, result);
     }
 
     return result;
@@ -2256,7 +2256,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(VkDevice device, const VkQueryPoo
     if (!skip) {
         result = device_data->dispatch_table.CreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool);
 
-        validate_result(report_data, "vkCreateQueryPool", result);
+        validate_result(report_data, "vkCreateQueryPool", {}, result);
     }
 
     return result;
@@ -2288,7 +2288,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetQueryPoolResults(VkDevice device, VkQueryPool 
         result =
             my_data->dispatch_table.GetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
 
-        validate_result(my_data->report_data, "vkGetQueryPoolResults", result);
+        validate_result(my_data->report_data, "vkGetQueryPoolResults", {}, result);
     }
 
     return result;
@@ -2351,7 +2351,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(VkDevice device, const VkBufferCreat
     if (!skip) {
         result = device_data->dispatch_table.CreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
 
-        validate_result(report_data, "vkCreateBuffer", result);
+        validate_result(report_data, "vkCreateBuffer", {}, result);
     }
 
     return result;
@@ -2381,7 +2381,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(VkDevice device, const VkBufferV
     if (!skip) {
         result = my_data->dispatch_table.CreateBufferView(device, pCreateInfo, pAllocator, pView);
 
-        validate_result(my_data->report_data, "vkCreateBufferView", result);
+        validate_result(my_data->report_data, "vkCreateBufferView", {}, result);
     }
 
     return result;
@@ -2609,7 +2609,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(VkDevice device, const VkImageCreateI
     if (!skip) {
         result = device_data->dispatch_table.CreateImage(device, pCreateInfo, pAllocator, pImage);
 
-        validate_result(report_data, "vkCreateImage", result);
+        validate_result(report_data, "vkCreateImage", {}, result);
     }
 
     return result;
@@ -2728,7 +2728,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(VkDevice device, const VkImageVie
     if (!skip) {
         result = my_data->dispatch_table.CreateImageView(device, pCreateInfo, pAllocator, pView);
 
-        validate_result(my_data->report_data, "vkCreateImageView", result);
+        validate_result(my_data->report_data, "vkCreateImageView", {}, result);
     }
 
     return result;
@@ -2758,7 +2758,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(VkDevice device, const VkShade
     if (!skip) {
         result = my_data->dispatch_table.CreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule);
 
-        validate_result(my_data->report_data, "vkCreateShaderModule", result);
+        validate_result(my_data->report_data, "vkCreateShaderModule", {}, result);
     }
 
     return result;
@@ -2789,7 +2789,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(VkDevice device, const VkPipe
     if (!skip) {
         result = my_data->dispatch_table.CreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache);
 
-        validate_result(my_data->report_data, "vkCreatePipelineCache", result);
+        validate_result(my_data->report_data, "vkCreatePipelineCache", {}, result);
     }
 
     return result;
@@ -2820,7 +2820,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPipelineCacheData(VkDevice device, VkPipelineC
     if (!skip) {
         result = my_data->dispatch_table.GetPipelineCacheData(device, pipelineCache, pDataSize, pData);
 
-        validate_result(my_data->report_data, "vkGetPipelineCacheData", result);
+        validate_result(my_data->report_data, "vkGetPipelineCacheData", {}, result);
     }
 
     return result;
@@ -2838,7 +2838,7 @@ VKAPI_ATTR VkResult VKAPI_CALL MergePipelineCaches(VkDevice device, VkPipelineCa
     if (!skip) {
         result = my_data->dispatch_table.MergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches);
 
-        validate_result(my_data->report_data, "vkMergePipelineCaches", result);
+        validate_result(my_data->report_data, "vkMergePipelineCaches", {}, result);
     }
 
     return result;
@@ -3404,7 +3404,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice device, VkPipeli
     if (!skip) {
         result = device_data->dispatch_table.CreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos,
                                                                      pAllocator, pPipelines);
-        validate_result(report_data, "vkCreateGraphicsPipelines", result);
+        validate_result(report_data, "vkCreateGraphicsPipelines", {}, result);
     }
 
     return result;
@@ -3439,7 +3439,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, VkPipelin
     if (!skip) {
         result = my_data->dispatch_table.CreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
                                                                 pPipelines);
-        validate_result(my_data->report_data, "vkCreateComputePipelines", result);
+        validate_result(my_data->report_data, "vkCreateComputePipelines", {}, result);
     }
 
     return result;
@@ -3469,7 +3469,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(VkDevice device, const VkPip
     if (!skip) {
         result = my_data->dispatch_table.CreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout);
 
-        validate_result(my_data->report_data, "vkCreatePipelineLayout", result);
+        validate_result(my_data->report_data, "vkCreatePipelineLayout", {}, result);
     }
 
     return result;
@@ -3527,7 +3527,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(VkDevice device, const VkSamplerCre
     if (!skip) {
         result = device_data->dispatch_table.CreateSampler(device, pCreateInfo, pAllocator, pSampler);
 
-        validate_result(report_data, "vkCreateSampler", result);
+        validate_result(report_data, "vkCreateSampler", {}, result);
     }
 
     return result;
@@ -3596,7 +3596,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(VkDevice device, const 
     if (!skip) {
         result = device_data->dispatch_table.CreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout);
 
-        validate_result(report_data, "vkCreateDescriptorSetLayout", result);
+        validate_result(report_data, "vkCreateDescriptorSetLayout", {}, result);
     }
 
     return result;
@@ -3629,7 +3629,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(VkDevice device, const VkDes
     if (!skip) {
         result = my_data->dispatch_table.CreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool);
 
-        validate_result(my_data->report_data, "vkCreateDescriptorPool", result);
+        validate_result(my_data->report_data, "vkCreateDescriptorPool", {}, result);
     }
 
     return result;
@@ -3660,7 +3660,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetDescriptorPool(VkDevice device, VkDescriptor
     if (!skip) {
         result = my_data->dispatch_table.ResetDescriptorPool(device, descriptorPool, flags);
 
-        validate_result(my_data->report_data, "vkResetDescriptorPool", result);
+        validate_result(my_data->report_data, "vkResetDescriptorPool", {}, result);
     }
 
     return result;
@@ -3678,7 +3678,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(VkDevice device, const VkD
     if (!skip) {
         result = my_data->dispatch_table.AllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
 
-        validate_result(my_data->report_data, "vkAllocateDescriptorSets", result);
+        validate_result(my_data->report_data, "vkAllocateDescriptorSets", {}, result);
     }
 
     return result;
@@ -3703,7 +3703,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(VkDevice device, VkDescriptorP
     if (!skip) {
         result = device_data->dispatch_table.FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
-        validate_result(report_data, "vkFreeDescriptorSets", result);
+        validate_result(report_data, "vkFreeDescriptorSets", {}, result);
     }
 
     return result;
@@ -3869,7 +3869,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(VkDevice device, const VkFrameb
     if (!skip) {
         result = my_data->dispatch_table.CreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer);
 
-        validate_result(my_data->report_data, "vkCreateFramebuffer", result);
+        validate_result(my_data->report_data, "vkCreateFramebuffer", {}, result);
     }
 
     return result;
@@ -3926,7 +3926,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(VkDevice device, const VkRenderP
     if (!skip) {
         result = my_data->dispatch_table.CreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
 
-        validate_result(my_data->report_data, "vkCreateRenderPass", result);
+        validate_result(my_data->report_data, "vkCreateRenderPass", {}, result);
     }
 
     return result;
@@ -3971,7 +3971,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(VkDevice device, const VkComman
     if (!skip) {
         result = my_data->dispatch_table.CreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool);
 
-        validate_result(my_data->report_data, "vkCreateCommandPool", result);
+        validate_result(my_data->report_data, "vkCreateCommandPool", {}, result);
     }
 
     return result;
@@ -4000,7 +4000,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandPool(VkDevice device, VkCommandPool c
     if (!skip) {
         result = my_data->dispatch_table.ResetCommandPool(device, commandPool, flags);
 
-        validate_result(my_data->report_data, "vkResetCommandPool", result);
+        validate_result(my_data->report_data, "vkResetCommandPool", {}, result);
     }
 
     return result;
@@ -4018,7 +4018,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(VkDevice device, const VkC
     if (!skip) {
         result = my_data->dispatch_table.AllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers);
 
-        validate_result(my_data->report_data, "vkAllocateCommandBuffers", result);
+        validate_result(my_data->report_data, "vkAllocateCommandBuffers", {}, result);
     }
 
     return result;
@@ -4102,7 +4102,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(VkCommandBuffer commandBuffer,
     if (!skip) {
         result = device_data->dispatch_table.BeginCommandBuffer(commandBuffer, pBeginInfo);
 
-        validate_result(report_data, "vkBeginCommandBuffer", result);
+        validate_result(report_data, "vkBeginCommandBuffer", {}, result);
     }
 
     return result;
@@ -4114,7 +4114,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EndCommandBuffer(VkCommandBuffer commandBuffer) {
 
     VkResult result = my_data->dispatch_table.EndCommandBuffer(commandBuffer);
 
-    validate_result(my_data->report_data, "vkEndCommandBuffer", result);
+    validate_result(my_data->report_data, "vkEndCommandBuffer", {}, result);
 
     return result;
 }
@@ -4129,7 +4129,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ResetCommandBuffer(VkCommandBuffer commandBuffer,
     if (!skip) {
         result = my_data->dispatch_table.ResetCommandBuffer(commandBuffer, flags);
 
-        validate_result(my_data->report_data, "vkResetCommandBuffer", result);
+        validate_result(my_data->report_data, "vkResetCommandBuffer", {}, result);
     }
 
     return result;
@@ -5062,7 +5062,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(VkDevice device, const VkSwapc
     if (!skip) {
         result = my_data->dispatch_table.CreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
 
-        validate_result(my_data->report_data, "vkCreateSwapchainKHR", result);
+        validate_result(my_data->report_data, "vkCreateSwapchainKHR", {}, result);
     }
 
     return result;
@@ -5083,7 +5083,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(VkDevice device, VkSwapchai
     if (!skip) {
         result = my_data->dispatch_table.GetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages);
 
-        validate_result(my_data->report_data, "vkGetSwapchainImagesKHR", result);
+        validate_result(my_data->report_data, "vkGetSwapchainImagesKHR", {}, result);
     }
 
     return result;
@@ -5104,7 +5104,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImageKHR(VkDevice device, VkSwapchainK
     if (!skip) {
         result = my_data->dispatch_table.AcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex);
 
-        validate_result(my_data->report_data, "vkAcquireNextImageKHR", result);
+        validate_result(my_data->report_data, "vkAcquireNextImageKHR", {}, result);
     }
 
     return result;
@@ -5159,7 +5159,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInf
     if (!skip) {
         result = my_data->dispatch_table.QueuePresentKHR(queue, pPresentInfo);
 
-        validate_result(my_data->report_data, "vkQueuePresentKHR", result);
+        validate_result(my_data->report_data, "vkQueuePresentKHR", {}, result);
     }
 
     return result;
@@ -5208,7 +5208,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevi
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported);
 
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfaceSupportKHR", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfaceSupportKHR", {}, result);
     }
 
     return result;
@@ -5229,7 +5229,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysica
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities);
 
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR", {}, result);
     }
 
     return result;
@@ -5253,7 +5253,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevi
         result = my_data->dispatch_table.GetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount,
                                                                             pSurfaceFormats);
 
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfaceFormatsKHR", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfaceFormatsKHR", {}, result);
     }
 
     return result;
@@ -5277,7 +5277,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfacePresentModesKHR(VkPhysica
         result = my_data->dispatch_table.GetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount,
                                                                                  pPresentModes);
 
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfacePresentModesKHR", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfacePresentModesKHR", {}, result);
     }
 
     return result;
@@ -5313,7 +5313,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(VkInstance instance, const 
         result = my_data->dispatch_table.CreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     }
 
-    validate_result(my_data->report_data, "vkCreateWin32SurfaceKHR", result);
+    validate_result(my_data->report_data, "vkCreateWin32SurfaceKHR", {}, result);
 
     return result;
 }
@@ -5358,7 +5358,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(VkInstance instance, const Vk
         result = my_data->dispatch_table.CreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     }
 
-    validate_result(my_data->report_data, "vkCreateXcbSurfaceKHR", result);
+    validate_result(my_data->report_data, "vkCreateXcbSurfaceKHR", {}, result);
 
     return result;
 }
@@ -5405,7 +5405,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(VkInstance instance, const V
         result = my_data->dispatch_table.CreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     }
 
-    validate_result(my_data->report_data, "vkCreateXlibSurfaceKHR", result);
+    validate_result(my_data->report_data, "vkCreateXlibSurfaceKHR", {}, result);
 
     return result;
 }
@@ -5451,7 +5451,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMirSurfaceKHR(VkInstance instance, const Vk
         result = my_data->dispatch_table.CreateMirSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     }
 
-    validate_result(my_data->report_data, "vkCreateMirSurfaceKHR", result);
+    validate_result(my_data->report_data, "vkCreateMirSurfaceKHR", {}, result);
 
     return result;
 }
@@ -5495,7 +5495,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(VkInstance instance, cons
         result = my_data->dispatch_table.CreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     }
 
-    validate_result(my_data->report_data, "vkCreateWaylandSurfaceKHR", result);
+    validate_result(my_data->report_data, "vkCreateWaylandSurfaceKHR", {}, result);
 
     return result;
 }
@@ -5540,7 +5540,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(VkInstance instance, cons
         result = my_data->dispatch_table.CreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
     }
 
-    validate_result(my_data->report_data, "vkCreateAndroidSurfaceKHR", result);
+    validate_result(my_data->report_data, "vkCreateAndroidSurfaceKHR", {}, result);
 
     return result;
 }
@@ -5563,7 +5563,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(VkDevice device, uint32
     if (!skip) {
         result = my_data->dispatch_table.CreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
 
-        validate_result(my_data->report_data, "vkCreateSharedSwapchainsKHR", result);
+        validate_result(my_data->report_data, "vkCreateSharedSwapchainsKHR", {}, result);
     }
 
     return result;
@@ -5584,7 +5584,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalD
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties);
 
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceDisplayPropertiesKHR", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceDisplayPropertiesKHR", {}, result);
     }
 
     return result;
@@ -5605,7 +5605,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(VkPhys
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties);
 
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR", {}, result);
     }
 
     return result;
@@ -5626,7 +5626,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDev
     if (!skip) {
         result = my_data->dispatch_table.GetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays);
 
-        validate_result(my_data->report_data, "vkGetDisplayPlaneSupportedDisplaysKHR", result);
+        validate_result(my_data->report_data, "vkGetDisplayPlaneSupportedDisplaysKHR", {}, result);
     }
 
     return result;
@@ -5647,7 +5647,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(VkPhysicalDevice phys
     if (!skip) {
         result = my_data->dispatch_table.GetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties);
 
-        validate_result(my_data->report_data, "vkGetDisplayModePropertiesKHR", result);
+        validate_result(my_data->report_data, "vkGetDisplayModePropertiesKHR", {}, result);
     }
 
     return result;
@@ -5669,7 +5669,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(VkPhysicalDevice physicalDev
     if (!skip) {
         result = my_data->dispatch_table.CreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode);
 
-        validate_result(my_data->report_data, "vkCreateDisplayModeKHR", result);
+        validate_result(my_data->report_data, "vkCreateDisplayModeKHR", {}, result);
     }
 
     return result;
@@ -5690,7 +5690,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice p
     if (!skip) {
         result = my_data->dispatch_table.GetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities);
 
-        validate_result(my_data->report_data, "vkGetDisplayPlaneCapabilitiesKHR", result);
+        validate_result(my_data->report_data, "vkGetDisplayPlaneCapabilitiesKHR", {}, result);
     }
 
     return result;
@@ -5711,7 +5711,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(VkInstance instance,
     if (!skip) {
         result = my_data->dispatch_table.CreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
 
-        validate_result(my_data->report_data, "vkCreateDisplayPlaneSurfaceKHR", result);
+        validate_result(my_data->report_data, "vkCreateDisplayPlaneSurfaceKHR", {}, result);
     }
 
     return result;
@@ -5785,7 +5785,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHR(
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo,
                                                                                     pImageFormatProperties);
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceImageFormatProperties2KHR", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceImageFormatProperties2KHR", {}, result);
     }
 
     return result;
@@ -5929,7 +5929,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(VkDevice device
     if (!skip) {
         result =
             my_data->dispatch_table.CreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
-        validate_result(my_data->report_data, "vkCreateDescriptorUpdateTemplateKHR", result);
+        validate_result(my_data->report_data, "vkCreateDescriptorUpdateTemplateKHR", {}, result);
     }
 
     return result;
@@ -6009,7 +6009,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHX(
     if (!skip) {
         result = my_data->dispatch_table.EnumeratePhysicalDeviceGroupsKHX(instance, pPhysicalDeviceGroupCount,
                                                                           pPhysicalDeviceGroupProperties);
-        validate_result(my_data->report_data, "vkEnumeratePhysicalDeviceGroupsKHX", result);
+        validate_result(my_data->report_data, "vkEnumeratePhysicalDeviceGroupsKHX", {}, result);
     }
     return result;
 }
@@ -6049,7 +6049,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHX(VkDevice device, uint32_t bi
 
     if (!skip) {
         result = my_data->dispatch_table.BindBufferMemory2KHX(device, bindInfoCount, pBindInfos);
-        validate_result(my_data->report_data, "vkBindBufferMemory2KHX", result);
+        validate_result(my_data->report_data, "vkBindBufferMemory2KHX", {}, result);
     }
 
     return result;
@@ -6069,7 +6069,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHX(VkDevice device, uint32_t bin
 
     if (!skip) {
         result = my_data->dispatch_table.BindImageMemory2KHX(device, bindInfoCount, pBindInfos);
-        validate_result(my_data->report_data, "vkBindImageMemory2KHX", result);
+        validate_result(my_data->report_data, "vkBindImageMemory2KHX", {}, result);
     }
 
     return result;
@@ -6106,7 +6106,7 @@ GetDeviceGroupPresentCapabilitiesKHX(VkDevice device, VkDeviceGroupPresentCapabi
 
     if (!skip) {
         result = my_data->dispatch_table.GetDeviceGroupPresentCapabilitiesKHX(device, pDeviceGroupPresentCapabilities);
-        validate_result(my_data->report_data, "vkGetDeviceGroupPresentCapabilitiesKHX", result);
+        validate_result(my_data->report_data, "vkGetDeviceGroupPresentCapabilitiesKHX", {}, result);
     }
 
     return result;
@@ -6126,7 +6126,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupSurfacePresentModesKHX(VkDevice dev
 
     if (!skip) {
         result = my_data->dispatch_table.GetDeviceGroupSurfacePresentModesKHX(device, surface, pModes);
-        validate_result(my_data->report_data, "vkGetDeviceGroupSurfacePresentModesKHX", result);
+        validate_result(my_data->report_data, "vkGetDeviceGroupSurfacePresentModesKHX", {}, result);
     }
     return result;
 }
@@ -6145,7 +6145,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImage2KHX(VkDevice device, const VkAcq
 
     if (!skip) {
         result = my_data->dispatch_table.AcquireNextImage2KHX(device, pAcquireInfo, pImageIndex);
-        validate_result(my_data->report_data, "vkAcquireNextImage2KHX", result);
+        validate_result(my_data->report_data, "vkAcquireNextImage2KHX", {}, result);
     }
     return result;
 }
@@ -6183,7 +6183,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDevicePresentRectanglesKHX(VkPhysicalD
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDevicePresentRectanglesKHX(physicalDevice, surface, pRectCount, pRects);
 
-        validate_result(my_data->report_data, "vkGetPhysicalDevicePresentRectanglesKHX", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDevicePresentRectanglesKHX", {}, result);
     }
 
     return result;
@@ -6224,7 +6224,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHX(VkDevice device, VkDeviceMemory me
 
     if (!skip) {
         result = my_data->dispatch_table.GetMemoryFdKHX(device, memory, handleType, pFd);
-        validate_result(my_data->report_data, "vkGetMemoryFdKHX", result);
+        validate_result(my_data->report_data, "vkGetMemoryFdKHX", {}, result);
     }
 
     return result;
@@ -6244,7 +6244,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdPropertiesKHX(VkDevice device, VkExter
 
     if (!skip) {
         result = my_data->dispatch_table.GetMemoryFdPropertiesKHX(device, handleType, fd, pMemoryFdProperties);
-        validate_result(my_data->report_data, "vkGetMemoryFdPropertiesKHX", result);
+        validate_result(my_data->report_data, "vkGetMemoryFdPropertiesKHX", {}, result);
     }
 
     return result;
@@ -6266,7 +6266,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHX(VkDevice device, VkDevice
 
     if (!skip) {
         result = my_data->dispatch_table.GetMemoryWin32HandleKHX(device, memory, handleType, pHandle);
-        validate_result(my_data->report_data, "vkGetMemoryWin32HandleKHX", result);
+        validate_result(my_data->report_data, "vkGetMemoryWin32HandleKHX", {}, result);
     }
     return result;
 }
@@ -6287,7 +6287,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHX(VkDevice device
     if (!skip) {
         result =
             my_data->dispatch_table.GetMemoryWin32HandlePropertiesKHX(device, handleType, handle, pMemoryWin32HandleProperties);
-        validate_result(my_data->report_data, "vkGetMemoryWin32HandlePropertiesKHX", result);
+        validate_result(my_data->report_data, "vkGetMemoryWin32HandlePropertiesKHX", {}, result);
     }
     return result;
 }
@@ -6327,7 +6327,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHX(VkDevice device, const VkImp
 
     if (!skip) {
         result = my_data->dispatch_table.ImportSemaphoreFdKHX(device, pImportSemaphoreFdInfo);
-        validate_result(my_data->report_data, "vkImportSemaphoreFdKHX", result);
+        validate_result(my_data->report_data, "vkImportSemaphoreFdKHX", {}, result);
     }
 
     return result;
@@ -6347,7 +6347,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreFdKHX(VkDevice device, VkSemaphore se
 
     if (!skip) {
         result = my_data->dispatch_table.GetSemaphoreFdKHX(device, semaphore, handleType, pFd);
-        validate_result(my_data->report_data, "vkGetSemaphoreFdKHX", result);
+        validate_result(my_data->report_data, "vkGetSemaphoreFdKHX", {}, result);
     }
 
     return result;
@@ -6368,7 +6368,7 @@ ImportSemaphoreWin32HandleKHX(VkDevice device, const VkImportSemaphoreWin32Handl
     skip |= parameter_validation_vkImportSemaphoreWin32HandleKHX(my_data->report_data, pImportSemaphoreWin32HandleInfo);
     if (!skip) {
         result = my_data->dispatch_table.ImportSemaphoreWin32HandleKHX(device, pImportSemaphoreWin32HandleInfo);
-        validate_result(my_data->report_data, "vkImportSemaphoreWin32HandleKHX", result);
+        validate_result(my_data->report_data, "vkImportSemaphoreWin32HandleKHX", {}, result);
     }
     return result;
 }
@@ -6384,7 +6384,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHX(VkDevice device, VkSem
     skip |= parameter_validation_vkGetSemaphoreWin32HandleKHX(my_data->report_data, semaphore, handleType, pHandle);
     if (!skip) {
         result = my_data->dispatch_table.GetSemaphoreWin32HandleKHX(device, semaphore, handleType, pHandle);
-        validate_result(my_data->report_data, "vkGetSemaphoreWin32HandleKHX", result);
+        validate_result(my_data->report_data, "vkGetSemaphoreWin32HandleKHX", {}, result);
     }
     return result;
 }
@@ -6403,7 +6403,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(VkPhysicalDevice physicalDe
     skip |= parameter_validation_vkAcquireXlibDisplayEXT(my_data->report_data, dpy, display);
     if (!skip) {
         result = my_data->dispatch_table.AcquireXlibDisplayEXT(physicalDevice, dpy, display);
-        validate_result(my_data->report_data, "vkAcquireXlibDisplayEXT", result);
+        validate_result(my_data->report_data, "vkAcquireXlibDisplayEXT", {}, result);
     }
     return result;
 }
@@ -6419,7 +6419,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(VkPhysicalDevice physica
     skip |= parameter_validation_vkGetRandROutputDisplayEXT(my_data->report_data, dpy, rrOutput, pDisplay);
     if (!skip) {
         result = my_data->dispatch_table.GetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay);
-        validate_result(my_data->report_data, "vkGetRandROutputDisplayEXT", result);
+        validate_result(my_data->report_data, "vkGetRandROutputDisplayEXT", {}, result);
     }
     return result;
 }
@@ -6441,7 +6441,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(VkDevice device, VkDeb
     if (!skip) {
         if (my_data->dispatch_table.DebugMarkerSetObjectTagEXT) {
             result = my_data->dispatch_table.DebugMarkerSetObjectTagEXT(device, pTagInfo);
-            validate_result(my_data->report_data, "vkDebugMarkerSetObjectTagEXT", result);
+            validate_result(my_data->report_data, "vkDebugMarkerSetObjectTagEXT", {}, result);
         } else {
             result = VK_SUCCESS;
         }
@@ -6464,7 +6464,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(VkDevice device, VkDe
     if (!skip) {
         if (my_data->dispatch_table.DebugMarkerSetObjectNameEXT) {
             result = my_data->dispatch_table.DebugMarkerSetObjectNameEXT(device, pNameInfo);
-            validate_result(my_data->report_data, "vkDebugMarkerSetObjectNameEXT", result);
+            validate_result(my_data->report_data, "vkDebugMarkerSetObjectNameEXT", {}, result);
         } else {
             result = VK_SUCCESS;
         }
@@ -6517,7 +6517,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(VkPhysicalDevice physicalDevice
 #endif
     if (!skip) {
         result = my_data->dispatch_table.ReleaseDisplayEXT(physicalDevice, display);
-        validate_result(my_data->report_data, "vkGetRandROutputDisplayEXT", result);
+        validate_result(my_data->report_data, "vkGetRandROutputDisplayEXT", {}, result);
     }
     return result;
 }
@@ -6559,7 +6559,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DisplayPowerControlEXT(VkDevice device, VkDisplay
     if (!skip) {
         if (my_data->dispatch_table.DisplayPowerControlEXT) {
             result = my_data->dispatch_table.DisplayPowerControlEXT(device, display, pDisplayPowerInfo);
-            validate_result(my_data->report_data, "vkDisplayPowerControlEXT", result);
+            validate_result(my_data->report_data, "vkDisplayPowerControlEXT", {}, result);
         } else {
             result = VK_SUCCESS;
         }
@@ -6583,7 +6583,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(VkDevice device, const VkD
     if (!skip) {
         if (my_data->dispatch_table.RegisterDeviceEventEXT) {
             result = my_data->dispatch_table.RegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence);
-            validate_result(my_data->report_data, "vkRegisterDeviceEventEXT", result);
+            validate_result(my_data->report_data, "vkRegisterDeviceEventEXT", {}, result);
         } else {
             result = VK_SUCCESS;
         }
@@ -6608,7 +6608,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(VkDevice device, VkDispla
     if (!skip) {
         if (my_data->dispatch_table.RegisterDisplayEventEXT) {
             result = my_data->dispatch_table.RegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence);
-            validate_result(my_data->report_data, "vkRegisterDisplayEventEXT", result);
+            validate_result(my_data->report_data, "vkRegisterDisplayEventEXT", {}, result);
         } else {
             result = VK_SUCCESS;
         }
@@ -6632,7 +6632,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainCounterEXT(VkDevice device, VkSwapcha
     if (!skip) {
         if (my_data->dispatch_table.GetSwapchainCounterEXT) {
             result = my_data->dispatch_table.GetSwapchainCounterEXT(device, swapchain, counter, pCounterValue);
-            validate_result(my_data->report_data, "vkGetSwapchainCounterEXT", result);
+            validate_result(my_data->report_data, "vkGetSwapchainCounterEXT", {}, result);
         } else {
             result = VK_SUCCESS;
         }
@@ -6688,7 +6688,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysic
     skip |= parameter_validation_vkGetPhysicalDeviceSurfaceCapabilities2EXT(my_data->report_data, surface, pSurfaceCapabilities);
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities);
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfaceCapabilities2EXT", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceSurfaceCapabilities2EXT", {}, result);
     }
     return result;
 }
@@ -6732,7 +6732,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
         result = my_data->dispatch_table.GetPhysicalDeviceExternalImageFormatPropertiesNV(
             physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties);
 
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceExternalImageFormatPropertiesNV", result);
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceExternalImageFormatPropertiesNV", {}, result);
     }
 
     return result;
@@ -6803,7 +6803,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNVX(VkDevice device,
                                                                    pIndirectCommandsLayout);
     if (!skip) {
         result = my_data->dispatch_table.CreateIndirectCommandsLayoutNVX(device, pCreateInfo, pAllocator, pIndirectCommandsLayout);
-        validate_result(my_data->report_data, "vkCreateIndirectCommandsLayoutNVX", result);
+        validate_result(my_data->report_data, "vkCreateIndirectCommandsLayoutNVX", {}, result);
     }
     return result;
 }
@@ -6834,7 +6834,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateObjectTableNVX(VkDevice device, const VkObj
     skip |= parameter_validation_vkCreateObjectTableNVX(my_data->report_data, pCreateInfo, pAllocator, pObjectTable);
     if (!skip) {
         result = my_data->dispatch_table.CreateObjectTableNVX(device, pCreateInfo, pAllocator, pObjectTable);
-        validate_result(my_data->report_data, "vkCreateObjectTableNVX", result);
+        validate_result(my_data->report_data, "vkCreateObjectTableNVX", {}, result);
     }
     return result;
 }
@@ -6867,7 +6867,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterObjectsNVX(VkDevice device, VkObjectTable
                                                       pObjectIndices);
     if (!skip) {
         result = my_data->dispatch_table.RegisterObjectsNVX(device, objectTable, objectCount, ppObjectTableEntries, pObjectIndices);
-        validate_result(my_data->report_data, "vkRegisterObjectsNVX", result);
+        validate_result(my_data->report_data, "vkRegisterObjectsNVX", {}, result);
     }
     return result;
 }
@@ -6884,7 +6884,7 @@ VKAPI_ATTR VkResult VKAPI_CALL UnregisterObjectsNVX(VkDevice device, VkObjectTab
                                                         pObjectIndices);
     if (!skip) {
         result = my_data->dispatch_table.UnregisterObjectsNVX(device, objectTable, objectCount, pObjectEntryTypes, pObjectIndices);
-        validate_result(my_data->report_data, "vkUnregisterObjectsNVX", result);
+        validate_result(my_data->report_data, "vkUnregisterObjectsNVX", {}, result);
     }
     return result;
 }

--- a/layers/parameter_validation.cpp
+++ b/layers/parameter_validation.cpp
@@ -1449,8 +1449,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties(VkPhysical
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags,
                                                                                 pImageFormatProperties);
-
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceImageFormatProperties", {}, result);
+        const std::vector<VkResult> ignore_list = {VK_ERROR_FORMAT_NOT_SUPPORTED};
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceImageFormatProperties", ignore_list, result);
     }
 
     return result;
@@ -5785,7 +5785,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHR(
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo,
                                                                                     pImageFormatProperties);
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceImageFormatProperties2KHR", {}, result);
+        const std::vector<VkResult> ignore_list = {VK_ERROR_FORMAT_NOT_SUPPORTED};
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceImageFormatProperties2KHR", ignore_list, result);
     }
 
     return result;
@@ -6731,8 +6732,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
     if (!skip) {
         result = my_data->dispatch_table.GetPhysicalDeviceExternalImageFormatPropertiesNV(
             physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties);
-
-        validate_result(my_data->report_data, "vkGetPhysicalDeviceExternalImageFormatPropertiesNV", {}, result);
+        const std::vector<VkResult> ignore_list = {VK_ERROR_FORMAT_NOT_SUPPORTED};
+        validate_result(my_data->report_data, "vkGetPhysicalDeviceExternalImageFormatPropertiesNV", ignore_list, result);
     }
 
     return result;

--- a/layers/parameter_validation_utils.h
+++ b/layers/parameter_validation_utils.h
@@ -813,12 +813,16 @@ static std::string get_result_description(VkResult result) {
 *
 * @param report_data debug_report_data object for routing validation messages.
 * @param apiName Name of API call being validated.
+* @param ignore vector of VkResult return codes to be ignored
 * @param value VkResult value to validate.
 */
-static void validate_result(debug_report_data *report_data, const char *apiName, VkResult result) {
+static void validate_result(debug_report_data *report_data, const char *apiName, std::vector<VkResult> const &ignore,
+                            VkResult result) {
     if (result < 0 && result != VK_ERROR_VALIDATION_FAILED_EXT) {
+        if (std::find(ignore.begin(), ignore.end(), result) != ignore.end()) {
+            return;
+        }
         std::string resultName = string_VkResult(result);
-
         if (resultName == UnsupportedResultString) {
             // Unrecognized result code
             log_msg(report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1057,37 +1057,6 @@ TEST_F(VkLayerTest, UnrecognizedValue) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, FailedReturnValue) {
-    TEST_DESCRIPTION("Check for a message describing a VkResult failure code");
-
-    ASSERT_NO_FATAL_FAILURE(Init());
-
-    // Find an unsupported image format
-    VkFormat unsupported = VK_FORMAT_UNDEFINED;
-    for (int f = VK_FORMAT_BEGIN_RANGE; f <= VK_FORMAT_END_RANGE; f++) {
-        VkFormat format = static_cast<VkFormat>(f);
-        VkFormatProperties fProps = m_device->format_properties(format);
-        if (format != VK_FORMAT_UNDEFINED && fProps.linearTilingFeatures == 0 && fProps.optimalTilingFeatures == 0) {
-            unsupported = format;
-            break;
-        }
-    }
-
-    if (unsupported != VK_FORMAT_UNDEFINED) {
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_WARNING_BIT_EXT,
-                                             "the requested format is not supported on this device");
-        // Specify an unsupported VkFormat value to generate a
-        // VK_ERROR_FORMAT_NOT_SUPPORTED return code
-        // Expected to trigger a warning from
-        // parameter_validation::validate_result
-        VkImageFormatProperties image_format_properties;
-        VkResult err = vkGetPhysicalDeviceImageFormatProperties(gpu(), unsupported, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
-                                                                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0, &image_format_properties);
-        ASSERT_TRUE(err == VK_ERROR_FORMAT_NOT_SUPPORTED);
-        m_errorMonitor->VerifyFound();
-    }
-}
-
 TEST_F(VkLayerTest, UpdateBufferAlignment) {
     TEST_DESCRIPTION("Check alignment parameters for vkCmdUpdateBuffer");
     uint32_t updateData[] = {1, 2, 3, 4, 5, 6, 7, 8};


### PR DESCRIPTION
Received some reasonable feedback that the extra noise was unnecessary since this return code is perfectly valid, acceptable, and expected.  If anybody has requests to ignore other return codes, chime in here.

TLDR -- if `vkGetPhysicalDeviceImageFormatProperties`(), `vkGetPhysicalDeviceImageFormatProperties2KHR`() or `vkGetPhysicalDeviceExternalImageFormatPropertiesNV`() return "`VK_ERROR_FORMAT_NOT_SUPPORTED`", no log_msg call will be made.