### PR TITLE
scripts:Skip doc validation if src dir not found

### DIFF
--- a/tests/_run_all_tests.ps1
+++ b/tests/_run_all_tests.ps1
@@ -31,6 +31,6 @@ if ($lastexitcode -ne 0) {
 
 & $dPath\vk_layer_validation_tests --gtest_filter=-$TestExceptions
 
-# & .\vkvalidatelayerdoc.ps1 terse_mode
+& .\vkvalidatelayerdoc.ps1 terse_mode
 
 exit $lastexitcode

--- a/tests/_vkvalidatelayerdoc.ps1
+++ b/tests/_vkvalidatelayerdoc.ps1
@@ -4,6 +4,14 @@
 #    cd C:\src\Vulkan-LoaderAndValidationLayers\build\tests
 #    .\vkvalidatelayerdoc.ps1 [-Debug]
 
+if (-not (Test-Path -LiteralPath '..\..\layers')) {
+    write-host -background black -foreground green "[  SKIPPED  ] " -nonewline
+    write-host "vkvalidatelayerdoc.ps1: Validate layer documentation"
+    write-host "  To run validation DB checks you can manually execute"
+    write-host "  vk_validation_stats.py from the 'layers' dir of your source tree"
+    exit 0
+}
+
 if ($args[0] -eq "-Debug") {
     $dPath = "Debug"
 } else {

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -10,7 +10,7 @@ set -e
 ./run_loader_tests.sh
 
 # Verify that validation checks in source match documentation
-#./vkvalidatelayerdoc.sh terse_mode
+./vkvalidatelayerdoc.sh terse_mode
 
 # vk_layer_validation_tests check to see that validation layers will
 # catch the errors that they are supposed to by intentionally doing things

--- a/tests/vkvalidatelayerdoc.sh
+++ b/tests/vkvalidatelayerdoc.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #set -x
+
 if [ -t 1 ] ; then
     RED='\033[0;31m'
     GREEN='\033[0;32m'
@@ -8,6 +9,13 @@ else
     RED=''
     GREEN=''
     NC=''
+fi
+# If we can't find the source dir then skip
+if [ ! -d "../../layers" ]; then
+    printf "$GREEN[ SKIPPED  ]$NC $0\n"
+    printf "  To run validation DB checks you can manually execute\n"
+    printf "  vk_validation_stats.py from the 'layers' dir of your source tree\n"
+    exit
 fi
 
 printf "$GREEN[ RUN      ]$NC $0\n"


### PR DESCRIPTION
Fixes #1878

Re-enable doc validation in run_all_tests scripts but skip if directory 
structure does not align with expectations.
If vkvalidatelayerdoc script is not run from a directly two levels
below the layer source, then just skip running it. Print out a message
on how to run doc validation manually for those interested.