### PR TITLE
vulkaninfo: Remove "INFO" messages

### DIFF
--- a/demos/vulkaninfo.c
+++ b/demos/vulkaninfo.c
@@ -687,7 +687,7 @@ static void AppCreateInstance(struct AppInstance *inst) {
     VkDebugReportCallbackCreateInfoEXT dbg_info;
     memset(&dbg_info, 0, sizeof(dbg_info));
     dbg_info.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT;
-    dbg_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+    dbg_info.flags = VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT;
     dbg_info.pfnCallback = DbgCallback;
     inst_info.pNext = &dbg_info;
 


### PR DESCRIPTION
Removed messages marked with the "INFO" tag from vuklaninfo.