### PR TITLE
Stroyan android build

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -291,7 +291,13 @@ export PATH=/usr/local/bin:$PATH
 brew install cmake python python3 git
 ```
 ### Build steps for Android
+
+There are two options for building the Android layers. One using the SPIRV tools
+provided as part of the Android NDK or build using upstream sources.
+To build with SPIRV tools from the NDK, remove the build-android/third_party directory created
+by running update_external_sources_android.sh, (or never run update_external_sources_android.sh).
 Use the following script to build everything in the repo for Android, including validation layers, tests, demos, and APK packaging:
+This script does retrieve and use the upstream SPRIV tools.
 ```
 cd build-android
 ./build_all.sh

--- a/build-android/cmake/layerlib/CMakeLists.txt
+++ b/build-android/cmake/layerlib/CMakeLists.txt
@@ -32,7 +32,7 @@ else ()
     #   ${SRC_DIR}
     #   ${SRC_DIR}/build-android/external (for glslang, spirv-tools & shaderc )
     get_filename_component(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../.."  ABSOLUTE)
-    set(EXTERNAL_DIR "${SRC_DIR}/build-android/external")
+    set(EXTERNAL_DIR "${SRC_DIR}/build-android/third_party")
     set(SPIRV_LIB
         "${EXTERNAL_DIR}/shaderc/android_test/obj/local/${ANDROID_ABI}/libSPIRV-Tools.a")
 endif()

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-LOCAL_PATH := $(abspath $(call my-dir))
-SRC_DIR := $(LOCAL_PATH)/../../
-LAYER_DIR := $(LOCAL_PATH)/../generated
+LOCAL_PATH := $(call my-dir)
+SRC_DIR := ../..
+LAYER_DIR := ../generated
 ANDROID_DIR := $(SRC_DIR)/build-android
 
 include $(CLEAR_VARS)
@@ -24,11 +24,12 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_config.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_extension_utils.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_utils.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_format_utils.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(SRC_DIR)/loader
-LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
+LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
+LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
@@ -38,14 +39,15 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/descriptor_sets.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/buffer_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/shader_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_table.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/loader \
-                    $(ANDROID_DIR)/external/glslang \
-                    $(ANDROID_DIR)/external/spirv-tools/include
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader \
+                    $(LOCAL_PATH)/$(ANDROID_DIR)/external/glslang \
+                    $(LOCAL_PATH)/$(ANDROID_DIR)/external/spirv-tools/include
 LOCAL_STATIC_LIBRARIES += layer_utils SPIRV-Tools-prebuilt
-LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
+LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
+LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
 LOCAL_LDLIBS    := -llog
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
@@ -56,11 +58,12 @@ LOCAL_MODULE := VkLayer_parameter_validation
 LOCAL_SRC_FILES += $(LAYER_DIR)/include/parameter_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/parameter_validation_utils.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_table.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(SRC_DIR)/loader
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
 LOCAL_STATIC_LIBRARIES += layer_utils
+LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
 LOCAL_LDLIBS    := -llog
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
@@ -72,11 +75,12 @@ LOCAL_MODULE := VkLayer_object_tracker
 LOCAL_SRC_FILES += $(LAYER_DIR)/include/object_tracker.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/object_tracker_utils.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_table.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/loader
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
 LOCAL_STATIC_LIBRARIES += layer_utils
+LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
 LOCAL_LDLIBS    := -llog
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
@@ -87,11 +91,12 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_threading
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/threading.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_table.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/loader
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
 LOCAL_STATIC_LIBRARIES += layer_utils
+LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
 LOCAL_LDLIBS    := -llog
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
@@ -102,12 +107,13 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayer_unique_objects
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/unique_objects.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_table.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/loader
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
 LOCAL_STATIC_LIBRARIES += layer_utils
-LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden
+LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
+LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
 LOCAL_LDLIBS    := -llog
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
@@ -166,15 +172,16 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/vktestframeworkandroid.cpp \
                    $(SRC_DIR)/tests/vkrenderframework.cpp \
                    $(SRC_DIR)/common/vulkan_wrapper.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(SRC_DIR)/libs \
-                    $(SRC_DIR)/common \
-                    $(ANDROID_DIR)/external/shaderc/libshaderc/include
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(SRC_DIR)/libs \
+                    $(LOCAL_PATH)/$(SRC_DIR)/common \
+                    $(LOCAL_PATH)/$(ANDROID_DIR)/external/shaderc/libshaderc/include
 
 LOCAL_STATIC_LIBRARIES := googletest_main layer_utils
 LOCAL_SHARED_LIBRARIES += shaderc-prebuilt glslang-prebuilt OGLCompiler-prebuilt OSDependent-prebuilt HLSL-prebuilt shaderc_util-prebuilt SPIRV-prebuilt SPIRV-Tools-prebuilt SPIRV-Tools-opt-prebuilt
+LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden --include=$(SRC_DIR)/common/vulkan_wrapper.h
 LOCAL_LDLIBS := -llog
 LOCAL_LDFLAGS   += -Wl,-Bsymbolic
@@ -189,15 +196,16 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/vktestframeworkandroid.cpp \
                    $(SRC_DIR)/tests/vkrenderframework.cpp \
                    $(SRC_DIR)/common/vulkan_wrapper.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(LAYER_DIR)/include \
-                    $(SRC_DIR)/layers \
-                    $(SRC_DIR)/libs \
-                    $(SRC_DIR)/common \
-                    $(ANDROID_DIR)/external/shaderc/libshaderc/include
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(LAYER_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/layers \
+                    $(LOCAL_PATH)/$(SRC_DIR)/libs \
+                    $(LOCAL_PATH)/$(SRC_DIR)/common \
+                    $(LOCAL_PATH)/$(ANDROID_DIR)/external/shaderc/libshaderc/include
 
 LOCAL_STATIC_LIBRARIES := googletest_main layer_utils
 LOCAL_SHARED_LIBRARIES += shaderc-prebuilt glslang-prebuilt OGLCompiler-prebuilt OSDependent-prebuilt HLSL-prebuilt shaderc_util-prebuilt SPIRV-prebuilt SPIRV-Tools-prebuilt SPIRV-Tools-opt-prebuilt
+LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden -DVALIDATION_APK --include=$(SRC_DIR)/common/vulkan_wrapper.h
 LOCAL_WHOLE_STATIC_LIBRARIES += android_native_app_glue
 LOCAL_LDLIBS := -llog -landroid
@@ -210,9 +218,10 @@ LOCAL_SRC_FILES += $(SRC_DIR)/libs/vkjson/vkjson.cc \
                    $(SRC_DIR)/libs/vkjson/vkjson_instance.cc \
                    $(SRC_DIR)/common/vulkan_wrapper.cpp \
                    $(SRC_DIR)/loader/cJSON.c
-LOCAL_C_INCLUDES += $(SRC_DIR)/include \
-                    $(SRC_DIR)/loader
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
 
+LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden --include=$(SRC_DIR)/common/vulkan_wrapper.h
 include $(BUILD_STATIC_LIBRARY)
 
@@ -220,10 +229,11 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := vkjson_info
 LOCAL_SRC_FILES += $(SRC_DIR)/libs/vkjson/vkjson_info.cc \
                    $(SRC_DIR)/common/vulkan_wrapper.cpp
-LOCAL_C_INCLUDES += $(SRC_DIR)/loader \
-                    $(SRC_DIR)/include
+LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/loader \
+                    $(LOCAL_PATH)/$(SRC_DIR)/include
 
 LOCAL_STATIC_LIBRARIES += vkjson
+LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -Wno-sign-compare -DVK_USE_PLATFORM_ANDROID_KHR --include=$(SRC_DIR)/common/vulkan_wrapper.h
 LOCAL_LDLIBS := -llog
 LOCAL_LDFLAGS += -Wl,--exclude-libs,ALL

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -16,7 +16,6 @@
 LOCAL_PATH := $(call my-dir)
 SRC_DIR := ../..
 LAYER_DIR := ../generated
-ANDROID_DIR := $(SRC_DIR)/build-android
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := layer_utils
@@ -42,10 +41,8 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_table.cpp
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers \
                     $(LOCAL_PATH)/$(LAYER_DIR)/include \
-                    $(LOCAL_PATH)/$(SRC_DIR)/loader \
-                    $(LOCAL_PATH)/$(ANDROID_DIR)/external/glslang \
-                    $(LOCAL_PATH)/$(ANDROID_DIR)/external/spirv-tools/include
-LOCAL_STATIC_LIBRARIES += layer_utils SPIRV-Tools-prebuilt
+                    $(LOCAL_PATH)/$(SRC_DIR)/loader
+LOCAL_STATIC_LIBRARIES += layer_utils glslang SPIRV-Tools
 LOCAL_CPPFLAGS += -std=c++11 -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -DVK_PROTOTYPES -fvisibility=hidden
 LOCAL_LDLIBS    := -llog
@@ -119,52 +116,6 @@ LOCAL_LDFLAGS   += -Wl,-Bsymbolic
 LOCAL_LDFLAGS   += -Wl,--exclude-libs,ALL
 include $(BUILD_SHARED_LIBRARY)
 
-# Pull in prebuilt shaderc
-include $(CLEAR_VARS)
-LOCAL_MODULE := shaderc-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libshaderc.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := glslang-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libglslang.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := OGLCompiler-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libOGLCompiler.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := OSDependent-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libOSDependent.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := HLSL-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libHLSL.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := shaderc_util-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libshaderc_util.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := SPIRV-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libSPIRV.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := SPIRV-Tools-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libSPIRV-Tools.a
-include $(PREBUILT_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := SPIRV-Tools-opt-prebuilt
-LOCAL_SRC_FILES := $(ANDROID_DIR)/external/shaderc/android_test/obj/local/$(TARGET_ARCH_ABI)/libSPIRV-Tools-opt.a
-include $(PREBUILT_STATIC_LIBRARY)
-
 include $(CLEAR_VARS)
 LOCAL_MODULE := VkLayerValidationTests
 LOCAL_SRC_FILES += $(SRC_DIR)/tests/layer_validation_tests.cpp \
@@ -176,11 +127,9 @@ LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
                     $(LOCAL_PATH)/$(LAYER_DIR)/include \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers \
                     $(LOCAL_PATH)/$(SRC_DIR)/libs \
-                    $(LOCAL_PATH)/$(SRC_DIR)/common \
-                    $(LOCAL_PATH)/$(ANDROID_DIR)/external/shaderc/libshaderc/include
+                    $(LOCAL_PATH)/$(SRC_DIR)/common
 
-LOCAL_STATIC_LIBRARIES := googletest_main layer_utils
-LOCAL_SHARED_LIBRARIES += shaderc-prebuilt glslang-prebuilt OGLCompiler-prebuilt OSDependent-prebuilt HLSL-prebuilt shaderc_util-prebuilt SPIRV-prebuilt SPIRV-Tools-prebuilt SPIRV-Tools-opt-prebuilt
+LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden --include=$(SRC_DIR)/common/vulkan_wrapper.h
 LOCAL_LDLIBS := -llog
@@ -200,11 +149,9 @@ LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/include \
                     $(LOCAL_PATH)/$(LAYER_DIR)/include \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers \
                     $(LOCAL_PATH)/$(SRC_DIR)/libs \
-                    $(LOCAL_PATH)/$(SRC_DIR)/common \
-                    $(LOCAL_PATH)/$(ANDROID_DIR)/external/shaderc/libshaderc/include
+                    $(LOCAL_PATH)/$(SRC_DIR)/common
 
-LOCAL_STATIC_LIBRARIES := googletest_main layer_utils
-LOCAL_SHARED_LIBRARIES += shaderc-prebuilt glslang-prebuilt OGLCompiler-prebuilt OSDependent-prebuilt HLSL-prebuilt shaderc_util-prebuilt SPIRV-prebuilt SPIRV-Tools-prebuilt SPIRV-Tools-opt-prebuilt
+LOCAL_STATIC_LIBRARIES := googletest_main layer_utils shaderc
 LOCAL_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 LOCAL_CPPFLAGS += -DVK_USE_PLATFORM_ANDROID_KHR -fvisibility=hidden -DVALIDATION_APK --include=$(SRC_DIR)/common/vulkan_wrapper.h
 LOCAL_WHOLE_STATIC_LIBRARIES += android_native_app_glue
@@ -241,3 +188,4 @@ include $(BUILD_EXECUTABLE)
 
 $(call import-module,android/native_app_glue)
 $(call import-module,third_party/googletest)
+$(call import-module,third_party/shaderc)

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -18,3 +18,4 @@ APP_PLATFORM := android-22
 APP_STL := gnustl_static
 APP_MODULES := layer_utils VkLayer_core_validation VkLayer_parameter_validation VkLayer_object_tracker VkLayer_threading VkLayer_unique_objects VkLayerValidationTests VulkanLayerValidationTests vkjson_info
 NDK_TOOLCHAIN_VERSION := clang
+NDK_MODULE_PATH := .

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -17,5 +17,4 @@ APP_ABI := armeabi-v7a arm64-v8a x86 x86_64 mips mips64
 APP_PLATFORM := android-22
 APP_STL := gnustl_static
 APP_MODULES := layer_utils VkLayer_core_validation VkLayer_parameter_validation VkLayer_object_tracker VkLayer_threading VkLayer_unique_objects VkLayerValidationTests VulkanLayerValidationTests vkjson_info
-APP_CPPFLAGS += -std=c++11 -DVK_PROTOTYPES -Wall -Werror -Wno-unused-function -Wno-unused-const-variable -mxgot
 NDK_TOOLCHAIN_VERSION := clang

--- a/build-android/update_external_sources_android.bat
+++ b/build-android/update_external_sources_android.bat
@@ -22,10 +22,10 @@ setlocal EnableDelayedExpansion
 set errorCode=0
 set ANDROID_BUILD_DIR=%~dp0
 set BUILD_DIR=%ANDROID_BUILD_DIR%
-set BASE_DIR=%BUILD_DIR%\external
-set GLSLANG_DIR=%BASE_DIR%\glslang
-set SPIRV_TOOLS_DIR=%BASE_DIR%\spirv-tools
-set SPIRV_HEADERS_DIR=%BASE_DIR%\spirv-tools\external\spirv-headers
+set BASE_DIR=%BUILD_DIR%\third_party
+set GLSLANG_DIR=%BASE_DIR%\shaderc\third_party\glslang
+set SPIRV_TOOLS_DIR=%BASE_DIR%\shaderc\third_party\spirv-tools
+set SPIRV_HEADERS_DIR=%BASE_DIR%\shaderc\third_party\spirv-tools\external\spirv-headers
 set SHADERC_DIR=%BASE_DIR%\shaderc
 
 for %%X in (where.exe) do (set FOUND=%%~$PATH:X)
@@ -111,6 +111,15 @@ set sync-spirv-headers=1
 set sync-shaderc=1
 set build-shaderc=1
 
+if %sync-shaderc% equ 1 (
+   if not exist %SHADERC_DIR% (
+      call:create_shaderc
+   )
+   if %errorCode% neq 0 (goto:error)
+   call:update_shaderc
+   if %errorCode% neq 0 (goto:error)
+)
+
 if %sync-glslang% equ 1 (
    if not exist %GLSLANG_DIR% (
       call:create_glslang
@@ -137,15 +146,6 @@ if %sync-spirv-headers% equ 1 (
    )
    if %errorCode% neq 0 (goto:error)
    call:update_spirv-headers
-   if %errorCode% neq 0 (goto:error)
-)
-
-if %sync-shaderc% equ 1 (
-   if not exist %SHADERC_DIR% (
-      call:create_shaderc
-   )
-   if %errorCode% neq 0 (goto:error)
-   call:update_shaderc
    if %errorCode% neq 0 (goto:error)
 )
 
@@ -279,7 +279,7 @@ goto:eof
    echo Building %SHADERC_DIR%
    cd %SHADERC_DIR%\android_test
    echo Building shaderc with Android NDK
-   call ndk-build THIRD_PARTY_PATH=../.. -j 4
+   call ndk-build THIRD_PARTY_PATH=../third_party -j 4
    REM Check for existence of one lib, even though we should check for all results
    if not exist %SHADERC_DIR%\android_test\obj\local\x86\libshaderc.a (
       echo.

--- a/build-android/update_external_sources_android.sh
+++ b/build-android/update_external_sources_android.sh
@@ -20,7 +20,7 @@ set -e
 
 ANDROIDBUILDDIR=$PWD
 BUILDDIR=$ANDROIDBUILDDIR
-BASEDIR=$BUILDDIR/external
+BASEDIR=$BUILDDIR/third_party
 
 GLSLANG_REVISION=$(cat $ANDROIDBUILDDIR/glslang_revision_android)
 SPIRV_TOOLS_REVISION=$(cat $ANDROIDBUILDDIR/spirv-tools_revision_android)
@@ -93,17 +93,17 @@ then
 fi
 
 function create_glslang () {
-   rm -rf $BASEDIR/glslang
+   rm -rf $BASEDIR/shaderc/third_party/glslang
    echo "Creating local glslang repository ($BASEDIR/glslang)."
-   mkdir -p $BASEDIR/glslang
-   cd $BASEDIR/glslang
+   mkdir -p $BASEDIR/shaderc/third_party/glslang
+   cd $BASEDIR/shaderc/third_party/glslang
    git clone $GLSLANG_URL .
    git checkout $GLSLANG_REVISION
 }
 
 function update_glslang () {
-   echo "Updating $BASEDIR/glslang"
-   cd $BASEDIR/glslang
+   echo "Updating $BASEDIR/shaderc/third_party/glslang"
+   cd $BASEDIR/shaderc/third_party/glslang
    if [[ $(git config --get remote.origin.url) != $GLSLANG_URL ]]; then
       echo "glslang URL mismatch, recreating local repo"
       create_glslang
@@ -114,17 +114,17 @@ function update_glslang () {
 }
 
 function create_spirv-tools () {
-   rm -rf $BASEDIR/spirv-tools
-   echo "Creating local spirv-tools repository ($BASEDIR/spirv-tools)."
-   mkdir -p $BASEDIR/spirv-tools
-   cd $BASEDIR/spirv-tools
+   rm -rf $BASEDIR/shaderc/third_party/spirv-tools
+   echo "Creating local spirv-tools repository ($BASEDIR/shaderc/third_party/spirv-tools)."
+   mkdir -p $BASEDIR/shaderc/third_party/spirv-tools
+   cd $BASEDIR/shaderc/third_party/spirv-tools
    git clone $SPIRV_TOOLS_URL .
    git checkout $SPIRV_TOOLS_REVISION
 }
 
 function update_spirv-tools () {
-   echo "Updating $BASEDIR/spirv-tools"
-   cd $BASEDIR/spirv-tools
+   echo "Updating $BASEDIR/shaderc/third_party/spirv-tools"
+   cd $BASEDIR/shaderc/third_party/spirv-tools
    if [[ $(git config --get remote.origin.url) != $SPIRV_TOOLS_URL ]]; then
       echo "spirv-tools URL mismatch, recreating local repo"
       create_spirv-tools
@@ -135,17 +135,17 @@ function update_spirv-tools () {
 }
 
 function create_spirv-headers () {
-   rm -rf $BASEDIR/spirv-tools/external/spirv-headers
-   echo "Creating local spirv-headers repository ($BASEDIR/spirv-tools/external/spirv-headers)."
-   mkdir -p $BASEDIR/spirv-tools/external/spirv-headers
-   cd $BASEDIR/spirv-tools/external/spirv-headers
+   rm -rf $BASEDIR/shaderc/third_party/spirv-tools/external/spirv-headers
+   echo "Creating local spirv-headers repository ($BASEDIR/shaderc/third_party/spirv-tools/external/spirv-headers)."
+   mkdir -p $BASEDIR/shaderc/third_party/spirv-tools/external/spirv-headers
+   cd $BASEDIR/shaderc/third_party/spirv-tools/external/spirv-headers
    git clone $SPIRV_HEADERS_URL .
    git checkout $SPIRV_HEADERS_REVISION
 }
 
 function update_spirv-headers () {
-   echo "Updating $BASEDIR/spirv-tools/external/spirv-headers"
-   cd $BASEDIR/spirv-tools/external/spirv-headers
+   echo "Updating $BASEDIR/shaderc/third_party/spirv-tools/external/spirv-headers"
+   cd $BASEDIR/shaderc/third_party/spirv-tools/external/spirv-headers
    if [[ $(git config --get remote.origin.url) != $SPIRV_HEADERS_URL ]]; then
       echo "spirv-headers URL mismatch, recreating local repo"
       create_spirv-headers
@@ -158,9 +158,9 @@ function update_spirv-headers () {
 function create_shaderc () {
    rm -rf $BASEDIR/shaderc
    echo "Creating local shaderc repository ($BASEDIR/shaderc)."
-   cd $BASEDIR
-   git clone $SHADERC_URL
-   cd shaderc
+   mkdir -p $BASEDIR/shaderc
+   cd $BASEDIR/shaderc
+   git clone $SHADERC_URL .
    git checkout $SHADERC_REVISION
 }
 
@@ -180,32 +180,32 @@ function build_shaderc () {
    echo "Building $BASEDIR/shaderc"
    cd $BASEDIR/shaderc/android_test
    if [[ $abi ]]; then
-      ndk-build THIRD_PARTY_PATH=../.. APP_ABI=$abi -j $cores;
+      ndk-build THIRD_PARTY_PATH=../third_party APP_ABI=$abi -j $cores;
    else
-      ndk-build THIRD_PARTY_PATH=../.. -j $cores;
+      ndk-build THIRD_PARTY_PATH=../third_party -j $cores;
    fi
 }
-
-if [ ! -d "$BASEDIR/glslang" -o ! -d "$BASEDIR/glslang/.git" -o -d "$BASEDIR/glslang/.svn" ]; then
-   create_glslang
-fi
-update_glslang
-
-
-if [ ! -d "$BASEDIR/spirv-tools" -o ! -d "$BASEDIR/spirv-tools/.git" ]; then
-   create_spirv-tools
-fi
-update_spirv-tools
-
-if [ ! -d "$BASEDIR/spirv-tools/external/spirv-headers" -o ! -d "$BASEDIR/spirv-tools/external/spirv-headers/.git" ]; then
-   create_spirv-headers
-fi
-update_spirv-headers
 
 if [ ! -d "$BASEDIR/shaderc" -o ! -d "$BASEDIR/shaderc/.git" ]; then
      create_shaderc
 fi
 update_shaderc
+
+if [ ! -d "$BASEDIR/shaderc/third_party/glslang" -o ! -d "$BASEDIR/shaderc/third_party/glslang/.git" -o -d "$BASEDIR/shaderc/third_party/glslang/.svn" ]; then
+   create_glslang
+fi
+update_glslang
+
+if [ ! -d "$BASEDIR/shaderc/third_party/spirv-tools" -o ! -d "$BASEDIR/shaderc/third_party/spirv-tools/.git" ]; then
+   create_spirv-tools
+fi
+update_spirv-tools
+
+if [ ! -d "$BASEDIR/shaderc/third_party/spirv-tools/external/spirv-headers" -o ! -d "$BASEDIR/shaderc/third_party/spirv-tools/external/spirv-headers/.git" ]; then
+   create_spirv-headers
+fi
+update_spirv-headers
+
 build_shaderc
 
 echo ""


### PR DESCRIPTION
This updates the android build to align it with the android NDK build.
That will make it simpler to keep validation layers in the NDK build more up to date.
It also allows use of github validation source in combination with the NDK source version of shaderc and SPIRV repositories.