### PR TITLE
layers: Fix unique_objects_wrappers.h

### DIFF
--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -599,7 +599,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
     #
     # Clean up local declarations
     def cleanUpLocalDeclarations(self, indent, prefix, name, len, index, process_pnext):
-        cleanup = '%sif (local_%s%s)\n' % (indent, prefix, name)
+        cleanup = '%sif (local_%s%s) {\n' % (indent, prefix, name)
         if len is not None:
             if process_pnext:
                 cleanup += '%s    for (uint32_t %s = 0; %s < %s%s; ++%s) {\n' % (indent, index, index, prefix, len, index)
@@ -610,6 +610,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             if process_pnext:
                 cleanup += '%s    FreeUnwrappedExtensionStructs(const_cast<void *>(local_%s%s->pNext));\n' % (indent, prefix, name)
             cleanup += '%s    delete local_%s%s;\n' % (indent, prefix, name)
+        cleanup += "%s}\n" % (indent)
         return cleanup
     #
     # Output UO code for a single NDO (ndo_count is NULL) or a counted list of NDOs


### PR DESCRIPTION
The unique_objects_wrappers.h header was generated with code that
caused several compilation warnings.  This resolves those warnings.

Change-Id: I5ed3bdb6bbe7df48b3fe6fb6679916161b32fdfd