### PR TITLE
demos: Update cube.cpp DISPLAY_KHR code

### DIFF
--- a/demos/cube.c
+++ b/demos/cube.c
@@ -2945,8 +2945,8 @@ static VkResult demo_create_display_surface(struct demo *demo) {
     VkDisplayPlaneCapabilitiesKHR planeCaps;
     vkGetDisplayPlaneCapabilitiesKHR(demo->gpu, mode_props.displayMode, plane_index, &planeCaps);
     // Find a supported alpha mode
-    VkCompositeAlphaFlagBitsKHR alphaMode = VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR;
-    VkCompositeAlphaFlagBitsKHR alphaModes[4] = {
+    VkDisplayPlaneAlphaFlagBitsKHR alphaMode = VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR;
+    VkDisplayPlaneAlphaFlagBitsKHR alphaModes[4] = {
         VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR,
         VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR,
         VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR,

--- a/demos/cube.cpp
+++ b/demos/cube.cpp
@@ -2791,14 +2791,14 @@ Demo::Demo()
         free(plane_props);
 
         vk::DisplayPlaneCapabilitiesKHR planeCaps;
-        vk::getDisplayPlaneCapabilitiesKHR(gpu, mode_props.displayMode, plane_index, &planeCaps);
+        gpu.getDisplayPlaneCapabilitiesKHR(mode_props.displayMode, plane_index, &planeCaps);
         // Find a supported alpha mode
-        vk::CompositeAlphaFlagBitsKHR alphaMode = vk::CompositeAlphaFlagBitsKHR::eOpaque;
-        vk::CompositeAlphaFlagBitsKHR alphaModes[4] = {
-            vk::CompositeAlphaFlagBitsKHR::eOpaque,
-            vk::CompositeAlphaFlagBitsKHR::eGlobal,
-            vk::CompositeAlphaFlagBitsKHR::ePerPixel,
-            vk::CompositeAlphaFlagBitsKHR::ePerPixelPremultiplied,
+        vk::DisplayPlaneAlphaFlagBitsKHR alphaMode = vk::DisplayPlaneAlphaFlagBitsKHR::eOpaque;
+        vk::DisplayPlaneAlphaFlagBitsKHR alphaModes[4] = {
+            vk::DisplayPlaneAlphaFlagBitsKHR::eOpaque,
+            vk::DisplayPlaneAlphaFlagBitsKHR::eGlobal,
+            vk::DisplayPlaneAlphaFlagBitsKHR::ePerPixel,
+            vk::DisplayPlaneAlphaFlagBitsKHR::ePerPixelPremultiplied,
         };
         for (uint32_t i = 0; i < sizeof(alphaModes); i++) {
             if (planeCaps.supportedAlpha & alphaModes[i]) {


### PR DESCRIPTION
The physical display rendering code didn't compile due to drift in `vulcan.hpp`. Update for these changes.

Tested on i.MX8M / Vivante GC7000L.

(same change is needed in https://github.com/LunarG/VulkanSamples, originally noticed it there)