### PR TITLE
Allow non-unique shader capability mappings

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -15284,6 +15284,89 @@ TEST_F(VkLayerTest, CreateShaderModuleCheckBadCapability) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(VkPositiveLayerTest, CreatePipelineCheckShaderCapabilityExtension1of2) {
+    // This is a positive test, no errors expected
+    // Verifies the ability to deal with a shader that declares a non-unique SPIRV capability ID
+    TEST_DESCRIPTION("Create a shader in which uses a non-unique capability ID extension, 1 of 2");
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
+    if (!DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME)) {
+        printf("             Extension %s not supported, skipping this pass. \n",
+               VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
+        return;
+    }
+    m_device_extension_names.push_back(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    // These tests require that the device support multiViewport
+    if (!m_device->phy().features().multiViewport) {
+        printf("             Device does not support multiViewport, test skipped.\n");
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    // Vertex shader using viewport array capability
+    char const *vsSource =
+        "#version 450\n"
+        "#extension GL_ARB_shader_viewport_layer_array : enable\n"
+        "void main() {\n"
+        "    gl_ViewportIndex = 1;\n"
+        "}\n";
+
+    VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+
+    VkPipelineObj pipe(m_device);
+    pipe.AddDefaultColorAttachment();
+    pipe.AddShader(&vs);
+
+    const VkPipelineLayoutObj pipe_layout(m_device, {});
+
+    m_errorMonitor->ExpectSuccess();
+    pipe.CreateVKPipeline(pipe_layout.handle(), renderPass());
+    m_errorMonitor->VerifyNotFound();
+}
+
+TEST_F(VkPositiveLayerTest, CreatePipelineCheckShaderCapabilityExtension2of2) {
+    // This is a positive test, no errors expected
+    // Verifies the ability to deal with a shader that declares a non-unique SPIRV capability ID
+    TEST_DESCRIPTION("Create a shader in which uses a non-unique capability ID extension, 2 of 2");
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework(myDbgFunc, m_errorMonitor));
+    if (!DeviceExtensionSupported(gpu(), nullptr, VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME)) {
+        printf("             Extension %s not supported, skipping this pass. \n", VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME);
+        return;
+    }
+    m_device_extension_names.push_back(VK_NV_VIEWPORT_ARRAY2_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    // These tests require that the device support multiViewport
+    if (!m_device->phy().features().multiViewport) {
+        printf("             Device does not support multiViewport, test skipped.\n");
+        return;
+    }
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    // Vertex shader using viewport array capability
+    char const *vsSource =
+        "#version 450\n"
+        "#extension GL_ARB_shader_viewport_layer_array : enable\n"
+        "void main() {\n"
+        "    gl_ViewportIndex = 1;\n"
+        "}\n";
+
+    VkShaderObj vs(m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT, this);
+
+    VkPipelineObj pipe(m_device);
+    pipe.AddDefaultColorAttachment();
+    pipe.AddShader(&vs);
+
+    const VkPipelineLayoutObj pipe_layout(m_device, {});
+
+    m_errorMonitor->ExpectSuccess();
+    pipe.CreateVKPipeline(pipe_layout.handle(), renderPass());
+    m_errorMonitor->VerifyNotFound();
+}
+
 TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvided) {
     TEST_DESCRIPTION(
         "Test that an error is produced for a fragment shader input "


### PR DESCRIPTION
The shader capability required-feature/extension checks assumed a unique mapping from any single capability ID to a single feature or extension. SPIRV recently added capability **ShaderViewportIndexLayerEXT** which shares the same ID (5254) as **ShaderViewportIndexLayerNV**, but requires a different extension name (_SPV_EXT_shader_viewport_index_layer_, vs _SPV_NV_viewport_array2_).

This PR modifies capability checks from "must have" to "must have at least one of" logic for cases where there are multiple mappings of capability IDs.  It would be better if we could infer exactly _which one_ of the feature/extensions the shader requires, but that doesn't seem possible to know from the SPIRV binary alone.

Resolves issue #2288.