### PR TITLE
Fix doc validator on Windows

### DIFF
--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -103,7 +103,7 @@ class ValidationDatabase:
         """Read a database file into internal data structures, format of each line is <enum><implemented Y|N?><testname><api><errormsg><notes>"""
         #db_dict = {} # This is a simple db of just enum->errormsg, the same as is created from spec
         #max_id = 0
-        with open(self.db_file, "r") as infile:
+        with open(self.db_file, "r", encoding="utf8") as infile:
             for line in infile:
                 line = line.strip()
                 if line.startswith('#') or '' == line:

--- a/tests/vkvalidatelayerdoc.sh
+++ b/tests/vkvalidatelayerdoc.sh
@@ -24,7 +24,7 @@ printf "$GREEN[ RUN      ]$NC $0\n"
 pushd ../../scripts
 
 # Validate that layer database matches source contents
-python vk_validation_stats.py $1
+python3 vk_validation_stats.py $1
 
 RES=$?
 


### PR DESCRIPTION
vk.xml now includes some wacky unicode characters which end up in the vk_validation_error_database.txt and cause the doc validator to choke.  Added UTF encoding to fix that, and added python3 to the validator script to fix _that_.