### PR TITLE
vkjson: Add support for Android

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -333,7 +333,18 @@ adb install -r ../demos/android/cube-with-layers/bin/cube-with-layers.apk
 adb shell am start com.example.CubeWithLayers/android.app.NativeActivity
 adb shell am start -a android.intent.action.MAIN -c android-intent.category.LAUNCH -n com.example.CubeWithLayers/android.app.NativeActivity --es args "--validate"
 ```
+vkjson_info for Android is built as an executable for devices with root access.
 
+To use, simply push it to the device and run it:
+```
+./build_all.sh
+adb push obj/local/<abi>/vkjson_info /data/tmp/
+adb shell /data/tmp/vkjson_info
+```
+The resulting json file will be found in:
+```
+/sdcard/Android/<device_name>.json
+```
 To build, install, and run the Smoke demo for Android, run the following, and any
 prompts that come back from the script:
 ```

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -204,5 +204,30 @@ LOCAL_LDLIBS := -llog -landroid
 LOCAL_LDFLAGS := -u ANativeActivity_onCreate
 include $(BUILD_SHARED_LIBRARY)
 
+include $(CLEAR_VARS)
+LOCAL_MODULE := vkjson
+LOCAL_SRC_FILES += $(SRC_DIR)/libs/vkjson/vkjson.cc \
+                   $(SRC_DIR)/libs/vkjson/vkjson_instance.cc \
+                   $(SRC_DIR)/common/vulkan_wrapper.cpp \
+                   $(SRC_DIR)/loader/cJSON.c
+LOCAL_C_INCLUDES += $(SRC_DIR)/include \
+                    $(SRC_DIR)/loader
+
+LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden --include=$(SRC_DIR)/common/vulkan_wrapper.h
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := vkjson_info
+LOCAL_SRC_FILES += $(SRC_DIR)/libs/vkjson/vkjson_info.cc \
+                   $(SRC_DIR)/common/vulkan_wrapper.cpp
+LOCAL_C_INCLUDES += $(SRC_DIR)/loader \
+                    $(SRC_DIR)/include
+
+LOCAL_STATIC_LIBRARIES += vkjson
+LOCAL_CPPFLAGS += -Wno-sign-compare -DVK_USE_PLATFORM_ANDROID_KHR --include=$(SRC_DIR)/common/vulkan_wrapper.h
+LOCAL_LDLIBS := -llog
+LOCAL_LDFLAGS += -Wl,--exclude-libs,ALL
+include $(BUILD_EXECUTABLE)
+
 $(call import-module,android/native_app_glue)
 $(call import-module,third_party/googletest)

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -16,6 +16,6 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64 mips mips64
 APP_PLATFORM := android-22
 APP_STL := gnustl_static
-APP_MODULES := layer_utils VkLayer_core_validation VkLayer_parameter_validation VkLayer_object_tracker VkLayer_threading VkLayer_unique_objects VkLayerValidationTests VulkanLayerValidationTests
+APP_MODULES := layer_utils VkLayer_core_validation VkLayer_parameter_validation VkLayer_object_tracker VkLayer_threading VkLayer_unique_objects VkLayerValidationTests VulkanLayerValidationTests vkjson_info
 APP_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 NDK_TOOLCHAIN_VERSION := clang

--- a/libs/vkjson/vkjson.cc
+++ b/libs/vkjson/vkjson.cc
@@ -22,6 +22,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <cmath>
 #include <cinttypes>
@@ -38,7 +39,12 @@
 namespace {
 
 inline bool IsIntegral(double value) {
+#if defined(ANDROID)
+  // Android NDK doesn't provide std::trunc yet
+  return trunc(value) == value;
+#else
   return std::trunc(value) == value;
+#endif
 }
 
 template <typename T> struct EnumTraits;

--- a/libs/vkjson/vkjson_info.cc
+++ b/libs/vkjson/vkjson_info.cc
@@ -18,7 +18,10 @@
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////////////
 
+#ifndef VK_PROTOTYPES
 #define VK_PROTOTYPES
+#endif
+
 #include "vkjson.h"
 
 #include <assert.h>
@@ -121,7 +124,11 @@ bool Dump(const VkJsonInstance& instance, const Options& options) {
   std::string output_file;
   if (options.output_file.empty()) {
     assert(out_device);
+#if defined(ANDROID)
+    output_file.assign("/sdcard/Android/" + std::string(out_device->properties.deviceName));
+#else
     output_file.assign(out_device->properties.deviceName);
+#endif
     output_file.append(".json");
   } else {
     output_file = options.output_file;
@@ -153,6 +160,11 @@ bool Dump(const VkJsonInstance& instance, const Options& options) {
 }
 
 int main(int argc, char* argv[]) {
+#if defined(ANDROID)
+  int vulkanSupport = InitVulkan();
+  if (vulkanSupport == 0)
+    return 1;
+#endif
   Options options;
   if (!ParseOptions(argc, argv, &options))
     return 1;

--- a/libs/vkjson/vkjson_instance.cc
+++ b/libs/vkjson/vkjson_instance.cc
@@ -18,7 +18,10 @@
 // limitations under the License.
 ///////////////////////////////////////////////////////////////////////////////
 
+#ifndef VK_PROTOTYPES
 #define VK_PROTOTYPES
+#endif
+
 #include "vkjson.h"
 
 #include <utility>


### PR DESCRIPTION
This commit adds `vkjson` and `vkjson_info` to the Android build.
It is only generated as an executable for devices with root
access, but it could be expanded to an APK with some more
boilerplate work.

See updates to `BUILD.md` for how to build and run on the device.

This work is primarily to support downstream validation of the
`device_simulation` layer on Android.