### PR TITLE
Updates to improve build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,7 @@ android:
     - build-tools-23.0.2
     - android-23
 
-cache:
-  directories:
-    - external
-    - build-android/external
+cache: ccache
 
 before_install:
   # Install the appropriate Linux packages.
@@ -59,9 +56,9 @@ script:
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then make -C dbuild; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then LD_LIBRARY_PATH=dbuild/loader:$LD_LIBRARY_PATH VK_LAYER_PATH=dbuild/layers VK_ICD_FILENAMES=dbuild/icd/VkICD_mock_icd.json dbuild/tests/vk_layer_validation_tests; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then pushd build-android; fi
-  - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ./update_external_sources_android.sh --abi $ANDROID_ABI; fi
+  - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ./update_external_sources_android.sh --abi $ANDROID_ABI --no-build; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ./android-generate.sh; fi
-  - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ndk-build APP_ABI=$ANDROID_ABI; fi
+  - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then USE_CCACHE=1 NDK_CCACHE=/usr/lib/ccache ndk-build APP_ABI=$ANDROID_ABI; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then popd; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,6 @@ matrix:
       compiler: clang
       env: VULKAN_BUILD_TARGET=LINUX
 
-android:
-  components:
-    - tools
-    - platform-tools
-    - build-tools-23.0.2
-    - android-23
-
 cache: ccache
 
 before_install:
@@ -47,18 +40,17 @@ before_install:
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then export JAVA_HOME="/usr/lib/jvm/java-8-oracle"; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then export PATH="$ANDROID_NDK_HOME:$PATH"; fi
 
-  # Clear the toolchain contents if revisions have changed
-  - ./scripts/check_toolchain_revisions.sh
+  - export core_count=$(nproc || echo 4) && echo core_count = $core_count
 
 script:
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then ./update_external_sources.sh; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then cmake -H. -Bdbuild -DCMAKE_BUILD_TYPE=Debug; fi
-  - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then make -C dbuild; fi
+  - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then make -C dbuild -j $core_count; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then LD_LIBRARY_PATH=dbuild/loader:$LD_LIBRARY_PATH VK_LAYER_PATH=dbuild/layers VK_ICD_FILENAMES=dbuild/icd/VkICD_mock_icd.json dbuild/tests/vk_layer_validation_tests; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then pushd build-android; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ./update_external_sources_android.sh --abi $ANDROID_ABI --no-build; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then ./android-generate.sh; fi
-  - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then USE_CCACHE=1 NDK_CCACHE=/usr/lib/ccache ndk-build APP_ABI=$ANDROID_ABI; fi
+  - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then USE_CCACHE=1 NDK_CCACHE=ccache ndk-build APP_ABI=$ANDROID_ABI -j $core_count; fi
   - if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then popd; fi
 
 notifications:

--- a/BUILD.md
+++ b/BUILD.md
@@ -40,6 +40,8 @@ cd dbuild
 make
 ```
 
+If your build system supports ccache, you can enable that via cmake option `-DUSE_CCACHE=On`
+
 If you have installed a Vulkan driver obtained from your graphics hardware vendor, the install process should
 have configured the driver so that the Vulkan loader can find and load it.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,15 @@ string(TOLOWER ${API_NAME} API_LOWERCASE)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(PythonInterp 3 REQUIRED)
 
+option(USE_CCACHE "Use ccache" OFF)
+if (USE_CCACHE)
+    find_program(CCACHE_FOUND ccache)
+    if(CCACHE_FOUND)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    endif(CCACHE_FOUND)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(FALLBACK_CONFIG_DIRS "/etc/xdg" CACHE STRING
         "Search path to use when XDG_CONFIG_DIRS is unset or empty or the current process is SUID/SGID. Default is freedesktop compliant.")

--- a/build-android/update_external_sources_android.sh
+++ b/build-android/update_external_sources_android.sh
@@ -55,19 +55,11 @@ fi
 function printUsage {
    echo "Supported parameters are:"
    echo "    --abi <abi> (optional)"
+   echo "    --no-build (optional)"
    echo
    echo "i.e. ${0##*/} --abi arm64-v8a \\"
    exit 1
 }
-
-if [[ $(($# % 2)) -ne 0 ]]
-then
-    echo Parameters must be provided in pairs.
-    echo parameter count = $#
-    echo
-    printUsage
-    exit 1
-fi
 
 while [[ $# -gt 0 ]]
 do
@@ -75,6 +67,10 @@ do
         --abi)
             abi="$2"
             shift 2
+            ;;
+        --no-build)
+            nobuild=1
+            shift 1
             ;;
         *)
             # unknown option
@@ -90,6 +86,12 @@ echo abi=$abi
 if [[ -z $abi ]]
 then
     echo No abi provided, so building for all supported abis.
+fi
+
+echo no-build=$nobuild
+if [[ $nobuild ]]
+then
+    echo Skipping build.
 fi
 
 function create_glslang () {
@@ -206,7 +208,10 @@ if [ ! -d "$BASEDIR/shaderc/third_party/spirv-tools/external/spirv-headers" -o !
 fi
 update_spirv-headers
 
+if [[ -z $nobuild ]]
+then
 build_shaderc
+fi
 
 echo ""
 echo "${0##*/} finished."


### PR DESCRIPTION
This series:

- Updates the Android build script to allow skipping the build.  This is required due to how we're using import to build shaderc.  We're building it twice currently.
- Switches Travis-CI to use **ccache** which improves Android and desktop build times.  The improvements aren't uniform, so there is probably more work that could be done here.
- Use multiple cores in Travis-CI build.  I don't recall why we didn't do that, probably oversight.
- Add ccache option to local cmake builds.  This could probably be added to toolchain components too.

From my tests with hot cache, old build times:
```
Android arm32:  10 min 15 sec
Android arm64:  10 min 8 sec
Linux gcc:  9 min 17 sec
Linux clang:  7 min 30 sec
```
New build times:
```
Android arm32:  3 min 28 sec
Android arm64:  4 min 59 sec
Linux gcc:  3 min 17 sec
Linux clang:  5 min 49 sec
```
