### PR TITLE
scripts: Check toolchain revisions and clear the cache if needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ before_install:
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then export JAVA_HOME="/usr/lib/jvm/java-8-oracle"; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then export PATH="$ANDROID_NDK_HOME:$PATH"; fi
 
+  # Clear the toolchain contents if revisions have changed
+  - ./scripts/check_toolchain_revisions.sh
+
 script:
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then ./update_external_sources.sh; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then cmake -H. -Bdbuild -DCMAKE_BUILD_TYPE=Debug; fi

--- a/scripts/check_toolchain_revisions.sh
+++ b/scripts/check_toolchain_revisions.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -e
+
+# If any tracked revision no longer matches the local revision, blast the extenal toolchain directoies
+
+function check_revision()
+{
+  echo Checking current revision for $1 in $2
+  if [ -d $2/.git ]; then
+    current_rev=$(git --git-dir=$2/.git rev-parse HEAD);
+  fi
+  echo current_rev for $1 is $current_rev;
+  tracked_rev=$(cat $3);
+  echo tracked_rev for $1 is $tracked_rev;
+  if [ "$current_rev" != "$tracked_rev" ]; then
+    echo Revisions for $1 do not match.;
+    if [ -d external ]; then
+      echo Removing current desktop toolchain;
+      rm -rf external/*;
+    fi
+    if [ -d build-android/external ]; then
+      echo Removing current android toolchain;
+      rm -rf build-android/external/*;
+    fi
+    echo Done removing toolchains.
+    exit 0;
+  fi
+}
+
+# Parameters are tool, current git repo location, tracked revision location
+tool=glslang
+dir=external/glslang
+rev=external_revisions/glslang_revision
+check_revision $tool $dir $rev
+
+tool=spirv-tools
+dir=external/spirv-tools
+rev=external_revisions/spirv-tools_revision
+check_revision $tool $dir $rev
+
+tool=spirv-headers
+dir=external/spirv-tools/external/spirv-headers
+rev=external_revisions/spirv-headers_revision
+check_revision $tool $dir $rev
+
+tool=glslang_android
+dir=build-android/external/glslang
+rev=build-android/glslang_revision_android
+check_revision $tool $dir $rev
+
+tool=spirv-tools_android
+dir=build-android/external/spirv-tools
+rev=build-android/spirv-tools_revision_android
+check_revision $tool $dir $rev
+
+tool=spirv-headers_android
+dir=build-android/external/spirv-tools/external/spirv-headers
+rev=build-android/spirv-headers_revision_android
+check_revision $tool $dir $rev
+
+tool=shaderc_android
+dir=build-android/external/shaderc
+rev=build-android/shaderc_revision_android
+check_revision $tool $dir $rev
+
+exit 0


### PR DESCRIPTION
This script compares tracked revisions against those loaded from Travis-CI cache and clears it if any don't match.

There's something not quite right about the cache being restored.  This clearly became a problem after the Android revisions were updated in #2062 and the Travis-CI build of desktop toolchain couldn't find clang (failed build [log](https://travis-ci.org/KhronosGroup/Vulkan-LoaderAndValidationLayers/jobs/273004378)).

This is a bigger hammer than we'd like, but should be effective.