### PR TITLE
tests:Re-enable DS attachment for TriTest

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -577,17 +577,17 @@ void VkLayerTest::VKTriangleTest(BsoFailSelect failCase) {
             break;
         }
         case BsoFailStencilReadMask: {
-            // failcase_needs_depth = true; // Mali driver failing if DS gets cleared
+            failcase_needs_depth = true;
             pipelineobj.MakeDynamic(VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK);
             break;
         }
         case BsoFailStencilWriteMask: {
-            // failcase_needs_depth = true; // Mali driver failing if DS gets cleared
+            failcase_needs_depth = true;
             pipelineobj.MakeDynamic(VK_DYNAMIC_STATE_STENCIL_WRITE_MASK);
             break;
         }
         case BsoFailStencilReference: {
-            // failcase_needs_depth = true; // Mali driver failing if DS gets cleared
+            failcase_needs_depth = true;
             pipelineobj.MakeDynamic(VK_DYNAMIC_STATE_STENCIL_REFERENCE);
             break;
         }


### PR DESCRIPTION
Three cases were disabling DS attachment to accomodate a driver bug,
but this is actually invalid for the tests.
Re-enabling the DS attachment for those cases as with device updates
and other workarounds, the tests are now working across all devices.
