### PR TITLE
Make ExternalMemory test more robust

### DIFF
--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -422,7 +422,7 @@ void DeviceMemory::unmap() const { vkUnmapMemory(device(), handle()); }
 VkMemoryAllocateInfo DeviceMemory::get_resource_alloc_info(const Device &dev, const VkMemoryRequirements &reqs,
                                                            VkMemoryPropertyFlags mem_props) {
     VkMemoryAllocateInfo info = alloc_info(reqs.size, 0);
-    dev.phy().set_memory_type(reqs.memoryTypeBits, &info, mem_props);
+    EXPECT(dev.phy().set_memory_type(reqs.memoryTypeBits, &info, mem_props));
     return info;
 }
 


### PR DESCRIPTION
- Use dedicated allocation when required by the external memory implementation
- Add required pNext structs for all buffers and memory
- Relax the requirement that external memory be host visible for this test
- Verify that the export/import memory is actually linked

Also fixes #2206 