### PR TITLE
Enable linux 32-bit builds with ASFLAGS

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -142,6 +142,7 @@ This list may vary depending on your distro and which windowing systems you are 
 Set up your environment for building 32-bit targets:
 
 ```
+export ASFLAGS=--32
 export CFLAGS=-m32
 export CXXFLAGS=-m32
 export PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -107,6 +107,7 @@ else()
     if (CMAKE_ASM-ATT_COMPILER_WORKS)
         set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} phys_dev_chain_gas.asm)
 
+        set(CMAKE_ASM-ATT_FLAGS "${CMAKE_ASM-ATT_FLAGS} $ENV{ASFLAGS}")
         set(CMAKE_ASM-ATT_FLAGS "${CMAKE_ASM-ATT_FLAGS} -I${CMAKE_CURRENT_BINARY_DIR}")
         add_executable(asm_offset asm_offset.c)
         add_dependencies(asm_offset generate_helper_files loader_gen_files)


### PR DESCRIPTION
PR #1879 made it possible to build for 32-bit linux again, but the way you have to specify the 32-bit build doesn't fit cleanly with the environment variable method given in build.md. This PR lets you build by defining `export ASFLAGS=--32` on the command line, and updates the build instructions to specify that you now need to pass an assembler flag to the build.