### PR TITLE
Change wrap-objects loader test filter

### DIFF
--- a/tests/run_wrap_objects_tests.sh
+++ b/tests/run_wrap_objects_tests.sh
@@ -127,7 +127,9 @@ then
    exit 1
 fi
 
-filter=-VkLayerTest.ExceedMemoryAllocationCount:VkLayerTest.CreateImageViewFormatFeatureMismatch:VkLayerTest.CreateImageViewFormatMismatchUnrelated:VkLayerTest.CreateImageViewNoMutableFormatBit
+# Pick a random subset of valid LVT tests to wrap -- None of these can use the device profile API extension!
+filter=VkLayerTest.ThreadCommandBufferCollision:VkLayerTest.ImageDescriptorLayoutMismatch:VkLayerTest.CreateBufferViewNoMemoryBoundToBuffer:VkLayerTest.CommandBufferResetErrors:VkLayerTest.PSOLineWidthInvalid:VkLayerTest.EndCommandBufferWithinRenderPass:VkLayerTest.DSBufferLimitErrors:VkLayerTest.InvalidImageLayout:VkLayerTest.CreatePipelineVsFsMismatchByLocation:VkLayerTest.ImageBufferCopyTests:VkLayerTest.ClearImageErrors:VkPositiveLayerTest.NonCoherentMemoryMapping:VkPositiveLayerTest.BarrierLayoutToImageUsage:VkPositiveLayerTest.TwoSubmitInfosWithSemaphoreOneQueueSubmitsOneFence
+
 # Run the layer validation tests with and without the wrap-objects layer. Diff the results.
 # Filter out the "Unexpected:" lines because they contain varying object handles.
 GTEST_PRINT_TIME=0 \


### PR DESCRIPTION
Replace blacklist with shorter whitelist -- as there are fundamental incompatibilities between this test and using the device profile layer, it was too easy to add a new validation test without updating the blacklist (not to mention being completely non-obvious).  This replaces the blacklist with a much shorter whitelist of stable tests, which should still serve to validate the loader's ability to handle wrapped instance objects.  And, it makes the test much faster.
