### PR TITLE
demos: Print XCB errors to stderr

### DIFF
--- a/demos/vulkaninfo.c
+++ b/demos/vulkaninfo.c
@@ -928,14 +928,14 @@ static void AppCreateXcbWindow(struct AppInstance *inst) {
 
     inst->xcb_connection = xcb_connect(NULL, &scr);
     if (inst->xcb_connection == NULL) {
-        fprintf(stderr, "XCB failed to connect to the X server.\nExiting ...\n");
+        fprintf(stderr, "XCB failed to connect to the X server.\n");
         fflush(stderr);
         exit(1);
     }
 
     int conn_error = xcb_connection_has_error(inst->xcb_connection);
     if (conn_error) {
-        fprintf(stderr, "XCB failed to connect to the X server due to error:%d.\nExiting ...\n", conn_error);
+        fprintf(stderr, "XCB failed to connect to the X server due to error:%d.\n", conn_error);
         fflush(stderr);
         exit(1);
     }

--- a/demos/vulkaninfo.c
+++ b/demos/vulkaninfo.c
@@ -930,7 +930,7 @@ static void AppCreateXcbWindow(struct AppInstance *inst) {
     inst->xcb_connection = xcb_connect(NULL, &scr);
     int conn_error = xcb_connection_has_error(inst->xcb_connection);
     if (conn_error) {
-        fprintf(stderr, "XCB failed to connect to the X server due to error:%d.\n", conn_error);
+        fprintf(stderr, "XCB failed to connect to the X server due to error:%d.\nExiting ...\n", conn_error);
         fflush(stderr);
         exit(1);
     }

--- a/demos/vulkaninfo.c
+++ b/demos/vulkaninfo.c
@@ -926,13 +926,8 @@ static void AppCreateXcbWindow(struct AppInstance *inst) {
     xcb_screen_iterator_t iter;
     int scr;
 
+    // API guarantees non-null xcb_connection
     inst->xcb_connection = xcb_connect(NULL, &scr);
-    if (inst->xcb_connection == NULL) {
-        fprintf(stderr, "XCB failed to connect to the X server.\n");
-        fflush(stderr);
-        exit(1);
-    }
-
     int conn_error = xcb_connection_has_error(inst->xcb_connection);
     if (conn_error) {
         fprintf(stderr, "XCB failed to connect to the X server due to error:%d.\n", conn_error);

--- a/demos/vulkaninfo.c
+++ b/demos/vulkaninfo.c
@@ -928,15 +928,15 @@ static void AppCreateXcbWindow(struct AppInstance *inst) {
 
     inst->xcb_connection = xcb_connect(NULL, &scr);
     if (inst->xcb_connection == NULL) {
-        printf("XCB failed to connect to the X server.\nExiting ...\n");
-        fflush(stdout);
+        fprintf(stderr, "XCB failed to connect to the X server.\nExiting ...\n");
+        fflush(stderr);
         exit(1);
     }
 
     int conn_error = xcb_connection_has_error(inst->xcb_connection);
     if (conn_error) {
-        printf("XCB failed to connect to the X server due to error:%d.\nExiting ...\n", conn_error);
-        fflush(stdout);
+        fprintf(stderr, "XCB failed to connect to the X server due to error:%d.\nExiting ...\n", conn_error);
+        fflush(stderr);
         exit(1);
     }
 


### PR DESCRIPTION
Printing to stdout is weird for error messages.