### PR TITLE
scripts: Enable instance extension checks in PV

### DIFF
--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -1143,9 +1143,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             startIndex = 0 if command.name == 'vkCreateInstance' else 1
             lines, unused = self.genFuncBody(command.name, command.params[startIndex:], '', '', None)
             # Cannot validate extension dependencies for device extension APIs a physical device as their dispatchable object
-            if self.required_extensions and self.extension_type == 'device' and command.params[0].type != 'VkPhysicalDevice':
-                # The actual extension names are not all available yet, so we'll tag these now and replace them just before
-                # writing the validation routines out to a file
+            if self.required_extensions and (self.extension_type != 'device' or command.params[0].type != 'VkPhysicalDevice'):
                 ext_test = ''
                 for ext in self.required_extensions:
                     ext_name_define = ''


### PR DESCRIPTION
Parameter_validation's hammer for excluding some pdev-ish checks was
too large.  This adds extension dependency checks for about 50 more
APIs.

Change-Id: Icb44cdb36c8c0384781e04e207ceb18d9f67ff0c