### PR TITLE
Tobin shared ptr cleanup

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -149,7 +149,7 @@ struct layer_data {
     unordered_map<VkCommandPool, COMMAND_POOL_NODE> commandPoolMap;
     unordered_map<VkDescriptorPool, DESCRIPTOR_POOL_STATE *> descriptorPoolMap;
     unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> setMap;
-    unordered_map<VkDescriptorSetLayout, std::shared_ptr<cvdescriptorset::DescriptorSetLayout>> descriptorSetLayoutMap;
+    unordered_map<VkDescriptorSetLayout, std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>> descriptorSetLayoutMap;
     unordered_map<VkPipelineLayout, PIPELINE_LAYOUT_NODE> pipelineLayoutMap;
     unordered_map<VkDeviceMemory, unique_ptr<DEVICE_MEM_INFO>> memObjMap;
     unordered_map<VkFence, FENCE_NODE> fenceMap;
@@ -709,8 +709,8 @@ FRAMEBUFFER_STATE *GetFramebufferState(const layer_data *dev_data, VkFramebuffer
     return it->second.get();
 }
 
-std::shared_ptr<cvdescriptorset::DescriptorSetLayout> const GetDescriptorSetLayout(layer_data const *dev_data,
-                                                                                   VkDescriptorSetLayout dsLayout) {
+std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> const GetDescriptorSetLayout(layer_data const *dev_data,
+                                                                                         VkDescriptorSetLayout dsLayout) {
     auto it = dev_data->descriptorSetLayoutMap.find(dsLayout);
     if (it == dev_data->descriptorSetLayoutMap.end()) {
         return nullptr;

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1061,7 +1061,7 @@ static bool verify_set_layout_compatibility(const cvdescriptorset::DescriptorSet
         return false;
     }
     auto layout_node = pipeline_layout->set_layouts[layoutIndex];
-    return descriptor_set->IsCompatible(layout_node, &errorMsg);
+    return descriptor_set->IsCompatible(layout_node.get(), &errorMsg);
 }
 
 // Validate overall state at the time of a draw call

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4530,8 +4530,7 @@ static bool PreCallValidateCreateDescriptorSetLayout(layer_data *dev_data, const
 
 static void PostCallRecordCreateDescriptorSetLayout(layer_data *dev_data, const VkDescriptorSetLayoutCreateInfo *create_info,
                                                     VkDescriptorSetLayout set_layout) {
-    dev_data->descriptorSetLayoutMap[set_layout] =
-        std::shared_ptr<cvdescriptorset::DescriptorSetLayout>(new cvdescriptorset::DescriptorSetLayout(create_info, set_layout));
+    dev_data->descriptorSetLayoutMap[set_layout] = std::make_shared<cvdescriptorset::DescriptorSetLayout>(create_info, set_layout);
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -526,7 +526,7 @@ struct hash<ImageSubresourcePair> {
 // Store layouts and pushconstants for PipelineLayout
 struct PIPELINE_LAYOUT_NODE {
     VkPipelineLayout layout;
-    std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout>> set_layouts;
+    std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>> set_layouts;
     std::vector<VkPushConstantRange> push_constant_ranges;
 
     PIPELINE_LAYOUT_NODE() : layout(VK_NULL_HANDLE), set_layouts{}, push_constant_ranges{} {}
@@ -765,7 +765,7 @@ struct DeviceExtensions;
 namespace core_validation {
 struct layer_data;
 cvdescriptorset::DescriptorSet *GetSetNode(const layer_data *, VkDescriptorSet);
-std::shared_ptr<cvdescriptorset::DescriptorSetLayout> const GetDescriptorSetLayout(layer_data const *, VkDescriptorSetLayout);
+std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> const GetDescriptorSetLayout(layer_data const *, VkDescriptorSetLayout);
 DESCRIPTOR_POOL_STATE *GetDescriptorPoolState(const layer_data *, const VkDescriptorPool);
 BUFFER_STATE *GetBufferState(const layer_data *, VkBuffer);
 IMAGE_STATE *GetImageState(const layer_data *, VkImage);

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -209,7 +209,7 @@ VkSampler const *cvdescriptorset::DescriptorSetLayout::GetImmutableSamplerPtrFro
 }
 // If our layout is compatible with rh_ds_layout, return true,
 //  else return false and fill in error_msg will description of what causes incompatibility
-bool cvdescriptorset::DescriptorSetLayout::IsCompatible(std::shared_ptr<DescriptorSetLayout const> const rh_ds_layout,
+bool cvdescriptorset::DescriptorSetLayout::IsCompatible(DescriptorSetLayout const *const rh_ds_layout,
                                                         std::string *error_msg) const {
     // Trivial case
     if (layout_ == rh_ds_layout->GetDescriptorSetLayout()) return true;
@@ -390,9 +390,8 @@ static std::string string_descriptor_req_view_type(descriptor_req req) {
 }
 
 // Is this sets underlying layout compatible with passed in layout according to "Pipeline Layout Compatibility" in spec?
-bool cvdescriptorset::DescriptorSet::IsCompatible(std::shared_ptr<DescriptorSetLayout const> const layout,
-                                                  std::string *error) const {
-    return layout->IsCompatible(p_layout_, error);
+bool cvdescriptorset::DescriptorSet::IsCompatible(DescriptorSetLayout const *const layout, std::string *error) const {
+    return layout->IsCompatible(p_layout_.get(), error);
 }
 
 // Validate that the state of this set is appropriate for the given bindings and dynamic_offsets at Draw time

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -313,7 +313,7 @@ cvdescriptorset::AllocateDescriptorSetsData::AllocateDescriptorSetsData(uint32_t
     : required_descriptors_by_type{}, layout_nodes(count, nullptr) {}
 
 cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, const VkDescriptorPool pool,
-                                              std::shared_ptr<DescriptorSetLayout> layout, const layer_data *dev_data)
+                                              const std::shared_ptr<DescriptorSetLayout> &layout, const layer_data *dev_data)
     : some_update_(false),
       set_(set),
       pool_state_(nullptr),

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -209,7 +209,7 @@ VkSampler const *cvdescriptorset::DescriptorSetLayout::GetImmutableSamplerPtrFro
 }
 // If our layout is compatible with rh_ds_layout, return true,
 //  else return false and fill in error_msg will description of what causes incompatibility
-bool cvdescriptorset::DescriptorSetLayout::IsCompatible(std::shared_ptr<DescriptorSetLayout> const rh_ds_layout,
+bool cvdescriptorset::DescriptorSetLayout::IsCompatible(std::shared_ptr<DescriptorSetLayout const> const rh_ds_layout,
                                                         std::string *error_msg) const {
     // Trivial case
     if (layout_ == rh_ds_layout->GetDescriptorSetLayout()) return true;
@@ -313,7 +313,7 @@ cvdescriptorset::AllocateDescriptorSetsData::AllocateDescriptorSetsData(uint32_t
     : required_descriptors_by_type{}, layout_nodes(count, nullptr) {}
 
 cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, const VkDescriptorPool pool,
-                                              const std::shared_ptr<DescriptorSetLayout> &layout, const layer_data *dev_data)
+                                              const std::shared_ptr<DescriptorSetLayout const> &layout, const layer_data *dev_data)
     : some_update_(false),
       set_(set),
       pool_state_(nullptr),
@@ -390,7 +390,8 @@ static std::string string_descriptor_req_view_type(descriptor_req req) {
 }
 
 // Is this sets underlying layout compatible with passed in layout according to "Pipeline Layout Compatibility" in spec?
-bool cvdescriptorset::DescriptorSet::IsCompatible(std::shared_ptr<DescriptorSetLayout> const layout, std::string *error) const {
+bool cvdescriptorset::DescriptorSet::IsCompatible(std::shared_ptr<DescriptorSetLayout const> const layout,
+                                                  std::string *error) const {
     return layout->IsCompatible(p_layout_, error);
 }
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -110,7 +110,7 @@ class DescriptorSetLayout {
     bool HasBinding(const uint32_t binding) const { return binding_to_index_map_.count(binding) > 0; };
     // Return true if this layout is compatible with passed in layout,
     //   else return false and update error_msg with description of incompatibility
-    bool IsCompatible(std::shared_ptr<DescriptorSetLayout> const, std::string *) const;
+    bool IsCompatible(std::shared_ptr<DescriptorSetLayout const> const, std::string *) const;
     // Return true if binding 1 beyond given exists and has same type, stageFlags & immutable sampler use
     bool IsNextBindingConsistent(const uint32_t) const;
     // Various Get functions that can either be passed a binding#, which will
@@ -321,7 +321,7 @@ void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const Vk
  */
 class DescriptorSet : public BASE_NODE {
    public:
-    DescriptorSet(const VkDescriptorSet, const VkDescriptorPool, const std::shared_ptr<DescriptorSetLayout> &,
+    DescriptorSet(const VkDescriptorSet, const VkDescriptorPool, const std::shared_ptr<DescriptorSetLayout const> &,
                   const core_validation::layer_data *);
     ~DescriptorSet();
     // A number of common Get* functions that return data based on layout from which this set was created
@@ -342,7 +342,7 @@ class DescriptorSet : public BASE_NODE {
     // Return true if given binding is present in this set
     bool HasBinding(const uint32_t binding) const { return p_layout_->HasBinding(binding); };
     // Is this set compatible with the given layout?
-    bool IsCompatible(std::shared_ptr<DescriptorSetLayout> const, std::string *) const;
+    bool IsCompatible(std::shared_ptr<DescriptorSetLayout const> const, std::string *) const;
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
     bool ValidateDrawState(const std::map<uint32_t, descriptor_req> &, const std::vector<uint32_t> &, const GLOBAL_CB_NODE *,
                            const char *caller, std::string *) const;
@@ -363,7 +363,7 @@ class DescriptorSet : public BASE_NODE {
     // Perform a CopyUpdate whose contents were just validated using ValidateCopyUpdate
     void PerformCopyUpdate(const VkCopyDescriptorSet *, const DescriptorSet *);
 
-    std::shared_ptr<DescriptorSetLayout> const GetLayout() const { return p_layout_; };
+    std::shared_ptr<DescriptorSetLayout const> const GetLayout() const { return p_layout_; };
     VkDescriptorSet GetSet() const { return set_; };
     // Return unordered_set of all command buffers that this set is bound to
     std::unordered_set<GLOBAL_CB_NODE *> GetBoundCmdBuffers() const { return cb_bindings; }
@@ -397,7 +397,7 @@ class DescriptorSet : public BASE_NODE {
     bool some_update_;  // has any part of the set ever been updated?
     VkDescriptorSet set_;
     DESCRIPTOR_POOL_STATE *pool_state_;
-    const std::shared_ptr<DescriptorSetLayout> p_layout_;
+    const std::shared_ptr<DescriptorSetLayout const> p_layout_;
     std::vector<std::unique_ptr<Descriptor>> descriptors_;
     // Ptr to device data used for various data look-ups
     const core_validation::layer_data *device_data_;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -110,7 +110,7 @@ class DescriptorSetLayout {
     bool HasBinding(const uint32_t binding) const { return binding_to_index_map_.count(binding) > 0; };
     // Return true if this layout is compatible with passed in layout,
     //   else return false and update error_msg with description of incompatibility
-    bool IsCompatible(std::shared_ptr<DescriptorSetLayout const> const, std::string *) const;
+    bool IsCompatible(DescriptorSetLayout const *const, std::string *) const;
     // Return true if binding 1 beyond given exists and has same type, stageFlags & immutable sampler use
     bool IsNextBindingConsistent(const uint32_t) const;
     // Various Get functions that can either be passed a binding#, which will
@@ -342,7 +342,7 @@ class DescriptorSet : public BASE_NODE {
     // Return true if given binding is present in this set
     bool HasBinding(const uint32_t binding) const { return p_layout_->HasBinding(binding); };
     // Is this set compatible with the given layout?
-    bool IsCompatible(std::shared_ptr<DescriptorSetLayout const> const, std::string *) const;
+    bool IsCompatible(DescriptorSetLayout const *const, std::string *) const;
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
     bool ValidateDrawState(const std::map<uint32_t, descriptor_req> &, const std::vector<uint32_t> &, const GLOBAL_CB_NODE *,
                            const char *caller, std::string *) const;

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -276,7 +276,7 @@ class BufferDescriptor : public Descriptor {
 // Structs to contain common elements that need to be shared between Validate* and Perform* calls below
 struct AllocateDescriptorSetsData {
     uint32_t required_descriptors_by_type[VK_DESCRIPTOR_TYPE_RANGE_SIZE];
-    std::vector<std::shared_ptr<DescriptorSetLayout>> layout_nodes;
+    std::vector<std::shared_ptr<DescriptorSetLayout const>> layout_nodes;
     AllocateDescriptorSetsData(uint32_t);
 };
 // Helper functions for descriptor set functions that cross multiple sets

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -321,7 +321,7 @@ void PerformAllocateDescriptorSets(const VkDescriptorSetAllocateInfo *, const Vk
  */
 class DescriptorSet : public BASE_NODE {
    public:
-    DescriptorSet(const VkDescriptorSet, const VkDescriptorPool, const std::shared_ptr<DescriptorSetLayout>,
+    DescriptorSet(const VkDescriptorSet, const VkDescriptorPool, const std::shared_ptr<DescriptorSetLayout> &,
                   const core_validation::layer_data *);
     ~DescriptorSet();
     // A number of common Get* functions that return data based on layout from which this set was created


### PR DESCRIPTION
Clean up various shared_ptr uses for recent DescriptorSetLayout changes.

@chrisforbes, should be better but lemme know if I'm still missing anything

I looked at making AllocateDescriptorSetsData non-owning, but it's used to transfer shared_ptr ownership into DescriptorSet at create time so seemed appropriate to keep shared_ptr there although its lifetime is limited.