### PR TITLE
Remove uninitialized warning for external memory

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -358,6 +358,18 @@ static void add_mem_obj_info(layer_data *dev_data, void *object, const VkDeviceM
     assert(object != NULL);
 
     dev_data->memObjMap[mem] = unique_ptr<DEVICE_MEM_INFO>(new DEVICE_MEM_INFO(object, mem, pAllocateInfo));
+
+    if (pAllocateInfo->pNext) {
+        auto struct_header = reinterpret_cast<const GENERIC_HEADER *>(pAllocateInfo->pNext);
+        while (struct_header) {
+            if (VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR == struct_header->sType ||
+                VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR == struct_header->sType) {
+                dev_data->memObjMap[mem]->global_valid = true;
+                break;
+            }
+            struct_header = reinterpret_cast<const GENERIC_HEADER *>(struct_header->pNext);
+        }
+    }
 }
 
 // For given bound_object_handle, bound to given mem allocation, verify that the range for the bound object is valid

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -316,7 +316,7 @@ struct MEMORY_RANGE {
 // Data struct for tracking memory object
 struct DEVICE_MEM_INFO : public BASE_NODE {
     void *object;       // Dispatchable object used to create this memory (device of swapchain)
-    bool global_valid;  // If allocation is mapped, set to "true" to be picked up by subsequently bound ranges
+    bool global_valid;  // If allocation is mapped or external, set to "true" to be picked up by subsequently bound ranges
     VkDeviceMemory mem;
     VkMemoryAllocateInfo alloc_info;
     std::unordered_set<VK_OBJECT> obj_bindings;               // objects bound to this memory

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -25679,6 +25679,109 @@ TEST_F(VkPositiveLayerTest, ClearDepthStencilWithValidRange) {
     }
 }
 
+TEST_F(VkPositiveLayerTest, ExternalMemory) {
+    TEST_DESCRIPTION("Perform a copy from a buffer backed by external memory");
+
+#ifdef _WIN32
+    const auto extension_name = VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME;
+    const auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR;
+#else
+    const auto extension_name = VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME;
+    const auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
+#endif
+
+    // Check for external memory instance extensions
+    if (InstanceExtensionSupported(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME)) {
+        m_instance_extension_names.push_back(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
+        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    } else {
+        printf("             External memory extension not supported, skipping test\n");
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
+
+    // Check for external memory device extensions
+    if (DeviceExtensionSupported(gpu(), nullptr, extension_name)) {
+        m_device_extension_names.push_back(extension_name);
+        m_device_extension_names.push_back(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
+    } else {
+        printf("             External memory extension not supported, skipping test\n");
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    // Check for import/export capability
+    VkPhysicalDeviceExternalBufferInfoKHR ebi = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR, nullptr, 0,
+                                                 VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, handle_type};
+    VkExternalBufferPropertiesKHR ebp = {VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR, nullptr, {0, 0, 0}};
+    auto vkGetPhysicalDeviceExternalBufferPropertiesKHR = (PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR)vkGetInstanceProcAddr(
+        instance(), "vkGetPhysicalDeviceExternalBufferPropertiesKHR");
+    ASSERT_TRUE(vkGetPhysicalDeviceExternalBufferPropertiesKHR != nullptr);
+    vkGetPhysicalDeviceExternalBufferPropertiesKHR(gpu(), &ebi, &ebp);
+    if (!(ebp.externalMemoryProperties.compatibleHandleTypes & handle_type)) {
+        printf("             External buffer does not support importing and exporting, skipping test\n");
+        return;
+    }
+
+    m_errorMonitor->ExpectSuccess(VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT);
+
+    VkMemoryPropertyFlags mem_flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+    const VkDeviceSize buffer_size = 32;
+
+    // Create source buffer
+    vk_testing::Buffer buffer_src;
+    buffer_src.init_no_mem(*m_device, vk_testing::Buffer::create_info(buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT));
+
+    // Allocate memory
+    vk_testing::DeviceMemory memory_export;
+    auto alloc_info = vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, buffer_src.memory_requirements(), mem_flags);
+    memory_export.init(*m_device, alloc_info);
+
+#ifdef _WIN32
+    // Export memory to handle
+    auto vkGetMemoryWin32HandleKHR = (PFN_vkGetMemoryWin32HandleKHR)vkGetInstanceProcAddr(instance(), "vkGetMemoryWin32HandleKHR");
+    ASSERT_TRUE(vkGetMemoryWin32HandleKHR != nullptr);
+    VkMemoryGetWin32HandleInfoKHR mghi = {VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, nullptr, memory_export.handle(),
+                                          handle_type};
+    HANDLE handle;
+    ASSERT_VK_SUCCESS(vkGetMemoryWin32HandleKHR(m_device->device(), &mghi, &handle));
+
+    VkImportMemoryWin32HandleInfoKHR import_info = {VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR, nullptr, handle_type,
+                                                    handle};
+#else
+    // Export memory to fd
+    auto vkGetMemoryFdKHR = (PFN_vkGetMemoryFdKHR)vkGetInstanceProcAddr(instance(), "vkGetMemoryFdKHR");
+    ASSERT_TRUE(vkGetMemoryFdKHR != nullptr);
+    VkMemoryGetFdInfoKHR mgfi = {VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR, nullptr, memory_export.handle(), handle_type};
+    int fd;
+    ASSERT_VK_SUCCESS(vkGetMemoryFdKHR(m_device->device(), &mgfi, &fd));
+
+    VkImportMemoryFdInfoKHR import_info = {VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR, nullptr, handle_type, fd};
+#endif
+
+    // Import memory
+    vk_testing::DeviceMemory memory_import;
+    alloc_info.pNext = &import_info;
+    memory_import.init(*m_device, alloc_info);
+
+    // Bind source buffer to external memory
+    buffer_src.bind_memory(memory_import, 0);
+
+    // Create destination buffer because we need a target for the copy
+    vk_testing::Buffer buffer_dst;
+    vk_testing::Buffer buffer;
+    buffer_dst.init_as_dst(*m_device, buffer_size, mem_flags);
+
+    // Copy from source buffer with external backing memory
+    m_commandBuffer->begin();
+    VkBufferCopy copy_info = {0, 0, buffer_size};
+    vkCmdCopyBuffer(m_commandBuffer->handle(), buffer_src.handle(), buffer_dst.handle(), 1, &copy_info);
+    m_commandBuffer->end();
+    m_commandBuffer->QueueCommandBuffer();
+
+    m_errorMonitor->VerifyNotFound();
+}
+
 TEST_F(VkLayerTest, AMDMixedAttachmentSamplesValidateRenderPass) {
     TEST_DESCRIPTION(
         "Verify error messages for supported and unsupported "

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -62,14 +62,6 @@ std::vector<T> make_handles(const std::vector<S> &v) {
     return handles;
 }
 
-VkMemoryAllocateInfo get_resource_alloc_info(const vk_testing::Device &dev, const VkMemoryRequirements &reqs,
-                                             VkMemoryPropertyFlags mem_props) {
-    VkMemoryAllocateInfo info = vk_testing::DeviceMemory::alloc_info(reqs.size, 0);
-    dev.phy().set_memory_type(reqs.memoryTypeBits, &info, mem_props);
-
-    return info;
-}
-
 }  // namespace
 
 namespace vk_testing {
@@ -426,6 +418,13 @@ void *DeviceMemory::map(VkFlags flags) {
 
 void DeviceMemory::unmap() const { vkUnmapMemory(device(), handle()); }
 
+VkMemoryAllocateInfo DeviceMemory::get_resource_alloc_info(const Device &dev, const VkMemoryRequirements &reqs,
+                                                           VkMemoryPropertyFlags mem_props) {
+    VkMemoryAllocateInfo info = alloc_info(reqs.size, 0);
+    dev.phy().set_memory_type(reqs.memoryTypeBits, &info, mem_props);
+    return info;
+}
+
 NON_DISPATCHABLE_HANDLE_DTOR(Fence, vkDestroyFence)
 
 void Fence::init(const Device &dev, const VkFenceCreateInfo &info) { NON_DISPATCHABLE_HANDLE_INIT(vkCreateFence, dev, &info); }
@@ -462,7 +461,7 @@ NON_DISPATCHABLE_HANDLE_DTOR(Buffer, vkDestroyBuffer)
 void Buffer::init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props) {
     init_no_mem(dev, info);
 
-    internal_mem_.init(dev, get_resource_alloc_info(dev, memory_requirements(), mem_props));
+    internal_mem_.init(dev, DeviceMemory::get_resource_alloc_info(dev, memory_requirements(), mem_props));
     bind_memory(internal_mem_, 0);
 }
 
@@ -495,7 +494,7 @@ void Image::init(const Device &dev, const VkImageCreateInfo &info, VkMemoryPrope
     init_no_mem(dev, info);
 
     if (initialized()) {
-        internal_mem_.init(dev, get_resource_alloc_info(dev, memory_requirements(), mem_props));
+        internal_mem_.init(dev, DeviceMemory::get_resource_alloc_info(dev, memory_requirements(), mem_props));
         bind_memory(internal_mem_, 0);
     }
 }

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -257,6 +257,8 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
     void unmap() const;
 
     static VkMemoryAllocateInfo alloc_info(VkDeviceSize size, uint32_t memory_type_index);
+    static VkMemoryAllocateInfo get_resource_alloc_info(const vk_testing::Device &dev, const VkMemoryRequirements &reqs,
+                                                        VkMemoryPropertyFlags mem_props);
 };
 
 class Fence : public internal::NonDispHandle<VkFence> {


### PR DESCRIPTION
Fixes GH issue #2096 / LX issue [712](https://vulkan.lunarg.com/issue/view/59b6b9b2e46ffe6c0d3db481)

Treat imported external memory as valid (similar to mapped memory) so we don't warn when an image or buffer bound to the external memory is used as a src.