### PR TITLE
tests: Return errorcode on Windows if layer tests fail

### DIFF
--- a/tests/_run_all_tests.ps1
+++ b/tests/_run_all_tests.ps1
@@ -30,6 +30,9 @@ if ($lastexitcode -ne 0) {
 }
 
 & $dPath\vk_layer_validation_tests --gtest_filter=-$TestExceptions
+if ($lastexitcode -ne 0) {
+   exit 1
+}
 
 & .\vkvalidatelayerdoc.ps1 terse_mode
 


### PR DESCRIPTION
The call to validate docs was stomping on the layer validation test result.