### PR TITLE
Fix Doc Validator test: add in missing CreatDevice physical device object check

### DIFF
--- a/layers/object_tracker.cpp
+++ b/layers/object_tracker.cpp
@@ -3282,6 +3282,10 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(VkInstance instance,
 VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                             const VkAllocationCallbacks *pAllocator, VkDevice *pDevice) {
     std::lock_guard<std::mutex> lock(global_lock);
+    bool skip = ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, VALIDATION_ERROR_1fc27a01,
+                               VALIDATION_ERROR_UNDEFINED);
+    if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
+
     layer_data *phy_dev_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
     VkLayerDeviceCreateInfo *chain_info = get_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 


### PR DESCRIPTION
This lived in the swapchain layer for some reason.  Added back into object tracker.