### PR TITLE
WIP: support using cygwin git

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -212,7 +212,7 @@ for the Properties->Details tab of the loader vulkan-1.dll file that is built.
 Build all Windows targets after installing required software and cloning the Loader and Validation Layer repo as described above by completing the following steps in a "Developer Command Prompt for VS2013" window (Note that the update\_external\_sources script used below builds external tools into predefined locations. See **Loader and Validation Layer Dependencies** for more information and other options):
 ```
 cd Vulkan-LoaderAndValidationLayers  # cd to the root of the cloned git repository
-update_external_sources.bat --all
+update_external_sources.bat
 build_windows_targets.bat
 ```
 
@@ -225,14 +225,19 @@ This is described in a `LoaderAndLayerInterface` document in the `loader` folder
 This specification describes both how ICDs and layers should be properly
 packaged, and how developers can point to ICDs and layers within their builds.
 
-### Cygwin
+### Using Cygwin Git
 
-If you are using Cygwin git instead of win32-native git, you can use Cygwin's git to sync external sources:
+If you are using Cygwin git instead of win32-native git, you can use the *sh* script to sync using Cygwin's git (but not also build), then use the *bat* script to build (but not also sync).
+
+In a cygwin shell do this:
 ```
 ./update_external_sources.sh --no-build
 ```
 
-Unfortunately, "update\_external\_sources.bat" does not have a --no-sync option. To build the external sources you have to modify "update\_external\_sources.bat" to skip the sync portions of the script.
+Then in a Visual Studio Developer Command Prompt shell do this:
+```
+update_external_sources.bat --no-sync
+```
 
 ## Android Build
 Install the required tools for Linux and Windows covered above, then add the following.

