### PR TITLE
headers: Enforce C-style comments

### DIFF
--- a/include/vulkan/vk_icd.h
+++ b/include/vulkan/vk_icd.h
@@ -1,7 +1,7 @@
-//
-// File: vk_icd.h
-//
 /*
+ * File: vk_icd.h
+ *
+ *
  * Copyright (c) 2015-2016 The Khronos Group Inc.
  * Copyright (c) 2015-2016 Valve Corporation
  * Copyright (c) 2015-2016 LunarG, Inc.
@@ -26,28 +26,30 @@
 #include "vulkan.h"
 #include <stdbool.h>
 
-// Loader-ICD version negotiation API.  Versions add the following features:
-//   Version 0 - Initial.  Doesn't support vk_icdGetInstanceProcAddr
-//               or vk_icdNegotiateLoaderICDInterfaceVersion.
-//   Version 1 - Add support for vk_icdGetInstanceProcAddr.
-//   Version 2 - Add Loader/ICD Interface version negotiation
-//               via vk_icdNegotiateLoaderICDInterfaceVersion.
-//   Version 3 - Add ICD creation/destruction of KHR_surface objects.
-//   Version 4 - Add unknown physical device extension qyering via
-//               vk_icdGetPhysicalDeviceProcAddr.
-//   Version 5 - Tells ICDs that the loader is now paying attention to the
-//               application version of Vulkan passed into the ApplicationInfo
-//               structure during vkCreateInstance.  This will tell the ICD
-//               that if the loader is older, it should automatically fail a
-//               call for any API version > 1.0.  Otherwise, the loader will
-//               manually determine if it can support the expected version.
+/* Loader-ICD version negotiation API.  Versions add the following features:
+ *   Version 0 - Initial.  Doesn't support vk_icdGetInstanceProcAddr
+ *               or vk_icdNegotiateLoaderICDInterfaceVersion.
+ *   Version 1 - Add support for vk_icdGetInstanceProcAddr.
+ *   Version 2 - Add Loader/ICD Interface version negotiation
+ *               via vk_icdNegotiateLoaderICDInterfaceVersion.
+ *   Version 3 - Add ICD creation/destruction of KHR_surface objects.
+ *   Version 4 - Add unknown physical device extension qyering via
+ *               vk_icdGetPhysicalDeviceProcAddr.
+ *   Version 5 - Tells ICDs that the loader is now paying attention to the
+ *               application version of Vulkan passed into the ApplicationInfo
+ *               structure during vkCreateInstance.  This will tell the ICD
+ *               that if the loader is older, it should automatically fail a
+ *               call for any API version > 1.0.  Otherwise, the loader will
+ *               manually determine if it can support the expected version.
+ */
 #define CURRENT_LOADER_ICD_INTERFACE_VERSION 5
 #define MIN_SUPPORTED_LOADER_ICD_INTERFACE_VERSION 0
 #define MIN_PHYS_DEV_EXTENSION_ICD_INTERFACE_VERSION 4
 typedef VkResult (VKAPI_PTR *PFN_vkNegotiateLoaderICDInterfaceVersion)(uint32_t *pVersion);
 
-// This is defined in vk_layer.h which will be found by the loader, but if an ICD is building against this
-// flie directly, it won't be found.
+/* This is defined in vk_layer.h which will be found by the loader, but if an ICD is building against this
+ * flie directly, it won't be found.
+ */
 #ifndef PFN_GetPhysicalDeviceProcAddr
 typedef PFN_vkVoidFunction (VKAPI_PTR *PFN_GetPhysicalDeviceProcAddr)(VkInstance instance, const char* pName);
 #endif
@@ -98,7 +100,7 @@ typedef struct {
     MirConnection *connection;
     MirSurface *mirSurface;
 } VkIcdSurfaceMir;
