### PR TITLE
Suppress info/warning messages when running doc validator from run_all scripts

### DIFF
--- a/tests/_run_all_tests.ps1
+++ b/tests/_run_all_tests.ps1
@@ -31,4 +31,6 @@ if ($lastexitcode -ne 0) {
 
 & $dPath\vk_layer_validation_tests --gtest_filter=-$TestExceptions
 
+& .\vkvalidatelayerdoc.ps1 terse_mode
+
 exit $lastexitcode

--- a/tests/_vkvalidatelayerdoc.ps1
+++ b/tests/_vkvalidatelayerdoc.ps1
@@ -10,6 +10,10 @@ if ($args[0] -eq "-Debug") {
     $dPath = "Release"
 }
 
+if (($args[0] -eq "terse_mode") -Or ($args[1] -eq "terse_mode")) {
+    $output_mode = "terse_mode"
+}
+
 write-host -background black -foreground green "[  RUN     ] " -nonewline
 write-host "vkvalidatelayerdoc.ps1: Validate layer documentation"
 
@@ -17,7 +21,7 @@ write-host "vkvalidatelayerdoc.ps1: Validate layer documentation"
 push-location ..\..\layers
 
 # Validate that layer documentation matches source contents
-python vk_validation_stats.py
+python vk_validation_stats.py $output_mode
 
 # Report result based on exit code
 if (!$LASTEXITCODE) {

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -10,7 +10,7 @@ set -e
 ./run_loader_tests.sh
 
 # Verify that validation checks in source match documentation
-./vkvalidatelayerdoc.sh
+./vkvalidatelayerdoc.sh terse_mode
 
 # vk_layer_validation_tests check to see that validation layers will
 # catch the errors that they are supposed to by intentionally doing things

--- a/tests/vkvalidatelayerdoc.sh
+++ b/tests/vkvalidatelayerdoc.sh
@@ -16,7 +16,7 @@ printf "$GREEN[ RUN      ]$NC $0\n"
 pushd ../../layers
 
 # Validate that layer database matches source contents
-python vk_validation_stats.py
+python vk_validation_stats.py $1
 
 RES=$?
 


### PR DESCRIPTION
- Added doc validator test back into windows run_all_tests script;
- Added 'terse_mode' parm to validator script;
- Modified test scripts to call validator script with terse_mode when called from the linux and windows run_all_tests scripts;