### PR TITLE
layers:Limit warning on secondary command buffer

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -5208,15 +5208,16 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(VkCommandBuffer commandBuffer,
                     cb_node->framebuffers.insert(cb_node->beginInfo.pInheritanceInfo->framebuffer);
                 } else if (VK_NULL_HANDLE != cb_node->beginInfo.pInheritanceInfo->renderPass) {
                     // This is a user-requested warning. This is a likely case where user forgot to set RP continue bit
-                    skip |=
-                        log_msg(dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT,
-                                HandleToUint64(cb_node->beginInfo.pInheritanceInfo->renderPass), __LINE__,
-                                VALIDATION_ERROR_0280006a, "CORE",
-                                "vkBeginCommandBuffer(): Secondary command buffer with a non-null pInheritanceInfo->renderPass "
-                                "does not have "
-                                "VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT. If you intend to draw from this command buffer "
-                                "you must set "
-                                "VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT in pBeginInfo->flags.");
+                    //  but only warn if renderPass actually exists, indicating this was intentional vs just uninitialized junk
+                    if (GetRenderPassState(dev_data, cb_node->beginInfo.pInheritanceInfo->renderPass)) {
+                        skip |= log_msg(
+                            dev_data->report_data, VK_DEBUG_REPORT_WARNING_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT,
+                            HandleToUint64(cb_node->beginInfo.pInheritanceInfo->renderPass), __LINE__, VALIDATION_ERROR_0280006a,
+                            "CORE",
+                            "vkBeginCommandBuffer(): Secondary command buffer with a non-null pInheritanceInfo->renderPass "
+                            "does not have VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT. If you intend to draw from this "
+                            "command buffer you must set VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT in pBeginInfo->flags.");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Slight tweak to previous warning so that it only fires if renderPass is valid. This prevents warning for random data due to uninitialized buffer (unless random data aliases valid renderPass which is unlikely and doesn't hurt to warn on).

Only warn if a secondary command buffer has a renderPass that is valid
and has not set VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT. This
avoid warning for the case where uninitialized data is present in the
renderPass handle.