### PR TITLE
Require Python 2.7 instead of Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(MAJOR "1")
 string(TOLOWER ${API_NAME} API_LOWERCASE)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-find_package(PythonInterp 3 REQUIRED)
+find_package(PythonInterp 2.7 REQUIRED)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(FALLBACK_CONFIG_DIRS "/etc/xdg" CACHE STRING

--- a/demos/smoke/generate-dispatch-table.py
+++ b/demos/smoke/generate-dispatch-table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (C) 2016 Google, Inc.
 #
@@ -18,6 +18,7 @@
 """Generate Vulkan dispatch table.
 """
 
+from __future__ import print_function
 import os
 import sys
 

--- a/demos/smoke/glsl-to-spirv
+++ b/demos/smoke/glsl-to-spirv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Copyright (C) 2016 Google, Inc.
 #
@@ -19,6 +19,7 @@
 Depends on glslangValidator.
 """
 
+from __future__ import print_function
 import os
 import sys
 import subprocess
@@ -56,10 +57,10 @@ def compile_glsl(filename, tmpfile):
         assert(len(data) and len(data) % 4 == 0)
 
         # determine endianness
-        fmt = ("<" if data[0] == (SPIRV_MAGIC & 0xff) else ">") + "I"
+        b = struct.unpack("B", data[0])[0]
+        fmt = ("<" if b == (SPIRV_MAGIC & 0xff) else ">") + "I"
         for i in range(0, len(data), 4):
             words.append(struct.unpack(fmt, data[i:(i + 4)])[0])
-
         assert(words[0] == SPIRV_MAGIC)
 
 


### PR DESCRIPTION
The other day, I had some CMake issues while building the LVL project on a new Windows workstation; it complained that Python 3 was required, and I only have 2.7 installed. I've already had to jump through some hoops in the past in this area, as while the layers need Python 3 to build, running "git clang-format" on my patches invokes a script that's only compatible with Python 2.x. I usually just install both and dance between them as necessary, but today I decided to figure out if the layers *really* need Python 3.  And as far as I can tell, they don't; only a few scripts in the "smoketest" demo complained at build time, and they seemed relatively easy to fix.

Please take a look and confirm that I've fixed the two specific Python 2.x issues in a way that won't cause problems with Python 3, or that I'm not missing any other unexpected consequences of using an older version. Thanks!
