### PR TITLE
Android toolchain single ABI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
     - os: linux
       compiler: gcc
       env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=armeabi-v7a
+    # Android 64-bit build.
+    - os: linux
+      compiler: gcc
+      env: VULKAN_BUILD_TARGET=ANDROID ANDROID_TARGET=android-23 ANDROID_ABI=arm64-v8a
     # Linux GCC debug build.
     - os: linux
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then cmake -H. -Bdbuild -DCMAKE_BUILD_TYPE=Debug; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then make -C dbuild; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then pushd build-android; fi
-  - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ./update_external_sources_android.sh; fi
+  - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ./update_external_sources_android.sh --abi $ANDROID_ABI; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ./android-generate.sh; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ndk-build APP_ABI=$ANDROID_ABI; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then popd; fi


### PR DESCRIPTION
This series:
* Updates the Android toolchain script to specify a single ABI (default is still all)
* Specifies a toolchain ABI in the Travis-CI config file
* Adds a 64-bit Android job to run in parallel

End result is a much faster Android toolchain build (~3m30s -> ~42s for arm32 locally), and better coverage in our public CI.
