### PR TITLE
Handle layers in PnP registry locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,6 +346,8 @@ add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 endif()
 
+add_definitions(-DAPI_NAME="${API_NAME}")
+
 # loader: Generic VULKAN ICD loader
 # tests: VULKAN tests
 if(BUILD_LOADER)

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -80,8 +80,6 @@ set(OPT_LOADER_SRCS
     phys_dev_ext.c
 )
 
-add_definitions(-DAPI_NAME="${API_NAME}")
-
 # Check for assembler support
 set(ASM_FAILURE_MSG "The build will fall back on building with C code\n")
 set(ASM_FAILURE_MSG "${ASM_FAILURE_MSG}Note that this may be unsafe, as the C code requires tail-call optimizations to remove")

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -435,7 +435,7 @@ bool loaderGetDeviceRegistryEntry(const struct loader_instance *inst, char **reg
     // query value
     LSTATUS ret = RegQueryValueEx(
         hkrKey,
-        HKR_VK_DRIVER_NAME,
+        LoaderPnpDriverRegistry(),
         NULL,
         NULL,
         NULL,
@@ -457,7 +457,7 @@ bool loaderGetDeviceRegistryEntry(const struct loader_instance *inst, char **reg
 
     ret = RegQueryValueEx(
         hkrKey,
-        HKR_VK_DRIVER_NAME,
+        LoaderPnpDriverRegistry(),
         NULL,
         &dataType,
         pVkDriverPath,

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -195,6 +195,22 @@ static inline const char *LoaderPnpDriverRegistry() {
     IsWow64Process(GetCurrentProcess(), &is_wow);
     return is_wow ? (API_NAME "DriverNameWow") : (API_NAME "DriverName");
 }
+
+// Get the key for the plug 'n play explicit layer registry
+// The string returned by this function should NOT be freed
+static inline const char *LoaderPnpELayerRegistry() {
+    BOOL is_wow;
+    IsWow64Process(GetCurrentProcess(), &is_wow);
+    return is_wow ? (API_NAME "ExplicitLayersWow") : (API_NAME "ExplicitLayers");
+}
+// Get the key for the plug 'n play implicit layer registry
+// The string returned by this function should NOT be freed
+
+static inline const char *LoaderPnpILayerRegistry() {
+    BOOL is_wow;
+    IsWow64Process(GetCurrentProcess(), &is_wow);
+    return is_wow ? (API_NAME "ImplicitLayersWow") : (API_NAME "ImplicitLayers");
+}
 #endif
 
 // File IO

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -172,11 +172,6 @@ static inline void loader_platform_thread_cond_broadcast(loader_platform_thread_
 #define SECONDARY_VK_REGISTRY_HIVE HKEY_CURRENT_USER
 #define SECONDARY_VK_REGISTRY_HIVE_STR "HKEY_CURRENT_USER"
 #define DEFAULT_VK_DRIVERS_INFO "SOFTWARE\\Khronos\\" API_NAME "\\Drivers"
-#ifdef _WIN64
-#define HKR_VK_DRIVER_NAME API_NAME "DriverName"
-#else
-#define HKR_VK_DRIVER_NAME API_NAME "DriverNameWow"
-#endif
 #define DEFAULT_VK_DRIVERS_PATH ""
 #define DEFAULT_VK_ELAYERS_INFO "SOFTWARE\\Khronos\\" API_NAME "\\ExplicitLayers"
 #define DEFAULT_VK_ILAYERS_INFO "SOFTWARE\\Khronos\\" API_NAME "\\ImplicitLayers"
@@ -191,6 +186,16 @@ static inline void loader_platform_thread_cond_broadcast(loader_platform_thread_
 #define RELATIVE_VK_ELAYERS_INFO ""
 #define RELATIVE_VK_ILAYERS_INFO ""
 #define PRINTF_SIZE_T_SPECIFIER "%Iu"
+
+#if defined(_WIN32)
+// Get the key for the plug n play driver registry
+// The string returned by this function should NOT be freed
+static inline const char *LoaderPnpDriverRegistry() {
+    BOOL is_wow;
+    IsWow64Process(GetCurrentProcess(), &is_wow);
+    return is_wow ? (API_NAME "DriverNameWow") : (API_NAME "DriverName");
+}
+#endif
 
 // File IO
 static bool loader_platform_file_exists(const char *path) {


### PR DESCRIPTION
Previously, we added a change that allows ICDs to be specified through the PnP system. This PR extends that to also allow layers to be specified through the same means. This is needed so that ICDs can continue to install layers in future versions of Windows, where they will not be able to access the old paths. The old paths are retained, and are expected to be used by anything that's not a driver.

This change also extends the PnP registries to allow a `REG_MULTI_SZ`, in the case that multiple layers or ICDs need to be specified from a single device.