### PR TITLE
Fix for VS version detection decoding error on international locales (VS 2017)

### DIFF
--- a/scripts/determine_vs_version.py
+++ b/scripts/determine_vs_version.py
@@ -20,6 +20,7 @@
 
 import sys
 import os
+import subprocess
 
 # Following function code snippet was found on StackOverflow (with a change to lower
 # camel-case on the variable names):
@@ -63,7 +64,7 @@ def determine_year(version):
 # it into a format we can use, which is "<version_num> <version_year>".
 if __name__ == '__main__':
     exeName     = 'msbuild.exe'
-    versionCall = exeName + ' /ver'
+    arguments   = '/ver'
 
     # Determine if the executable exists in the path, this is critical.
     #
@@ -75,7 +76,8 @@ if __name__ == '__main__':
         print('00 0000')
         print('Executable ' + exeName + ' not found in PATH!')
     else:
-        sysCallOut = os.popen(versionCall).read()
+        proc = subprocess.Popen([exeName, arguments], stdout=subprocess.PIPE)
+        sysCallOut = proc.stdout.readline().decode('iso-8859-1').rstrip()
         
         version = None
 


### PR DESCRIPTION
With VS 2017 MS decided to change the version output of MSBuild so that it now includes e.g. an Umlaut for the german version:

    Microsoft (R)-Buildmodul, Version 15.5.179.9764 für .NET Framework

This causes the ```determine_vs_version.py``` script to fail with a decoding error (on Python 3.6 at least):

    Traceback (most recent call last):
    File "determine_vs_version.py", line 78, in <module>
        sysCallOut = os.popen(versionCall).read()
    File "C:\Users\Sascha\AppData\Local\Programs\Python\Python36\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 49: character maps to <undefined>

As such no proper VS Version is detected and the scripts relying on this will fail (like ```update_external_sources.bat```).

This PR changes stdout handling of msbuild forcing ```iso-8859-1``` encoding on the output. This works fine for my german locale and as the script only needs to get the version's number part should work on other locales too. It still works fine with a VS 2015 developer prompt where msbuild returns no Umlaut.

Note that I haven't tested this change with Python 2.x, so before merging you may want to check if this doesn't break things with older python versions.