### PR TITLE
icd: Move include to header to fix clang build

### DIFF
--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -820,11 +820,11 @@ class MockICDOutputGenerator(OutputGenerator):
         if self.header:
             write('#include <unordered_map>', file=self.outFile)
             write('#include <mutex>', file=self.outFile)
+            write('#include <string>', file=self.outFile)
             write('#include <cstring>', file=self.outFile)
             write('#include "vulkan/vk_icd.h"', file=self.outFile)
         else:
             write('#include "mock_icd.h"', file=self.outFile)
-            write('#include <string.h>', file=self.outFile)
             write('#include <stdlib.h>', file=self.outFile)
             write('#include <vector>', file=self.outFile)
 


### PR DESCRIPTION
Move include <string> to header file to fix
clang build when using libstdc++.

Fixes #2303

Change-Id: Id2fc97be7cb83fa12ee1495ef57177c0a7dad893