### PR TITLE
Tobin khr std val header

### DIFF
--- a/demos/cube.cpp
+++ b/demos/cube.cpp
@@ -40,6 +40,7 @@
 #define VULKAN_HPP_NO_EXCEPTIONS
 #include <vulkan/vulkan.hpp>
 #include <vulkan/vk_sdk_platform.h>
+#include <vulkan/vk_standard_validation.h>
 
 #include "linmath.h"
 
@@ -1006,16 +1007,10 @@ Demo::Demo()
     void Demo::init_vk() {
         uint32_t instance_extension_count = 0;
         uint32_t instance_layer_count = 0;
-        uint32_t validation_layer_count = 0;
-        char const *const *instance_validation_layers = nullptr;
+        uint32_t validation_layer_count = vkval::VALIDATION_LAYER_COUNT;
+        char const *const *instance_validation_layers = vkval::standard_validation_array;
         enabled_extension_count = 0;
         enabled_layer_count = 0;
-
-        char const *const instance_validation_layers_alt1[] = {"VK_LAYER_LUNARG_standard_validation"};
-
-        char const *const instance_validation_layers_alt2[] = {
-            "VK_LAYER_GOOGLE_threading", "VK_LAYER_LUNARG_parameter_validation", "VK_LAYER_LUNARG_object_tracker",
-            "VK_LAYER_LUNARG_core_validation", "VK_LAYER_GOOGLE_unique_objects"};
 
         // Look for validation layers
         vk::Bool32 validation_found = VK_FALSE;
@@ -1023,25 +1018,15 @@ Demo::Demo()
             auto result = vk::enumerateInstanceLayerProperties(&instance_layer_count, nullptr);
             VERIFY(result == vk::Result::eSuccess);
 
-            instance_validation_layers = instance_validation_layers_alt1;
-            if (instance_layer_count > 0) {
+            if (instance_layer_count >= validation_layer_count) {
                 std::unique_ptr<vk::LayerProperties[]> instance_layers(new vk::LayerProperties[instance_layer_count]);
                 result = vk::enumerateInstanceLayerProperties(&instance_layer_count, instance_layers.get());
                 VERIFY(result == vk::Result::eSuccess);
 
-                validation_found = check_layers(ARRAY_SIZE(instance_validation_layers_alt1), instance_validation_layers,
-                                                instance_layer_count, instance_layers.get());
+                validation_found =
+                    check_layers(validation_layer_count, instance_validation_layers, instance_layer_count, instance_layers.get());
                 if (validation_found) {
-                    enabled_layer_count = ARRAY_SIZE(instance_validation_layers_alt1);
-                    enabled_layers[0] = "VK_LAYER_LUNARG_standard_validation";
-                    validation_layer_count = 1;
-                } else {
-                    // use alternative set of validation layers
-                    instance_validation_layers = instance_validation_layers_alt2;
-                    enabled_layer_count = ARRAY_SIZE(instance_validation_layers_alt2);
-                    validation_found = check_layers(ARRAY_SIZE(instance_validation_layers_alt2), instance_validation_layers,
-                                                    instance_layer_count, instance_layers.get());
-                    validation_layer_count = ARRAY_SIZE(instance_validation_layers_alt2);
+                    enabled_layer_count = validation_layer_count;
                     for (uint32_t i = 0; i < validation_layer_count; i++) {
                         enabled_layers[i] = instance_validation_layers[i];
                     }

--- a/demos/smoke/ShellAndroid.cpp
+++ b/demos/smoke/ShellAndroid.cpp
@@ -22,6 +22,7 @@
 #include "Helpers.h"
 #include "Game.h"
 #include "ShellAndroid.h"
+#include "vk_standard_validation.h"
 
 namespace {
 
@@ -103,11 +104,7 @@ std::vector<std::string> ShellAndroid::get_args(android_app &app) {
 
 ShellAndroid::ShellAndroid(android_app &app, Game &game) : Shell(game), app_(app) {
     if (game.settings().validate) {
-        instance_layers_.push_back("VK_LAYER_GOOGLE_threading");
-        instance_layers_.push_back("VK_LAYER_LUNARG_parameter_validation");
-        instance_layers_.push_back("VK_LAYER_LUNARG_object_tracker");
-        instance_layers_.push_back("VK_LAYER_LUNARG_core_validation");
-        instance_layers_.push_back("VK_LAYER_GOOGLE_unique_objects");
+        instance_layers_ = vkval::standard_validation_vector;
     }
 
     instance_extensions_.push_back(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);

--- a/include/vulkan/vk_standard_validation.h
+++ b/include/vulkan/vk_standard_validation.h
@@ -1,0 +1,62 @@
+//
+// File: vk_standard_validation.h
+//
+/*
+ * Copyright (c) 2017 The Khronos Group Inc.
+ * Copyright (c) 2017 Valve Corporation
+ * Copyright (c) 2017 LunarG, Inc.
+ * Copyright (c) 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#pragma once
+
+/*
+ * vk_standard_validation.h
+ *
+ * This is a header file to simplify using the standard set of validation layers across any platform.
+ * It defines the array "standard_validation_array" for C code and the vector "standard_validation_vector" for C++ code
+ * that can be used when creating a VkInstance in order to enable the standard validation layer stack.
+ *
+ * In C code VkInstanceCreateInfo struct you can use the values, for example, as:
+ *
+ *   VkInstanceCreateInfo instance_create_info;
+ *   instance_create_info.enabledLayerCount = VALIDATION_LAYER_COUNT;
+ *   instance_create_info.ppEnabledLayerNames = standard_validation_array;
+ *
+ * C++ code exists under the "vkval" namespace. The vector size and array can therefore be used as:
+ * vkval::VALIDATION_LAYER_COUNT and vkval::standard_validation_array.
+ * An example of using the vector in C++ is:
+ *
+ *   VkInstanceCreateInfo instance_create_info = {};
+ *   instance_create_info.enabledLayerCount = vkval::standard_validation_vector.size();
+ *   instance_create_info.ppEnabledLayerNames = vkval::standard_validation_vector.data();
+ */
+
+#ifdef __cplusplus
+#include <vector>
+namespace vkval {
+#endif
+static char const *const standard_validation_array[] = {"VK_LAYER_GOOGLE_threading", "VK_LAYER_LUNARG_parameter_validation",
+                                                        "VK_LAYER_LUNARG_object_tracker", "VK_LAYER_LUNARG_core_validation",
+                                                        "VK_LAYER_GOOGLE_unique_objects"};
+
+static const uint32_t VALIDATION_LAYER_COUNT = sizeof(standard_validation_array) / sizeof(standard_validation_array[0]);
+
+#ifdef __cplusplus
+static const std::vector<char const *> standard_validation_vector(standard_validation_array,
+                                                                  standard_validation_array + VALIDATION_LAYER_COUNT);
+}
+#endif

--- a/layers/README.md
+++ b/layers/README.md
@@ -34,13 +34,15 @@ logging callbacks.
 
 Note that some layers are code-generated and will therefore exist in the directory `(build_dir)/layers`
 
-`include/vkLayer.h` - header file for layer code.
+`include/vulkan/vkLayer.h` - header file for layer code.
 
 ### Layer Details
-For complete details of current validation layers, including all of the validation checks that they perform, please refer to the document `layers/vk_validation_layer_details.md`. Below is a brief overview of each layer.
+For complete details of current validation layers, the code is the ultimate source. There is also a text database file that contains all of the valid usage statements from the Vulkan specification and catalogs which checks are currently covered in the validation layers. The database file can be accessed at `layers/vk_validation_error_database.txt`. Below is a brief overview of each layer.
 
 ### Standard Validation
-This is a meta-layer managed by the loader. (name = `VK_LAYER_LUNARG_standard_validation`) - specifying this layer name will cause the loader to load the all of the standard validation layers (listed below) in the following optimal order:  `VK_LAYER_GOOGLE_threading`, `VK_LAYER_LUNARG_parameter_validation`, `VK_LAYER_LUNARG_object_tracker`, `VK_LAYER_LUNARG_core_validation`, and `VK_LAYER_GOOGLE_unique_objects`. Other layers can be specified and the loader will remove duplicates.
+"Standard Validation" refers to the recommended stack of validation layers that should be used to validate an application's correct use of Vulkan. To enable the standard validation layer, its recommended that you include `include/vulkan/vk_standard_validation.h` which has const vars that contain the standard validation stack. Usage details are included in that header file, with the concept being that you pass the const vars into VkCreateInstanceInfo when creating the VkInstance. This will work across all platforms.
+
+There is also a deprecated meta-layer that works on some loaders. (name = `VK_LAYER_LUNARG_standard_validation`) - specifying this layer name will cause a supporting loader to load the all of the standard validation layers (listed below) in the following optimal order:  `VK_LAYER_GOOGLE_threading`, `VK_LAYER_LUNARG_parameter_validation`, `VK_LAYER_LUNARG_object_tracker`, `VK_LAYER_LUNARG_core_validation`, and `VK_LAYER_GOOGLE_unique_objects`. Other layers can be specified and the loader will remove duplicates.
 
 ### Object Validation and Statistics
 (build dir)/layers/object_tracker.cpp (name=`VK_LAYER_LUNARG_object_tracker`) - Track object creation, use, and destruction. As objects are created they are stored in a map. As objects are used the layer verifies they exist in the map, flagging errors for unknown objects. As objects are destroyed they are removed from the map. At `vkDestroyDevice()` and `vkDestroyInstance()` times, if any objects have not been destroyed they are reported as leaked objects. If a Dbg callback function is registered this layer will use callback function(s) for reporting, otherwise it will use stdout.

--- a/loader/LoaderAndLayerInterface.md
+++ b/loader/LoaderAndLayerInterface.md
@@ -453,12 +453,11 @@ the case.  See the [Overall Layer Ordering](#overall-layer-ordering) section
 for more information.
 
 The following code section shows how you would go about enabling the
-VK_LAYER_LUNARG_standard_validation layer.
+standard validation layer stack.
 
 ```
-   char *instance_validation_layers[] = {
-        "VK_LAYER_LUNARG_standard_validation"
-    };
+    #include <vulkan/vk_standard_validation.h>
+    char *instance_validation_layers[] = standard_validation_array;
     const VkApplicationInfo app = {
         .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
         .pNext = NULL,
@@ -1408,7 +1407,9 @@ other layers (called component layers).
 
 The most common example of a meta-layer is the
 `VK_LAYER_LUNARG_standard_validation` layer which groups all the most common
-individual validation layers into a single layer for ease-of-use.
+individual validation layers into a single layer for ease-of-use. Note that this
+meta-layer has been deprecated in favor of using the `vk_standard_validation.h`
+header which works on all platforms. (see `include/vulkan/vk_standard_validation.h`)
 
 The benefits of a meta-layer are:
  1. You can activate more than one layer using a single layer name by simply

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -38,6 +38,7 @@
 
 #include "icd-spv.h"
 #include "test_common.h"
+#include <vulkan/vk_standard_validation.h>
 #include "vk_layer_config.h"
 #include "vk_format_utils.h"
 #include "vk_validation_error_messages.h"
@@ -447,11 +448,7 @@ class VkLayerTest : public VkRenderFramework {
 
         // Use Threading layer first to protect others from
         // ThreadCommandBufferCollision test
-        m_instance_layer_names.push_back("VK_LAYER_GOOGLE_threading");
-        m_instance_layer_names.push_back("VK_LAYER_LUNARG_parameter_validation");
-        m_instance_layer_names.push_back("VK_LAYER_LUNARG_object_tracker");
-        m_instance_layer_names.push_back("VK_LAYER_LUNARG_core_validation");
-        m_instance_layer_names.push_back("VK_LAYER_GOOGLE_unique_objects");
+        m_instance_layer_names = vkval::standard_validation_vector;
         if (VkTestFramework::m_devsim_layer) {
             if (InstanceLayerSupported("VK_LAYER_LUNARG_device_simulation")) {
                 m_instance_layer_names.push_back("VK_LAYER_LUNARG_device_simulation");

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -23,6 +23,7 @@
 
 #include "vkrenderframework.h"
 #include "vk_format_utils.h"
+#include "vulkan/vk_standard_validation.h"
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 #define GET_DEVICE_PROC_ADDR(dev, entrypoint)                                            \


### PR DESCRIPTION
Initial proposal for vk_standard_validation.h.

The header has a const array with the standard validation stack as well as a vector for use in C++. This updates the demos and tests to use this new method. The documentation is also updates to refer to the vk_standard_validation.h header as the preferred method and is refers to the VK_LAYER_LUNARG_standard_validation as deprecated.
I'm open for discussion on how this is advertised, but just took a first stab as updates that I hope will encourage unification on this new header.
From a technical standpoint, I don't like missing the "vkval" namespace on C, where namespaces aren't available. I tried some struct trick to fake the namespace but couldn't get anything that worked. As it is, I suspect C++ is dominant language for using Vulkan so I can live without the namespace but if anyone has input on this or anything else, let me know.