### PR TITLE
scripts: Switch codegen to use structextends

### DIFF
--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -344,7 +344,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                                                  isconst=True if 'const' in cdecl else False,
                                                  iscount=True if name in lens else False,
                                                  len=self.getLen(member),
-                                                 extstructs=member.attrib.get('validextensionstructs') if name == 'pNext' else None,
+                                                 extstructs=self.registry.validextensionstructs[typeName] if name == 'pNext' else None,
                                                  cdecl=cdecl))
         self.structMembers.append(self.StructMemberData(name=typeName, members=membersInfo, ifdef_protect=self.featureExtraProtect))
     #

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -422,7 +422,7 @@ class ParamCheckerOutputGenerator(OutputGenerator):
                                                 iscount=iscount,
                                                 noautovalidity=noautovalidity,
                                                 len=self.getLen(member),
-                                                extstructs=member.attrib.get('validextensionstructs') if name == 'pNext' else None,
+                                                extstructs=self.registry.validextensionstructs[typeName] if name == 'pNext' else None,
                                                 condition=conditions[name] if conditions and name in conditions else None,
                                                 cdecl=cdecl))
         self.structMembers.append(self.StructMemberData(name=typeName, members=membersInfo))
@@ -795,9 +795,8 @@ class ParamCheckerOutputGenerator(OutputGenerator):
         if value.extstructs:
             extStructVar = 'allowed_structs_{}'.format(struct_type_name)
             extStructCount = 'ARRAY_SIZE({})'.format(extStructVar)
-            structs = value.extstructs.split(',')
-            extStructNames = '"' + ', '.join(structs) + '"'
-            checkExpr.append('const VkStructureType {}[] = {{ {} }};\n'.format(extStructVar, ', '.join([self.getStructType(s) for s in structs])))
+            extStructNames = '"' + ', '.join(value.extstructs) + '"'
+            checkExpr.append('const VkStructureType {}[] = {{ {} }};\n'.format(extStructVar, ', '.join([self.getStructType(s) for s in value.extstructs])))
         checkExpr.append('skipCall |= validate_struct_pnext(layer_data->report_data, "{}", {ppp}"{}"{pps}, {}, {}{}, {}, {}, GeneratedHeaderVersion, {});\n'.format(
             funcPrintName, valuePrintName, extStructNames, prefix, value.name, extStructCount, extStructVar, vuid, **postProcSpec))
         return checkExpr

--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -172,7 +172,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
         self.cmd_info_data = []        # Save the cmdinfo data for wrapping the handles when processing is complete
         self.structMembers = []        # List of StructMemberData records for all Vulkan structs
         self.extension_structs = []    # List of all structs or sister-structs containing handles
-                                       # A sister-struct may contain no handles but shares <validextensionstructs> with one that does
+                                       # A sister-struct may contain no handles but shares a structextends attribute with one that does
         self.structTypes = dict()      # Map of Vulkan struct typename to required VkStructureType
         self.struct_member_dict = dict()
         # Named tuples to store struct and command data
@@ -400,7 +400,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
                 # Store the required type value
                 self.structTypes[typeName] = self.StructType(name=name, value=value)
             # Store pointer/array/string info
-            extstructs = member.attrib.get('validextensionstructs') if name == 'pNext' else None
+            extstructs = self.registry.validextensionstructs[typeName] if name == 'pNext' else None
             membersInfo.append(self.CommandParam(type=type,
                                                  name=name,
                                                  ispointer=self.paramIsPointer(member),
@@ -457,18 +457,18 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
                 ndo_list.add(item)
         return ndo_list
     #
-    # Construct list of extension structs containing handles, or extension structs that share a <validextensionstructs>
-    # tag WITH an extension struct containing handles. All extension structs in any pNext chain will have to be copied.
+    # Construct list of extension structs containing handles, or extension structs that share a structextends attribute
+    # WITH an extension struct containing handles. All extension structs in any pNext chain will have to be copied.
     # TODO: make this recursive -- structs buried three or more levels deep are not searched for extensions
     def GenerateCommandWrapExtensionList(self):
         for struct in self.structMembers:
             if (len(struct.members) > 1) and struct.members[1].extstructs is not None:
                 found = False;
-                for item in struct.members[1].extstructs.split(','):
+                for item in struct.members[1].extstructs:
                     if item != '' and self.struct_contains_ndo(item) == True:
                         found = True
                 if found == True:
-                    for item in struct.members[1].extstructs.split(','):
+                    for item in struct.members[1].extstructs:
                         if item != '' and item not in self.extension_structs:
                             self.extension_structs.append(item)
     #
@@ -477,7 +477,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
         if struct_type in self.struct_member_dict:
             param_info = self.struct_member_dict[struct_type]
             if (len(param_info) > 1) and param_info[1].extstructs is not None:
-                for item in param_info[1].extstructs.split(','):
+                for item in param_info[1].extstructs:
                     if item in self.extension_structs:
                         return True
         return False
@@ -820,7 +820,7 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
                     islocal = True
             isdestroy = True if True in [destroy_txt in cmdname for destroy_txt in ['Destroy', 'Free']] else False
             iscreate = True if True in [create_txt in cmdname for create_txt in ['Create', 'Allocate', 'GetRandROutputDisplayEXT', 'RegisterDeviceEvent', 'RegisterDisplayEvent']] else False
-            extstructs = member.attrib.get('validextensionstructs') if name == 'pNext' else None
+            extstructs = self.registry.validextensionstructs[type] if name == 'pNext' else None
             membersInfo.append(self.CommandParam(type=type,
                                                  name=name,
                                                  ispointer=ispointer,


### PR DESCRIPTION
Replace all usages of the deprecated validextensionstructs member
attribute with the registry.validextensionstructs dict.  Internally the
registry builds this extension dictionary using the new structextends
type attribute.