--- a/BUILD.md
+++ b/BUILD.md
@@ -194,7 +194,7 @@ Windows 7+ with additional required software packages:
   - Need python3.3 or later to get the Windows py.exe launcher that is used to get python3 rather than python2 if both are installed on Windows
   - 32 bit python works
 - [Git](http://git-scm.com/download/win).
-  - Note: If you use Cygwin, you can normally use Cygwin's "git.exe".  However, in order to use the "update\_external\_sources.bat" script, you must have this version.
+  - Note: If you use Cygwin, you can normally use Cygwin's "git.exe", and "update\_external\_sources.sh --no-build" does support Cygwin's git.  However, in order to use the "update\_external\_sources.bat" script, you must have this version.
   - Tell the installer to allow it to be used for "Developer Prompt" as well as "Git Bash".
   - Tell the installer to treat line endings "as is" (i.e. both DOS and Unix-style line endings).
   - Install each a 32-bit and a 64-bit version, as the 64-bit installer does not install the 32-bit libraries and tools.
@@ -224,6 +224,15 @@ To run Vulkan programs you must tell the icd loader where to find the libraries.
 This is described in a `LoaderAndLayerInterface` document in the `loader` folder in this repository.
 This specification describes both how ICDs and layers should be properly
 packaged, and how developers can point to ICDs and layers within their builds.
+
+### Cygwin
+
+If you are using Cygwin git instead of win32-native git, you can use Cygwin's git to sync external sources:
+```
+./update_external_sources.sh --no-build
+```
+
+Unfortunately, "update\_external\_sources.bat" does not have a --no-sync option. To build the external sources you have to modify "update\_external\_sources.bat" to skip the sync portions of the script.
 
 ## Android Build
 Install the required tools for Linux and Windows covered above, then add the following.

--- a/update_external_sources.bat
+++ b/update_external_sources.bat
@@ -105,7 +105,7 @@ REM // ======== Dependency checking ======== //
       if not defined FOUND (
          echo Dependency check failed:
          echo   cmake.exe not found
-         echo   Get CNake 2.8 for Windows here:  http://www.cmake.org/cmake/resources/software.html
+         echo   Get CMake for Windows here:  http://www.cmake.org/cmake/resources/software.html
          echo   Install and ensure each makes it into your PATH, default is "C:\Program Files (x86)\CMake\bin"
          set errorCode=1
       )

--- a/update_external_sources.bat
+++ b/update_external_sources.bat
@@ -20,16 +20,84 @@ set SPIRV_TOOLS_DIR=%BASE_DIR%\spirv-tools
 
 REM // ======== Parameter parsing ======== //
 
-   if "%1" == "" (
+   set arg-use-implicit-component-list=1
+   set arg-do-glslang=0
+   set arg-do-spirv-tools=0
+   set arg-no-sync=0
+   set arg-no-build=0
+
+   :parameterLoop
+
+      if "%1"=="" goto:parameterContinue
+
+      if "%1" == "-g" (
+         set arg-do-glslang=1
+         set arg-use-implicit-component-list=0
+         echo Building glslang ^(%1^)
+         shift
+         goto:parameterLoop
+      )
+
+      if "%1" == "--glslang" (
+         set arg-do-glslang=1
+         set arg-use-implicit-component-list=0
+         echo Building glslang ^(%1^)
+         shift
+         goto:parameterLoop
+      )
+
+      if "%1" == "--spirv-tools" (
+         set arg-do-spirv-tools=1
+         set arg-use-implicit-component-list=0
+         echo Building spirv-tools ^(%1^)
+         shift
+         goto:parameterLoop
+      )
+
+      if "%1" == "-s" (
+         set arg-do-spirv-tools=1
+         set arg-use-implicit-component-list=0
+         echo Building spirv-tools ^(%1^)
+         shift
+         goto:parameterLoop
+      )
+
+      if "%1" == "--no-sync" (
+         set arg-no-sync=1
+         echo Skipping sync ^(%1^)
+         shift
+         goto:parameterLoop
+      )
+
+      if "%1" == "--no-build" (
+         set arg-no-build=1
+         echo Skipping build ^(%1^)
+         shift
+         goto:parameterLoop
+      )
+
+      echo.
+      echo Unrecognized option "%1"
+      echo.
       echo usage: update_external_sources.bat [options]
       echo.
-      echo Available options:
-      echo   --sync-glslang      just pull glslang_revision
-      echo   --sync-spirv-tools  just pull spirv-tools_revision
-      echo   --build-glslang     pulls glslang_revision, configures CMake, builds Release and Debug
-      echo   --build-spirv-tools pulls spirv-tools_revision, configures CMake, builds Release and Debug
-      echo   --all               sync and build glslang, spirv-tools
-      goto:finish
+      echo   Available options:
+      echo     -g ^| --glslang      enable glslang
+      echo     -s ^| --spirv-tools  enable spirv-tools
+      echo     --no-sync           skip sync from git
+      echo     --no-build          skip build
+      echo.
+      echo   Sync uses git to pull a specific revision.
+      echo   Build configures CMake, builds Release and Debug.
+
+      goto:error
+
+   :parameterContinue
+
+   if %arg-use-implicit-component-list% equ 1 (
+      echo Building glslang, spirv-tools
+      set arg-do-glslang=1
+      set arg-do-spirv-tools=1
    )
 
    set sync-glslang=0
@@ -38,53 +106,37 @@ REM // ======== Parameter parsing ======== //
    set build-spirv-tools=0
    set check-glslang-build-dependencies=0
 
-   :parameterLoop
-
-      if "%1"=="" goto:parameterContinue
-
-      if "%1" == "--sync-glslang" (
+   if %arg-do-glslang% equ 1 (
+      if %arg-no-sync% equ 0 (
          set sync-glslang=1
-         shift
-         goto:parameterLoop
       )
-
-      if "%1" == "--sync-spirv-tools" (
-         set sync-spirv-tools=1
-         shift
-         goto:parameterLoop
-      )
-
-      if "%1" == "--build-glslang" (
-         set sync-glslang=1
+      if %arg-no-build% equ 0 (
          set check-glslang-build-dependencies=1
          set build-glslang=1
-         shift
-         goto:parameterLoop
       )
+   )
 
-      if "%1" == "--build-spirv-tools" (
+   if %arg-do-spirv-tools% equ 1 (
+      if %arg-no-sync% equ 0 (
          set sync-spirv-tools=1
-         REM glslang has the same needs as spirv-tools
+      )
+      if %arg-no-build% equ 0 (
+         REM glslang has the same dependencies as spirv-tools
          set check-glslang-build-dependencies=1
          set build-spirv-tools=1
-         shift
-         goto:parameterLoop
       )
+   )
 
-      if "%1" == "--all" (
-         set sync-glslang=1
-         set sync-spirv-tools=1
-         set build-glslang=1
-         set build-spirv-tools=1
-         set check-glslang-build-dependencies=1
-         shift
-         goto:parameterLoop
-      )
-
-      echo Unrecognized options "%1"
+   REM this is a debugging aid that can be enabled while debugging command-line parsing
+   if 0 equ 1 (
+      set arg
+      set sync-glslang
+      set sync-spirv-tools
+      set build-glslang
+      set build-spirv-tools
+      set check-glslang-build-dependencies
       goto:error
-
-   :parameterContinue
+   )
 
 REM // ======== end Parameter parsing ======== //
 

--- a/update_external_sources.bat
+++ b/update_external_sources.bat
@@ -30,7 +30,7 @@ REM // ======== Parameter parsing ======== //
 
       if "%1"=="" goto:parameterContinue
 
-      if "%1" == "-g" (
+      if "%1" == "--glslang" (
          set arg-do-glslang=1
          set arg-use-implicit-component-list=0
          echo Building glslang ^(%1^)
@@ -38,7 +38,7 @@ REM // ======== Parameter parsing ======== //
          goto:parameterLoop
       )
 
-      if "%1" == "--glslang" (
+      if "%1" == "-g" (
          set arg-do-glslang=1
          set arg-use-implicit-component-list=0
          echo Building glslang ^(%1^)
@@ -58,6 +58,15 @@ REM // ======== Parameter parsing ======== //
          set arg-do-spirv-tools=1
          set arg-use-implicit-component-list=0
          echo Building spirv-tools ^(%1^)
+         shift
+         goto:parameterLoop
+      )
+
+      if "%1" == "--all" (
+         set arg-do-glslang=1
+         set arg-do-spirv-tools=1
+         set arg-use-implicit-component-list=0
+         echo Building glslang, spirv-tools ^(%1^)
          shift
          goto:parameterLoop
       )
@@ -84,6 +93,7 @@ REM // ======== Parameter parsing ======== //
       echo   Available options:
       echo     -g ^| --glslang      enable glslang component
       echo     -s ^| --spirv-tools  enable spirv-tools component
+      echo     --all               enable all components
       echo     --no-sync           skip sync from git
       echo     --no-build          skip build
       echo.

--- a/update_external_sources.bat
+++ b/update_external_sources.bat
@@ -82,13 +82,17 @@ REM // ======== Parameter parsing ======== //
       echo usage: update_external_sources.bat [options]
       echo.
       echo   Available options:
-      echo     -g ^| --glslang      enable glslang
-      echo     -s ^| --spirv-tools  enable spirv-tools
+      echo     -g ^| --glslang      enable glslang component
+      echo     -s ^| --spirv-tools  enable spirv-tools component
       echo     --no-sync           skip sync from git
       echo     --no-build          skip build
       echo.
+      echo   If any component enables are provided, only those components are enabled.
+      echo   If no component enables are provided, all components are enabled.
+      echo.
       echo   Sync uses git to pull a specific revision.
       echo   Build configures CMake, builds Release and Debug.
+
 
       goto:error
 

--- a/update_external_sources.sh
+++ b/update_external_sources.sh
@@ -3,13 +3,14 @@
 
 set -e
 
-if [[ $(uname) == "Linux" ]]; then
+if [[ $(uname) == "Linux" || $(uname) =~ "CYGWIN" ]]; then
     CURRENT_DIR="$(dirname "$(readlink -f ${BASH_SOURCE[0]})")"
     CORE_COUNT=$(nproc || echo 4)
 elif [[ $(uname) == "Darwin" ]]; then
     CURRENT_DIR="$(dirname "$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ${BASH_SOURCE[0]})")"
     CORE_COUNT=$(sysctl -n hw.ncpu || echo 4)
 fi
+echo CURRENT_DIR=$CURRENT_DIR
 echo CORE_COUNT=$CORE_COUNT
 
 REVISION_DIR="$CURRENT_DIR/external_revisions"
@@ -95,57 +96,82 @@ function build_spirv-tools () {
    make -j $CORE_COUNT
 }
 
-# If any options are provided, just compile those tools
-# If no options are provided, build everything
+# If any options are provided, just sync and compile those tools
+# If no options are provided, sync and build everything
 INCLUDE_GLSLANG=false
 INCLUDE_SPIRV_TOOLS=false
+NO_SYNC=false
+NO_BUILD=false
+USE_IMPLICIT_COMPONENT_LIST=true
 
-if [ "$#" == 0 ]; then
+# Parse options
+while [[ $# > 0 ]]
+do
+  option="$1"
+
+  case $option in
+      # options to specify build of glslang components
+      -g|--glslang)
+      INCLUDE_GLSLANG=true
+      USE_IMPLICIT_COMPONENT_LIST=false
+      echo "Building glslang ($option)"
+      ;;
+      # options to specify build of spirv-tools components
+      -s|--spirv-tools)
+      INCLUDE_SPIRV_TOOLS=true
+      USE_IMPLICIT_COMPONENT_LIST=false
+      echo "Building spirv-tools ($option)"
+      ;;
+      # option to specify skipping sync from git
+      --no-sync)
+      NO_SYNC=true
+      echo "Skipping sync ($option)"
+      ;;
+      # option to specify skipping build
+      --no-build)
+      NO_BUILD=true
+      echo "Skipping build ($option)"
+      ;;
+      *)
+      echo "Unrecognized option: $option"
+      echo "Try the following:"
+      echo " -g | --glslang      # enable glslang"
+      echo " -s | --spirv-tools  # enable spirv-tools"
+      echo " --no-sync           # skip sync from git"
+      echo " --no-build          # skip build"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ ${USE_IMPLICIT_COMPONENT_LIST} == "true" ]; then
   echo "Building glslang, spirv-tools"
   INCLUDE_GLSLANG=true
   INCLUDE_SPIRV_TOOLS=true
-else
-  # Parse options
-  while [[ $# > 0 ]]
-  do
-    option="$1"
-
-    case $option in
-        # options to specify build of glslang components
-        -g|--glslang)
-        INCLUDE_GLSLANG=true
-        echo "Building glslang ($option)"
-        ;;
-        # options to specify build of spirv-tools components
-        -s|--spirv-tools)
-        INCLUDE_SPIRV_TOOLS=true
-        echo "Building spirv-tools ($option)"
-        ;;
-        *)
-        echo "Unrecognized option: $option"
-        echo "Try the following:"
-        echo " -g | --glslang      # enable glslang"
-        echo " -s | --spirv-tools  # enable spirv-tools"
-        exit 1
-        ;;
-    esac
-    shift
-  done
 fi
 
 if [ ${INCLUDE_GLSLANG} == "true" ]; then
-  if [ ! -d "${BASEDIR}/glslang" -o ! -d "${BASEDIR}/glslang/.git" -o -d "${BASEDIR}/glslang/.svn" ]; then
-     create_glslang
+  if [ ${NO_SYNC} == "false" ]; then
+    if [ ! -d "${BASEDIR}/glslang" -o ! -d "${BASEDIR}/glslang/.git" -o -d "${BASEDIR}/glslang/.svn" ]; then
+       create_glslang
+    fi
+    update_glslang
   fi
-  update_glslang
-  build_glslang
+  if [ ${NO_BUILD} == "false" ]; then
+    build_glslang
+  fi
 fi
 
 
 if [ ${INCLUDE_SPIRV_TOOLS} == "true" ]; then
+  if [ ${NO_SYNC} == "false" ]; then
     if [ ! -d "${BASEDIR}/spirv-tools" -o ! -d "${BASEDIR}/spirv-tools/.git" ]; then
        create_spirv-tools
     fi
     update_spirv-tools
+  fi
+  if [ ${NO_BUILD} == "false" ]; then
     build_spirv-tools
+  fi
 fi

--- a/update_external_sources.sh
+++ b/update_external_sources.sh
@@ -96,8 +96,6 @@ function build_spirv-tools () {
    make -j $CORE_COUNT
 }
 
-# If any options are provided, just sync and compile those tools
-# If no options are provided, sync and build everything
 INCLUDE_GLSLANG=false
 INCLUDE_SPIRV_TOOLS=false
 NO_SYNC=false
@@ -134,11 +132,16 @@ do
       ;;
       *)
       echo "Unrecognized option: $option"
-      echo "Try the following:"
-      echo " -g | --glslang      # enable glslang"
-      echo " -s | --spirv-tools  # enable spirv-tools"
-      echo " --no-sync           # skip sync from git"
-      echo " --no-build          # skip build"
+      echo "Usage: update_external_sources.sh [options]"
+      echo "  Available options:"
+      echo "    -g | --glslang      # enable glslang component"
+      echo "    -s | --spirv-tools  # enable spirv-tools component"
+      echo "    --no-sync           # skip sync from git"
+      echo "    --no-build          # skip build"
+      echo "  If any component enables are provided, only those components are enabled."
+      echo "  If no component enables are provided, all components are enabled."
+      echo "  Sync uses git to pull a specific revision."
+      echo "  Build configures CMake, builds Release."
       exit 1
       ;;
   esac


### PR DESCRIPTION
Adds support for syncing with cygwin git using the .sh script and --no-build,
then building with a Visual Studio Developer Command Prompt using the .bat script and --no-sync.

Also improves the usage text for both scripts, and aligns their command line options to be similar.

The .bat script's --all option is removed, as it is no longer needed. Passing it no arguments now does the same thing that the --all option used to do.