### PR TITLE
build: Exit with return code in update_external bat

### DIFF
--- a/update_external_sources.bat
+++ b/update_external_sources.bat
@@ -217,13 +217,12 @@ goto:finish
 :error
 echo.
 echo Halting due to error
+set errorCode=1
 goto:finish
 
 :finish
 if not "%cd%\" == "%BUILD_DIR%" ( cd %BUILD_DIR% )
-endlocal
-goto:eof
-
+exit /b %errorCode%
 
 
 REM // ======== Functions ======== //


### PR DESCRIPTION
Update_external_sources could fail and the scripts that call it would continue using whatever external sources were already built.  This change makes the failure more obvious.