### PR TITLE
scripts:Temporarily disable doc validation

### DIFF
--- a/tests/_run_all_tests.ps1
+++ b/tests/_run_all_tests.ps1
@@ -31,6 +31,6 @@ if ($lastexitcode -ne 0) {
 
 & $dPath\vk_layer_validation_tests --gtest_filter=-$TestExceptions
 
-& .\vkvalidatelayerdoc.ps1 terse_mode
+# & .\vkvalidatelayerdoc.ps1 terse_mode
 
 exit $lastexitcode

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -10,7 +10,7 @@ set -e
 ./run_loader_tests.sh
 
 # Verify that validation checks in source match documentation
-./vkvalidatelayerdoc.sh terse_mode
+#./vkvalidatelayerdoc.sh terse_mode
 
 # vk_layer_validation_tests check to see that validation layers will
 # catch the errors that they are supposed to by intentionally doing things


### PR DESCRIPTION
Doc validation makes some directory assumptions that are fragile.
Temporarily disabling doc validation from run_all_tests scripts while
I figure out a better solution for how to organize the script and make
sure it can access all the files it needs.