### PR TITLE
Output strings instead of indices in physical device feature error messages

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2009,12 +2009,11 @@ static bool ValidateRequestedFeatures(instance_layer_data *instance_data, const 
     uint32_t total_bools = sizeof(VkPhysicalDeviceFeatures) / sizeof(VkBool32);
     for (uint32_t i = 0; i < total_bools; i++) {
         if (requested[i] > actual[i]) {
-            // TODO: Add index to struct member name helper to be able to include a feature name
             skip |= log_msg(instance_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT,
                             VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, 0, __LINE__, DEVLIMITS_INVALID_FEATURE_REQUESTED, "DL",
-                            "While calling vkCreateDevice(), requesting feature #%u in VkPhysicalDeviceFeatures struct, "
+                            "While calling vkCreateDevice(), requesting feature '%s' in VkPhysicalDeviceFeatures struct, "
                             "which is not available on this device.",
-                            i);
+                            GetPhysDevFeatureString(i));
             errors++;
         }
     }

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -364,6 +364,23 @@ class HelperFileOutputGenerator(OutputGenerator):
         outstring += '}\n'
         return outstring
     #
+    # Tack on a helper which, given an index into a VkPhysicalDeviceFeatures structure, will print the corresponding feature name
+    def DeIndexPhysDevFeatures(self):
+        pdev_members = None
+        for name, members, ifdef in self.structMembers:
+            if name == 'VkPhysicalDeviceFeatures':
+                pdev_members = members
+                break
+        deindex = '\n'
+        deindex += 'static const char * GetPhysDevFeatureString(uint32_t index) {\n'
+        deindex += '    const char * IndexToPhysDevFeatureString[] = {\n'
+        for feature in pdev_members:
+            deindex += '        "%s",\n' % feature.name
+        deindex += '    };\n\n'
+        deindex += '    return IndexToPhysDevFeatureString[index];\n'
+        deindex += '}\n'
+        return deindex
+    #
     # Combine enum string helper header file preamble with body text and return
     def GenerateEnumStringHelperHeader(self):
             enum_string_helper_header = '\n'
@@ -375,6 +392,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             enum_string_helper_header += '#include <vulkan/vulkan.h>\n'
             enum_string_helper_header += '\n'
             enum_string_helper_header += self.enum_output
+            enum_string_helper_header += self.DeIndexPhysDevFeatures()
             return enum_string_helper_header
     #
     # struct_size_header: build function prototypes for header file


### PR DESCRIPTION
Fixes #1924.  Tacked a generated helper function onto the enum string helper header.