### PR TITLE
CMakeLists: only install headers when loader is being installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,7 @@ if(NOT WIN32)
     endif()
 endif()
 
-if(UNIX)
+if(UNIX AND BUILD_LOADER)
     install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # uninstall target


### PR DESCRIPTION
There are scenarios where various components such as
Vulkan-LoaderAndValidationLayers, VulkanTools etc
are installed side by side on the same system. The
header deployment gets in to a conflicting situation
in such setups.
Now we conditionalize the deployment so that the package
building the loader will install the headers as well.

Signed-off-by: Awais Belal <awais_belal@mentor.com>