-#endif // VK_USE_PLATFORM_MIR_KHR
+#endif /* VK_USE_PLATFORM_MIR_KHR */
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 typedef struct {
@@ -106,7 +108,7 @@ typedef struct {
     struct wl_display *display;
     struct wl_surface *surface;
 } VkIcdSurfaceWayland;
-#endif // VK_USE_PLATFORM_WAYLAND_KHR
+#endif /* VK_USE_PLATFORM_WAYLAND_KHR */
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 typedef struct {
@@ -114,7 +116,7 @@ typedef struct {
     HINSTANCE hinstance;
     HWND hwnd;
 } VkIcdSurfaceWin32;
-#endif // VK_USE_PLATFORM_WIN32_KHR
+#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
 typedef struct {
@@ -122,7 +124,7 @@ typedef struct {
     xcb_connection_t *connection;
     xcb_window_t window;
 } VkIcdSurfaceXcb;
-#endif // VK_USE_PLATFORM_XCB_KHR
+#endif /* VK_USE_PLATFORM_XCB_KHR */
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
 typedef struct {
@@ -130,13 +132,13 @@ typedef struct {
     Display *dpy;
     Window window;
 } VkIcdSurfaceXlib;
-#endif // VK_USE_PLATFORM_XLIB_KHR
+#endif /* VK_USE_PLATFORM_XLIB_KHR */
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 typedef struct {
     ANativeWindow* window;
 } VkIcdSurfaceAndroid;
-#endif //VK_USE_PLATFORM_ANDROID_KHR
+#endif /* VK_USE_PLATFORM_ANDROID_KHR */
 
 typedef struct {
     VkIcdSurfaceBase base;
@@ -149,4 +151,4 @@ typedef struct {
     VkExtent2D imageExtent;
 } VkIcdSurfaceDisplay;
 
-#endif // VKICD_H
+#endif /* VKICD_H */

--- a/include/vulkan/vk_layer.h
+++ b/include/vulkan/vk_layer.h
@@ -1,7 +1,7 @@
-//
-// File: vk_layer.h
-//
 /*
+ * File: vk_layer.h
+ *
+ *
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
@@ -35,26 +35,29 @@
 #define VK_LAYER_EXPORT
 #endif
 
-// Definition for VkLayerDispatchTable and VkLayerInstanceDispatchTable now appear in externally generated header
+/* Definition for VkLayerDispatchTable and VkLayerInstanceDispatchTable
+ * now appear in externally generated header
+ */
 #include "vk_layer_dispatch_table.h"
 
 #define MAX_NUM_UNKNOWN_EXTS 250
 
- // Loader-Layer version negotiation API.  Versions add the following features:
- //   Versions 0/1 - Initial.  Doesn't support vk_layerGetPhysicalDeviceProcAddr
- //                  or vk_icdNegotiateLoaderLayerInterfaceVersion.
- //   Version 2    - Add support for vk_layerGetPhysicalDeviceProcAddr and
- //                  vk_icdNegotiateLoaderLayerInterfaceVersion.
+ /* Loader-Layer version negotiation API.  Versions add the following features:
+  *   Versions 0/1 - Initial.  Doesn't support vk_layerGetPhysicalDeviceProcAddr
+  *                  or vk_icdNegotiateLoaderLayerInterfaceVersion.
+  *   Version 2    - Add support for vk_layerGetPhysicalDeviceProcAddr and
+  *                  vk_icdNegotiateLoaderLayerInterfaceVersion.
+  */
 #define CURRENT_LOADER_LAYER_INTERFACE_VERSION 2
 #define MIN_SUPPORTED_LOADER_LAYER_INTERFACE_VERSION 1
 
-// Version negotiation values
+/* Version negotiation values */
 typedef enum VkNegotiateLayerStructType {
     LAYER_NEGOTIATE_UNINTIALIZED = 0,
     LAYER_NEGOTIATE_INTERFACE_STRUCT = 1,
 } VkNegotiateLayerStructType;
 
-// Version negotiation structures
+/* Version negotiation structures */
 typedef struct VkNegotiateLayerInterface {
     VkNegotiateLayerStructType sType;
     void *pNext;
@@ -64,16 +67,16 @@ typedef struct VkNegotiateLayerInterface {
     PFN_GetPhysicalDeviceProcAddr pfnGetPhysicalDeviceProcAddr;
 } VkNegotiateLayerInterface;
 
-// Version negotiation functions
+/* Version negotiation functions */
 typedef VkResult (VKAPI_PTR *PFN_vkNegotiateLoaderLayerInterfaceVersion)(VkNegotiateLayerInterface *pVersionStruct);
 
-// Function prototype for unknown physical device extension command
+/* Function prototype for unknown physical device extension command */
 typedef VkResult(VKAPI_PTR *PFN_PhysDevExt)(VkPhysicalDevice phys_device);
 
-// ------------------------------------------------------------------------------------------------
-// CreateInstance and CreateDevice support structures
+/* ------------------------------------------------------------------------------------------------
+ * CreateInstance and CreateDevice support structures
 
-/* Sub type of structure for instance and device loader ext of CreateInfo.
+ * Sub type of structure for instance and device loader ext of CreateInfo.
  * When sType == VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
  * or sType == VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
  * then VkLayerFunction indicates struct type pointed to by pNext
@@ -107,7 +110,7 @@ typedef VkResult (VKAPI_PTR *PFN_vkSetDeviceLoaderData)(VkDevice device,
         void *object);
 
 typedef struct {
-    VkStructureType sType; // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
+    VkStructureType sType; /* VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO */
     const void *pNext;
     VkLayerFunction function;
     union {
@@ -123,7 +126,7 @@ typedef struct VkLayerDeviceLink_ {
 } VkLayerDeviceLink;
 
 typedef struct {
-    VkStructureType sType; // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
+    VkStructureType sType; /* VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO */
     const void *pNext;
     VkLayerFunction function;
     union {

--- a/include/vulkan/vk_platform.h
+++ b/include/vulkan/vk_platform.h
@@ -1,7 +1,7 @@
-//
-// File: vk_platform.h
-//
 /*
+** File: vk_platform.h
+**
+**
 ** Copyright (c) 2014-2017 The Khronos Group Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@
 #ifdef __cplusplus
 extern "C"
 {
-#endif // __cplusplus
+#endif /* __cplusplus */
 
 /*
 ***************************************************************************************************
@@ -47,22 +47,23 @@ extern "C"
  * Function pointer type: typedef void (VKAPI_PTR *PFN_vkCommand)(void);
  */
 #if defined(_WIN32)
-    // On Windows, Vulkan commands use the stdcall convention
+    /* On Windows, Vulkan commands use the stdcall convention */
     #define VKAPI_ATTR
     #define VKAPI_CALL __stdcall
     #define VKAPI_PTR  VKAPI_CALL
 #elif defined(__ANDROID__) && defined(__ARM_ARCH) && __ARM_ARCH < 7
     #error "Vulkan isn't supported for the 'armeabi' NDK ABI"
 #elif defined(__ANDROID__) && defined(__ARM_ARCH) && __ARM_ARCH >= 7 && defined(__ARM_32BIT_STATE)
-    // On Android 32-bit ARM targets, Vulkan functions use the "hardfloat"
-    // calling convention, i.e. float parameters are passed in registers. This
-    // is true even if the rest of the application passes floats on the stack,
-    // as it does by default when compiling for the armeabi-v7a NDK ABI.
+    /* On Android 32-bit ARM targets, Vulkan functions use the "hardfloat"
+    ** calling convention, i.e. float parameters are passed in registers. This
+    ** is true even if the rest of the application passes floats on the stack,
+    ** as it does by default when compiling for the armeabi-v7a NDK ABI.
+    */
     #define VKAPI_ATTR __attribute__((pcs("aapcs-vfp")))
     #define VKAPI_CALL
     #define VKAPI_PTR  VKAPI_ATTR
 #else
-    // On other platforms, use the default calling convention
+    /* On other platforms, use the default calling convention */
     #define VKAPI_ATTR
     #define VKAPI_CALL
     #define VKAPI_PTR
@@ -83,15 +84,16 @@ extern "C"
     #else
         #include <stdint.h>
     #endif
-#endif // !defined(VK_NO_STDINT_H)
+#endif /* !defined(VK_NO_STDINT_H) */
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
-// Platform-specific headers required by platform window system extensions.
-// These are enabled prior to #including "vulkan.h". The same enable then
-// controls inclusion of the extension interfaces in vulkan.h.
+/* Platform-specific headers required by platform window system extensions.
+** These are enabled prior to #including "vulkan.h". The same enable then
+** controls inclusion of the extension interfaces in vulkan.h.
+*/
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 #include <android/native_window.h>

--- a/include/vulkan/vk_sdk_platform.h
+++ b/include/vulkan/vk_sdk_platform.h
@@ -1,7 +1,7 @@
-//
-// File: vk_sdk_platform.h
-//
 /*
+ * File: vk_sdk_platform.h
+ *
+ *
  * Copyright (c) 2015-2016 The Khronos Group Inc.
  * Copyright (c) 2015-2016 Valve Corporation
  * Copyright (c) 2015-2016 LunarG, Inc.
@@ -27,20 +27,21 @@
 #ifndef __cplusplus
 #undef inline
 #define inline __inline
-#endif // __cplusplus
+#endif /* __cplusplus */
 
 #if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
-// C99:
-// Microsoft didn't implement C99 in Visual Studio; but started adding it with
-// VS2013.  However, VS2013 still didn't have snprintf().  The following is a
-// work-around (Note: The _CRT_SECURE_NO_WARNINGS macro must be set in the
-// "CMakeLists.txt" file).
-// NOTE: This is fixed in Visual Studio 2015.
+/* C99:
+** Microsoft didn't implement C99 in Visual Studio; but started adding it with
+** VS2013.  However, VS2013 still didn't have snprintf().  The following is a
+** work-around (Note: The _CRT_SECURE_NO_WARNINGS macro must be set in the
+** "CMakeLists.txt" file).
+** NOTE: This is fixed in Visual Studio 2015.
+*/
 #define snprintf _snprintf
 #endif
 
 #define strdup _strdup
 
-#endif // _WIN32
+#endif /* _WIN32 */
 
-#endif // VK_SDK_PLATFORM_H
+#endif /* VK_SDK_PLATFORM_H */

--- a/include/vulkan/vulkan.h
+++ b/include/vulkan/vulkan.h
@@ -33,16 +33,20 @@ extern "C" {
 #define VK_MAKE_VERSION(major, minor, patch) \
     (((major) << 22) | ((minor) << 12) | (patch))
 
-// DEPRECATED: This define has been removed. Specific version defines (e.g. VK_API_VERSION_1_0), or the VK_MAKE_VERSION macro, should be used instead.
-//#define VK_API_VERSION VK_MAKE_VERSION(1, 0, 0)
+/* DEPRECATED: This define has been removed. Specific
+** version defines (e.g. VK_API_VERSION_1_0), or the
+** VK_MAKE_VERSION macro, should be used instead.
+**
+** #define VK_API_VERSION VK_MAKE_VERSION(1, 0, 0)
+*/
 
-// Vulkan 1.0 version number
+/* Vulkan 1.0 version number */
 #define VK_API_VERSION_1_0 VK_MAKE_VERSION(1, 0, 0)
 
 #define VK_VERSION_MAJOR(version) ((uint32_t)(version) >> 22)
 #define VK_VERSION_MINOR(version) (((uint32_t)(version) >> 12) & 0x3ff)
 #define VK_VERSION_PATCH(version) ((uint32_t)(version) & 0xfff)
-// Version of this file
+/* Version of this file */
 #define VK_HEADER_VERSION 51
 
 


### PR DESCRIPTION
When compiling with -std=c90, GCC complains about C++ style comments.
These changes do no affect readability of the header files and
ensures that the headers can be included in any C90-conformant code.