### PR TITLE
scripts:Include string.h in ext helper

### DIFF
--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -559,6 +559,7 @@ class HelperFileOutputGenerator(OutputGenerator):
         extension_helper_header += '#define VK_EXTENSION_HELPER_H_\n'
         struct  = '\n'
         extension_helper_header += '#include <vulkan/vulkan.h>\n'
+        extension_helper_header += '#include <string.h>\n'
         extension_helper_header += '#include <utility>\n'
         extension_helper_header += '\n'
         extension_dict = dict()


### PR DESCRIPTION
vk_extension_helper.h uses strcmp so add include of string.h to make
sure this dependency is correctly met.