### PR TITLE
WIP: layers: Use CB invalidation mechanism for VU135.

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3258,7 +3258,6 @@ static void resetCB(layer_data *dev_data, const VkCommandBuffer cb) {
         pCB->drawData.clear();
         pCB->currentDrawData.buffers.clear();
         pCB->vertex_buffer_used = false;
-        pCB->primaryCommandBuffer = VK_NULL_HANDLE;
         // If secondary, invalidate any primary command buffer that may call us.
         if (pCB->createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
             invalidateCommandBuffers(dev_data,
@@ -4022,6 +4021,8 @@ static bool validatePrimaryCommandBufferState(layer_data *dev_data, GLOBAL_CB_NO
     // Track in-use for resources off of primary and any secondary CBs
     bool skip = false;
 
+    // TODO: inline this function into sole caller
+
     // If USAGE_SIMULTANEOUS_USE_BIT not set then CB cannot already be executing
     // on device
     skip |= validateCommandBufferSimultaneousUse(dev_data, pCB, current_submit_count);
@@ -4030,17 +4031,6 @@ static bool validatePrimaryCommandBufferState(layer_data *dev_data, GLOBAL_CB_NO
 
     for (auto pSubCB : pCB->linkedCommandBuffers) {
         skip |= validateResources(dev_data, pSubCB);
-        // TODO: replace with invalidateCommandBuffers() at recording.
-        if ((pSubCB->primaryCommandBuffer != pCB->commandBuffer) &&
-            !(pSubCB->beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
-            log_msg(
-                dev_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, 0,
-                __LINE__, VALIDATION_ERROR_00135, "DS",
-                "Commandbuffer 0x%p was submitted with secondary buffer 0x%p but that buffer has subsequently been bound to "
-                    "primary cmd buffer 0x%p and it does not have VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT set. %s",
-                pCB->commandBuffer, pSubCB->commandBuffer, pSubCB->primaryCommandBuffer,
-                validation_error_map[VALIDATION_ERROR_00135]);
-        }
     }
 
     skip |= validateCommandBufferState(dev_data, pCB, "vkQueueSubmit()", current_submit_count, VALIDATION_ERROR_00134);
@@ -9550,6 +9540,12 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(VkCommandBuffer commandBuffer, uin
                         pCommandBuffers[i], pCB->commandBuffer);
                     pCB->beginInfo.flags &= ~VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
                 }
+                if (pSubCB->linkedCommandBuffers.size()) {
+                    // TODO: adjust message support so we can report an accurate error message for this.
+                    invalidateCommandBuffers(dev_data, pSubCB->linkedCommandBuffers,
+                                             {HandleToUint64(pCommandBuffers[i]), kVulkanObjectTypeCommandBuffer});
+                    // TODO: consistent strategy for removing links.
+                }
             }
             if (!pCB->activeQueries.empty() && !dev_data->enabled_features.inheritedQueries) {
                 skip |=
@@ -9566,7 +9562,6 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(VkCommandBuffer commandBuffer, uin
             for (auto ilm_entry : pSubCB->imageLayoutMap) {
                 SetLayout(dev_data, pCB, ilm_entry.first, ilm_entry.second);
             }
-            pSubCB->primaryCommandBuffer = pCB->commandBuffer;
             pCB->linkedCommandBuffers.insert(pSubCB);
             pSubCB->linkedCommandBuffers.insert(pCB);
             for (auto &function : pSubCB->queryUpdates) {

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -662,7 +662,6 @@ struct GLOBAL_CB_NODE : public BASE_NODE {
     std::vector<DRAW_DATA> drawData;
     DRAW_DATA currentDrawData;
     bool vertex_buffer_used;  // Track for perf warning to make sure any bound vtx buffer used
-    VkCommandBuffer primaryCommandBuffer;
     // Track images and buffers that are updated by this CB at the point of a draw
     std::unordered_set<VkImageView> updateImages;
     std::unordered_set<VkBuffer> updateBuffers;


### PR DESCRIPTION
Makes more sense to use command buffer invalidation to drive this than
maintaining parallel logic and only picking this up at draw time.

Drops some additional TODOs in around areas that need some more work to
make this nice.

Note: Looking for feedback here, this isn't ready -- we make the validation message in this case much less clear by this change.