### PR TITLE
Roll back to NDK r15c

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ before_install:
   - |
     if [[ "$VULKAN_BUILD_TARGET" == "ANDROID" ]]; then
       export ARCH=`uname -m`
-      wget http://dl.google.com/android/repository/android-ndk-r16b-linux-${ARCH}.zip
-      unzip -u -q android-ndk-r16b-linux-${ARCH}.zip
-      export ANDROID_NDK_HOME=`pwd`/android-ndk-r16b
+      wget http://dl.google.com/android/repository/android-ndk-r15c-linux-${ARCH}.zip
+      unzip -u -q android-ndk-r15c-linux-${ARCH}.zip
+      export ANDROID_NDK_HOME=`pwd`/android-ndk-r15c
       export JAVA_HOME="/usr/lib/jvm/java-8-oracle"
       export PATH="$ANDROID_NDK_HOME:$PATH"
     fi

--- a/build-android/jni/shaderc/Application.mk
+++ b/build-android/jni/shaderc/Application.mk
@@ -1,0 +1,4 @@
+APP_ABI := all
+APP_BUILD_SCRIPT := Android.mk
+APP_STL := c++_static
+APP_PLATFORM := android-23


### PR DESCRIPTION
We're unable to complete test runs using r16b, and being short staffed for the holidays, switching back to an earlier release that is working.  We'll get it sorted out once everyone is back.  We've already switched the test farms to r15c.