### PR TITLE
android: Switch to the LLVM libc++ runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ before_install:
     # Install the Android NDK.
     if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then
       export ARCH=`uname -m`
-      wget http://dl.google.com/android/repository/android-ndk-r13b-linux-${ARCH}.zip
-      unzip -u -q android-ndk-r13b-linux-${ARCH}.zip
-      export ANDROID_NDK_HOME=`pwd`/android-ndk-r13b
+      wget http://dl.google.com/android/repository/android-ndk-r16b-linux-${ARCH}.zip
+      unzip -u -q android-ndk-r16b-linux-${ARCH}.zip
+      export ANDROID_NDK_HOME=`pwd`/android-ndk-r16b
       export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
       export PATH="$ANDROID_NDK_HOME:$PATH"
     fi

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -15,7 +15,7 @@
 
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_PLATFORM := android-22
-APP_STL := gnustl_static
+APP_STL := c++_static
 APP_MODULES := layer_utils VkLayer_core_validation VkLayer_parameter_validation VkLayer_object_tracker VkLayer_threading VkLayer_unique_objects VkLayerValidationTests VulkanLayerValidationTests vkjson_info
 NDK_TOOLCHAIN_VERSION := clang
 NDK_MODULE_PATH := .

--- a/build-android/update_external_sources_android.bat
+++ b/build-android/update_external_sources_android.bat
@@ -279,7 +279,7 @@ goto:eof
    echo Building %SHADERC_DIR%
    cd %SHADERC_DIR%\android_test
    echo Building shaderc with Android NDK
-   call ndk-build THIRD_PARTY_PATH=../third_party -j 4
+   call ndk-build NDK_APPLICATION_MK=../../../jni/shaderc/Application.mk THIRD_PARTY_PATH=../third_party -j 4
    REM Check for existence of one lib, even though we should check for all results
    if not exist %SHADERC_DIR%\android_test\obj\local\x86\libshaderc.a (
       echo.

--- a/build-android/update_external_sources_android.sh
+++ b/build-android/update_external_sources_android.sh
@@ -182,9 +182,9 @@ function build_shaderc () {
    echo "Building $BASEDIR/shaderc"
    cd $BASEDIR/shaderc/android_test
    if [[ $abi ]]; then
-      ndk-build THIRD_PARTY_PATH=../third_party APP_ABI=$abi -j $cores;
+      ndk-build NDK_APPLICATION_MK=../../../jni/shaderc/Application.mk THIRD_PARTY_PATH=../third_party APP_ABI=$abi -j $cores;
    else
-      ndk-build THIRD_PARTY_PATH=../third_party -j $cores;
+      ndk-build NDK_APPLICATION_MK=../../../jni/shaderc/Application.mk THIRD_PARTY_PATH=../third_party -j $cores;
    fi
 }
 

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -33,19 +33,6 @@
 
 #include "buffer_validation.h"
 
-// TODO: remove on NDK update (r15 will probably have proper STL impl)
-#ifdef __ANDROID__
-namespace std {
-
-template <typename T>
-std::string to_string(T var) {
-    std::ostringstream ss;
-    ss << var;
-    return ss.str();
-}
-}  // namespace std
-#endif
-
 void SetLayout(layer_data *device_data, GLOBAL_CB_NODE *pCB, ImageSubresourcePair imgpair, const VkImageLayout &layout) {
     if (pCB->imageLayoutMap.find(imgpair) != pCB->imageLayoutMap.end()) {
         pCB->imageLayoutMap[imgpair].layout = layout;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -81,19 +81,6 @@
     }
 #endif
 
-// TODO: remove on NDK update (r15 will probably have proper STL impl)
-#ifdef __ANDROID__
-namespace std {
-
-template <typename T>
-std::string to_string(T var) {
-    std::ostringstream ss;
-    ss << var;
-    return ss.str();
-}
-}
-#endif
-
 // This intentionally includes a cpp file
 #include "vk_safe_struct.cpp"
 

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -50,19 +50,6 @@
 #include "parameter_name.h"
 #include "parameter_validation.h"
 
-// TODO: remove on NDK update (r15 will probably have proper STL impl)
-#ifdef __ANDROID__
-namespace std {
-
-template <typename T>
-std::string to_string(T var) {
-    std::ostringstream ss;
-    ss << var;
-    return ss.str();
-}
-}  // namespace std
-#endif
-
 namespace parameter_validation {
 
 extern std::unordered_map<std::string, void *> custom_functions;


### PR DESCRIPTION
This includes support for std::to_string, so we can also remove the overrides.

Requires switching our shaderc build over too, which is done with a custom Application.mk.