### PR TITLE
loader: Add emulation for EXT inst extensions

### DIFF
--- a/loader/extension_manual.h
+++ b/loader/extension_manual.h
@@ -110,3 +110,27 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceFormats2KHR(Vk
                                                                               const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
                                                                               uint32_t* pSurfaceFormatCount,
                                                                               VkSurfaceFormat2KHR* pSurfaceFormats);
+
+VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                                                        VkSurfaceCapabilities2EXT* pSurfaceCapabilities);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice physicalDevice,
+                                                                                   VkSurfaceKHR surface,
+                                                                                   VkSurfaceCapabilities2EXT* pSurfaceCapabilities);
+
+VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayKHR display);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_ReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayKHR display);
+
+#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
+VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, VkDisplayKHR display);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_AcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy,
+                                                                VkDisplayKHR display);
+
+VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, RROutput rrOutput,
+                                                        VkDisplayKHR* pDisplay);
+
+VKAPI_ATTR VkResult VKAPI_CALL terminator_GetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, RROutput rrOutput,
+                                                                   VkDisplayKHR* pDisplay);
+#endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -844,7 +844,11 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
                                'vkGetPhysicalDeviceMemoryProperties2KHR',
                                'vkGetPhysicalDeviceSparseImageFormatProperties2KHR',
                                'vkGetPhysicalDeviceSurfaceCapabilities2KHR',
-                               'vkGetPhysicalDeviceSurfaceFormats2KHR']
+                               'vkGetPhysicalDeviceSurfaceFormats2KHR',
+                               'vkGetPhysicalDeviceSurfaceCapabilities2EXT',
+                               'vkReleaseDisplayEXT',
+                               'vkAcquireXlibDisplayEXT',
+                               'vkGetRandROutputDisplayEXT']
 
         for ext_cmd in self.ext_commands:
             if (ext_cmd.ext_name in WSI_EXT_NAMES or


### PR DESCRIPTION
Add loader emulation for the following instance extensions:
    - `VK_EXT_display_surface_counter`
    - `VK_EXT_direct_mode_display`
    - `VK_EXT_acqire_xlib_display`

The loader will still crash when calling `vkReleaseDisplayEXT` on an unsupported physical device, but this is legal since there's no way to acquire a display on the device without getting an error.