### PR TITLE
Better handle invalidation of primary CB due to secondary having been rerecorded

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3898,6 +3898,7 @@ static bool validateCommandBufferState(layer_data *dev_data, GLOBAL_CB_NODE *cb_
                         "set, but has been submitted 0x%" PRIxLEAST64 " times.",
                         cb_state->commandBuffer, cb_state->submitCount + current_submit_count);
     }
+
     // Validate that cmd buffers have been updated
     if (CB_RECORDED != cb_state->state) {
         if (CB_INVALID == cb_state->state) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5629,6 +5629,11 @@ void invalidateCommandBuffers(const layer_data *dev_data, std::unordered_set<GLO
         }
         cb_node->state = CB_INVALID;
         cb_node->broken_bindings.push_back(obj);
+
+        // if secondary, then propagate the invalidation to the primaries that will call us.
+        if (cb_node->createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
+            invalidateCommandBuffers(dev_data, cb_node->linkedCommandBuffers, obj);
+        }
     }
 }
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -9542,7 +9542,7 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(VkCommandBuffer commandBuffer, uin
             skip |= validateSecondaryCommandBufferState(dev_data, pCB, pSubCB);
             skip |= validateCommandBufferState(dev_data, pSubCB, "vkCmdExecuteCommands()", 0, VALIDATION_ERROR_00155);
             if (!(pSubCB->beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
-                if (pSubCB->in_use.load()) {
+                if (pSubCB->in_use.load() || pCB->linkedCommandBuffers.count(pSubCB)) {
                     skip |= log_msg(dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
                                     VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, HandleToUint64(pCB->commandBuffer), __LINE__,
                                     VALIDATION_ERROR_00154, "DS",
@@ -9573,6 +9573,7 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(VkCommandBuffer commandBuffer, uin
                             "supported on this device. %s",
                             pCommandBuffers[i], validation_error_map[VALIDATION_ERROR_02062]);
             }
+            // TODO: separate validate from update! This is very tangled.
             // Propagate layout transitions to the primary cmd buffer
             for (auto ilm_entry : pSubCB->imageLayoutMap) {
                 SetLayout(dev_data, pCB, ilm_entry.first, ilm_entry.second);

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -668,7 +668,7 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     std::unordered_set<VkBuffer> updateBuffers;
     // If cmd buffer is primary, track secondary command buffers pending
     // execution
-    std::unordered_set<VkCommandBuffer> secondaryCommandBuffers;
+    std::unordered_set<GLOBAL_CB_NODE *> secondaryCommandBuffers;
     // MTMTODO : Scrub these data fields and merge active sets w/ lastBound as appropriate
     std::vector<std::function<bool()>> validate_functions;
     std::unordered_set<VkDeviceMemory> memObjs;

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -666,9 +666,9 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     // Track images and buffers that are updated by this CB at the point of a draw
     std::unordered_set<VkImageView> updateImages;
     std::unordered_set<VkBuffer> updateBuffers;
-    // If cmd buffer is primary, track secondary command buffers pending
-    // execution
-    std::unordered_set<GLOBAL_CB_NODE *> secondaryCommandBuffers;
+    // If primary, the secondary command buffers we will call.
+    // If secondary, the primary command buffers we will be called by.
+    std::unordered_set<GLOBAL_CB_NODE *> linkedCommandBuffers;
     // MTMTODO : Scrub these data fields and merge active sets w/ lastBound as appropriate
     std::vector<std::function<bool()>> validate_functions;
     std::unordered_set<VkDeviceMemory> memObjs;

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1135,7 +1135,7 @@ TEST_F(VkLayerTest, PSOPolygonModeInvalid) {
     std::vector<const char *> device_extension_names;
     auto features = m_device->phy().features();
     // Artificially disable support for non-solid fill modes
-    features.fillModeNonSolid = false;
+    features.fillModeNonSolid = VK_FALSE;
     // The sacrificial device object
     VkDeviceObj test_device(0, gpu(), device_extension_names, &features);
 
@@ -1154,7 +1154,7 @@ TEST_F(VkLayerTest, PSOPolygonModeInvalid) {
     rs_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
     rs_ci.pNext = nullptr;
     rs_ci.lineWidth = 1.0f;
-    rs_ci.rasterizerDiscardEnable = true;
+    rs_ci.rasterizerDiscardEnable = VK_TRUE;
 
     VkShaderObj vs(&test_device, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT, this);
     VkShaderObj fs(&test_device, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT, this);

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1288,10 +1288,11 @@ VkResult VkPipelineObj::CreateVKPipeline(VkPipelineLayout layout, VkRenderPass r
     return init_try(*m_device, *gp_ci);
 }
 
-VkCommandBufferObj::VkCommandBufferObj(VkDeviceObj *device, VkCommandPoolObj *pool) {
+VkCommandBufferObj::VkCommandBufferObj(VkDeviceObj *device, VkCommandPoolObj *pool, VkCommandBufferLevel level) {
     m_device = device;
-
-    init(*device, vk_testing::CommandBuffer::create_info(pool->handle()));
+    auto create_info = vk_testing::CommandBuffer::create_info(pool->handle());
+    create_info.level = level;
+    init(*device, create_info);
 }
 
 VkCommandBuffer VkCommandBufferObj::GetBufferHandle() { return handle(); }

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -155,7 +155,8 @@ class VkCommandPoolObj : public vk_testing::CommandPool {
 
 class VkCommandBufferObj : public vk_testing::CommandBuffer {
    public:
-    VkCommandBufferObj(VkDeviceObj *device, VkCommandPoolObj *pool);
+    VkCommandBufferObj(VkDeviceObj *device, VkCommandPoolObj *pool,
+                       VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY);
     VkCommandBuffer GetBufferHandle();
     VkResult BeginCommandBuffer();
     VkResult BeginCommandBuffer(VkCommandBufferBeginInfo *pInfo);


### PR DESCRIPTION
Tidies up various bad behavior around invalidation & secondary command buffer in-flight accounting.

- The global inflight list is gone.
- Cascaded invalidation from resource -> secondary -> primary works
- Test quality improved
- secondary CB implicit or explicit reset causes invalidation of primary CBs (Fixes #1780)