### PR TITLE
Remove APP_MODULES from Android Application.mk file

### DIFF
--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -16,6 +16,5 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_PLATFORM := android-22
 APP_STL := c++_static
-APP_MODULES := layer_utils VkLayer_core_validation VkLayer_parameter_validation VkLayer_object_tracker VkLayer_threading VkLayer_unique_objects VkLayerValidationTests VulkanLayerValidationTests vkjson_info
 NDK_TOOLCHAIN_VERSION := clang
 NDK_MODULE_PATH := .


### PR DESCRIPTION
This option is not required if all components are to be built. Removing this will make VulkanTools trunk merges safer and easier.