### PR TITLE
tests:Remove functional check from ExternalMemory

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -26170,13 +26170,6 @@ TEST_F(VkPositiveLayerTest, ExternalMemory) {
     m_commandBuffer->end();
     m_commandBuffer->QueueCommandBuffer();
 
-    // Verify output buffer
-    auto output_mem = (uint8_t *)buffer_output.memory().map();
-    for (uint32_t i = 0; i < buffer_size; i++) {
-        ASSERT_TRUE(output_mem[i] == (i & 0xFF));
-    }
-    buffer_output.memory().unmap();
-
     m_errorMonitor->VerifyNotFound();
 }
 


### PR DESCRIPTION
The ExternalMemory test is a positive test that would only pass if
underlying device functionality was verified.
Remove the functional check as that is not appropriate for LVL tests.

The purpose of positive tests in LVL is to stress the validation layers
in specific cases that are known to have had bugs or have potential for
bugs. These tests shouldn't be validating underlying device
capabilities. CTS is the appropriate place for device functional tests.