### PR TITLE
android: Updates for NDK r15

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -200,6 +200,7 @@ LOCAL_SHARED_LIBRARIES += shaderc-prebuilt glslang-prebuilt OGLCompiler-prebuilt
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden -DVALIDATION_APK --include=$(SRC_DIR)/common/vulkan_wrapper.h
 LOCAL_WHOLE_STATIC_LIBRARIES += android_native_app_glue
 LOCAL_LDLIBS := -llog -landroid
+LOCAL_LDFLAGS := -u ANativeActivity_onCreate
 include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,android/native_app_glue)

--- a/common/android_util.cpp
+++ b/common/android_util.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <string>
 #include <sstream>
+#include <stdlib.h>
 
 extern "C" {
 

--- a/demos/android/jni/Android.mk
+++ b/demos/android/jni/Android.mk
@@ -29,6 +29,7 @@ LOCAL_C_INCLUDES += $(SRC_DIR)/include \
 LOCAL_CFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR --include=$(SRC_DIR)/common/vulkan_wrapper.h
 LOCAL_WHOLE_STATIC_LIBRARIES += android_native_app_glue
 LOCAL_LDLIBS    := -llog -landroid
+LOCAL_LDFLAGS   := -u ANativeActivity_onCreate
 include $(BUILD_SHARED_LIBRARY)
 
 $(call import-module,android/native_app_glue)

--- a/demos/cube.c
+++ b/demos/cube.c
@@ -4131,8 +4131,6 @@ static void processCommand(struct android_app* app, int32_t cmd) {
 
 void android_main(struct android_app *app)
 {
-    app_dummy();
-
 #ifdef ANDROID
     int vulkanSupport = InitVulkan();
     if (vulkanSupport == 0)

--- a/demos/smoke/ShellAndroid.cpp
+++ b/demos/smoke/ShellAndroid.cpp
@@ -112,7 +112,6 @@ ShellAndroid::ShellAndroid(android_app &app, Game &game) : Shell(game), app_(app
 
     instance_extensions_.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
 
-    app_dummy();
     app_.userData = this;
     app_.onAppCmd = on_app_cmd;
     app_.onInputEvent = on_input_event;

--- a/demos/smoke/android/CMakeLists.txt
+++ b/demos/smoke/android/CMakeLists.txt
@@ -32,6 +32,11 @@ set(CMAKE_CXX_FLAGS
             -Wextra -Wno-unused-parameter \
             -DVK_NO_PROTOTYPES -DVK_USE_PLATFORM_ANDROID_KHR \
             -DGLM_FORCE_RADIANS")
+
+# Force export ANativeActivity_onCreate(),
+# Refer to: https://github.com/android-ndk/ndk/issues/381.
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
+
 add_library(Smoke SHARED
             ${smokeDir}/Game.cpp
             ${smokeDir}/Meshes.cpp

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -24707,8 +24707,6 @@ static void processCommand(struct android_app *app, int32_t cmd) {
 }
 
 void android_main(struct android_app *app) {
-    app_dummy();
-
     int vulkanSupport = InitVulkan();
     if (vulkanSupport == 0) {
         __android_log_print(ANDROID_LOG_INFO, appTag, "==== FAILED ==== No Vulkan support found");


### PR DESCRIPTION
Removes app_dummy from apps that use native activity.

For more details refer to: https://github.com/android-ndk/ndk/issues/381

@ggfan, this mirrors changes you've made downstream.