### PR TITLE
Install vk_layer_dispatch_table.h header.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ endif()
 if(UNIX)
     if(INSTALL_LVL_FILES)
         install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/vulkan" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/vk_layer_dispatch_table.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/vulkan")
     endif()
 
 # uninstall target


### PR DESCRIPTION
vk_layer.h is installed and includes it. Also, vk_layer.h is needed
to write third party layers, so I don't think not installing vk_layer.h
is an option.