### PR TITLE
CMake: GH1989, add wayland include dir to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 
     if (BUILD_WSI_WAYLAND_SUPPORT)
         find_package(Wayland REQUIRED)
+        include_directories(${WAYLAND_CLIENT_INCLUDE_DIR})
     endif()
 
     if (BUILD_WSI_MIR_SUPPORT)


### PR DESCRIPTION
On some Linux distributions (e.g  openSUSE) the wayland headers are in
a subdirectory.
Adding WAYLAND_CLIENT_INCLUDE_DIR to include_directories in CMakeLists.txt
will fix this issue.