### PR TITLE
layers: Don't do bogus transitions in invalidateCommandBuffers

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4117,7 +4117,7 @@ void invalidateCommandBuffers(const layer_data *dev_data, std::unordered_set<GLO
                     "Invalidating a command buffer that's currently being recorded: 0x%p.", cb_node->commandBuffer);
             cb_node->state = CB_INVALID_INCOMPLETE;
         }
-        else {
+        else if (cb_node->state == CB_RECORDED) {
             cb_node->state = CB_INVALID_COMPLETE;
         }
         cb_node->broken_bindings.push_back(obj);


### PR DESCRIPTION
Total nonsense like:

  RECORDING -> INVALID_INCOMPLETE -> INVALID_COMPLETE

was possible when there were two invalidations.