### PR TITLE
loader: Remove executable stack from libvulkan.so

### DIFF
--- a/loader/unknown_ext_chain_gas.asm
+++ b/loader/unknown_ext_chain_gas.asm
@@ -108,6 +108,10 @@ vkdev_ext\num:
 
 .endif
 
+#if defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
+
 .data
 
 termin_error_string:


### PR DESCRIPTION
This addresses issue #1956, which complains that the loader is requesting an executable stack. See that issue for more details.