### PR TITLE
Remove assert for NULL pInheritanceInfo->frameBuffer in BeginCommandBuffer

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -6503,9 +6503,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(VkCommandBuffer commandBuffer,
                             validation_error_map[VALIDATION_ERROR_00106]);
             } else {
                 if (pBeginInfo->flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) {
-                    // Object_tracker makes sure these objects are valid
                     assert(pInfo->renderPass);
-                    assert(pInfo->framebuffer);
                     string errorString = "";
                     auto framebuffer = GetFramebufferState(dev_data, pInfo->framebuffer);
                     if (framebuffer) {


### PR DESCRIPTION
Fixes #1778. It is acceptable for the frameBuffer member of this structure to be NULL. Removed assert.