### PR TITLE
build: Add clang-format checking of pull request changes to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
     - os: linux
       compiler: clang
       env: VULKAN_BUILD_TARGET=LINUX
+    # Check for proper clang formatting in the pull request.
+    - env: CHECK_FORMAT=ON
 
 cache: ccache
 
@@ -35,14 +37,14 @@ cache: ccache
 
 before_install:
   - set -e
+  # Install the appropriate Linux packages.
   - |
-    # Install the appropriate Linux packages.
     if [[ "$VULKAN_BUILD_TARGET" == "LINUX" ]]; then
       sudo apt-get -qq update
       sudo apt-get -y install libxkbcommon-dev libwayland-dev libmirclient-dev libxrandr-dev libx11-xcb-dev
     fi
+  # Install the Android NDK.
   - |
-    # Install the Android NDK.
     if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then
       export ARCH=`uname -m`
       wget http://dl.google.com/android/repository/android-ndk-r16b-linux-${ARCH}.zip
@@ -51,6 +53,13 @@ before_install:
       export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
       export PATH="$ANDROID_NDK_HOME:$PATH"
     fi
+  # Install the clang format diff tool, but only for pull requests.
+  - |
+    if [[ "$CHECK_FORMAT" == "ON" && "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+      curl -L http://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py -o scripts/clang-format-diff.py;
+    fi
+  # Misc setup
+  - |
   - export core_count=$(nproc || echo 4) && echo core_count = $core_count
   - set +e
 
@@ -81,6 +90,17 @@ script:
       ./android-generate.sh
       USE_CCACHE=1 NDK_CCACHE=ccache ndk-build APP_ABI=$ANDROID_ABI -j $core_count
       popd
+    fi
+  # Run the clang format check only for pull request builds because the
+  # master branch is needed to do the git diff.
+  - |
+    if [[ "$CHECK_FORMAT" == "ON" ]]; then
+      if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+        echo "Checking clang-format between TRAVIS_BRANCH=$TRAVIS_BRANCH and TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH"
+        ./scripts/check_code_format.sh
+      else
+        echo "Skipping clang-format check since this is not a pull request."
+      fi
     fi
   - set +e
 

--- a/scripts/check_code_format.sh
+++ b/scripts/check_code_format.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright (c) 2017 Google Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Script to determine if source code in Pull Request is properly formatted.
+# Exits with non 0 exit code if formatting is needed.
+#
+# This script assumes to be invoked at the project root directory.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+FILES_TO_CHECK=$(git diff --name-only master | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
+
+if [ -z "${FILES_TO_CHECK}" ]; then
+  echo -e "${GREEN}No source code to check for formatting.${NC}"
+  exit 0
+fi
+
+FORMAT_DIFF=$(git diff -U0 master -- ${FILES_TO_CHECK} | python ./scripts/clang-format-diff.py -p1 -style=file)
+
+if [ -z "${FORMAT_DIFF}" ]; then
+  echo -e "${GREEN}All source code in PR properly formatted.${NC}"
+  exit 0
+else
+  echo -e "${RED}Found formatting errors!${NC}"
+  echo "${FORMAT_DIFF}"
+  exit 1
+fi


### PR DESCRIPTION
Check modified lines in a pull request for correct clang-format.
Note that checking is not performed unless there is a pull request.

Heavily leveraged from https://github.com/KhronosGroup/SPIRV-Tools.