### PR TITLE
VS2013 Compatibility Round 2

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -187,7 +187,7 @@ cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DDEMOS_WSI_SELECTION=XLIB
 
 Windows 7+ with additional required software packages:
 
-- Microsoft Visual Studio 2015 Professional.  Note: it is possible that lesser/older versions may work, but that has not been tested.
+- Microsoft Visual Studio 2013 Professional.  Note: it is possible that lesser/older versions may work, but that has not been tested.
 - [CMake](http://www.cmake.org/download/).  Notes:
   - Tell the installer to "Add CMake to the system PATH" environment variable.
 - [Python 3](https://www.python.org/downloads).  Notes:
@@ -202,7 +202,7 @@ Windows 7+ with additional required software packages:
   - Install each a 32-bit and a 64-bit version, as the 64-bit installer does not install the 32-bit libraries and tools.
 - glslang is required for demos and tests.
   - [You can download and configure it (in a peer directory) here](https://github.com/KhronosGroup/glslang/blob/master/README.md)
-  - A windows batch file has been included that will pull and build the correct version.  Run it from Developer Command Prompt for VS2015 like so:
+  - A windows batch file has been included that will pull and build the correct version.  Run it from Developer Command Prompt for VS2013 like so:
     - update\_external\_sources.bat --build-glslang (Note: see **Loader and Validation Layer Dependencies** below for other options)
 
 ## Windows Build - MSVC
@@ -211,7 +211,7 @@ Before building on Windows, you may want to modify the customize section in load
 set the version numbers and build description for your build. Doing so will set the information displayed
 for the Properties->Details tab of the loader vulkan-1.dll file that is built.
 
-Build all Windows targets after installing required software and cloning the Loader and Validation Layer repo as described above by completing the following steps in a "Developer Command Prompt for VS2015" window (Note that the update\_external\_sources script used below builds external tools into predefined locations. See **Loader and Validation Layer Dependencies** for more information and other options):
+Build all Windows targets after installing required software and cloning the Loader and Validation Layer repo as described above by completing the following steps in a "Developer Command Prompt for VS2013" window (Note that the update\_external\_sources script used below builds external tools into predefined locations. See **Loader and Validation Layer Dependencies** for more information and other options):
 ```
 cd Vulkan-LoaderAndValidationLayers  # cd to the root of the cloned git repository
 update_external_sources.bat
@@ -325,7 +325,7 @@ cd build-android
 ndk-build -j $(sysctl -n hw.ncpu)
 ```
 #### Windows
-Follow the setup steps for Windows above, then from Developer Command Prompt for VS2015:
+Follow the setup steps for Windows above, then from Developer Command Prompt for VS2013:
 ```
 cd build-android
 update_external_sources_android.bat

--- a/include/vulkan/vk_sdk_platform.h
+++ b/include/vulkan/vk_sdk_platform.h
@@ -43,4 +43,27 @@
 
 #endif // _WIN32
 
-#endif // VK_SDK_PLATFORM_H
+// Check for noexcept support using clang, with fallback to Windows or GCC version numbers
+#ifndef NOEXCEPT
+#if defined(__clang__)
+#if __has_feature(cxx_noexcept)
+#define HAS_NOEXCEPT
+#endif
+#else
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ * 10 + __GNUC_MINOR__ >= 46
+#define HAS_NOEXCEPT
+#else
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026 && defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS
+#define HAS_NOEXCEPT
+#endif
+#endif
+#endif
+
+#ifdef HAS_NOEXCEPT
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
+#endif
+#endif
+
+#endif  // VK_SDK_PLATFORM_H

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -21,29 +21,6 @@
  * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 
-#ifndef NOEXCEPT
-// Check for noexcept support
-#if defined(__clang__)
-#if __has_feature(cxx_noexcept)
-#define HAS_NOEXCEPT
-#endif
-#else
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ * 10 + __GNUC_MINOR__ >= 46
-#define HAS_NOEXCEPT
-#else
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026 && defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS
-#define HAS_NOEXCEPT
-#endif
-#endif
-#endif
-
-#ifdef HAS_NOEXCEPT
-#define NOEXCEPT noexcept
-#else
-#define NOEXCEPT
-#endif
-#endif
-
 #pragma once
 #include "core_validation_error_enums.h"
 #include "vk_validation_error_messages.h"

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -23,29 +23,6 @@
 #ifndef CORE_VALIDATION_TYPES_H_
 #define CORE_VALIDATION_TYPES_H_
 
-#ifndef NOEXCEPT
-// Check for noexcept support
-#if defined(__clang__)
-#if __has_feature(cxx_noexcept)
-#define HAS_NOEXCEPT
-#endif
-#else
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ * 10 + __GNUC_MINOR__ >= 46
-#define HAS_NOEXCEPT
-#else
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026 && defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS
-#define HAS_NOEXCEPT
-#endif
-#endif
-#endif
-
-#ifdef HAS_NOEXCEPT
-#define NOEXCEPT noexcept
-#else
-#define NOEXCEPT
-#endif
-#endif
-
 #include "vk_safe_struct.h"
 #include "vulkan/vulkan.h"
 #include "vk_validation_error_messages.h"

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -20,29 +20,6 @@
 #ifndef CORE_VALIDATION_DESCRIPTOR_SETS_H_
 #define CORE_VALIDATION_DESCRIPTOR_SETS_H_
 
-// Check for noexcept support
-#ifndef NOEXCEPT
-#if defined(__clang__)
-#if __has_feature(cxx_noexcept)
-#define HAS_NOEXCEPT
-#endif
-#else
-#if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ * 10 + __GNUC_MINOR__ >= 46
-#define HAS_NOEXCEPT
-#else
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026 && defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS
-#define HAS_NOEXCEPT
-#endif
-#endif
-#endif
-
-#ifdef HAS_NOEXCEPT
-#define NOEXCEPT noexcept
-#else
-#define NOEXCEPT
-#endif
-#endif
-
 #include "core_validation_error_enums.h"
 #include "vk_validation_error_messages.h"
 #include "core_validation_types.h"

--- a/tests/test_environment.cpp
+++ b/tests/test_environment.cpp
@@ -25,7 +25,6 @@
  */
 
 #include "test_common.h"
-#include "vktestbinding.h"
 #include "test_environment.h"
 
 #if defined(NDEBUG) && defined(__GNUC__)

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -341,8 +341,12 @@ class VkDescriptorSetLayoutObj : public vk_testing::DescriptorSetLayout {
                              const std::vector<VkDescriptorSetLayoutBinding> &descriptor_set_bindings = {},
                              VkDescriptorSetLayoutCreateFlags flags = 0);
 
-    VkDescriptorSetLayoutObj(VkDescriptorSetLayoutObj &&src) = default;
-    VkDescriptorSetLayoutObj &operator=(VkDescriptorSetLayoutObj &&src) = default;
+    // Move constructor and move assignment operator for Visual Studio 2013
+    VkDescriptorSetLayoutObj(VkDescriptorSetLayoutObj &&src) : DescriptorSetLayout(std::move(src)){};
+    VkDescriptorSetLayoutObj &operator=(VkDescriptorSetLayoutObj &&src) {
+        DescriptorSetLayout::operator=(std::move(src));
+        return *this;
+    }
 };
 
 class VkDescriptorSetObj : public vk_testing::DescriptorPool {
@@ -389,8 +393,12 @@ class VkPipelineLayoutObj : public vk_testing::PipelineLayout {
     VkPipelineLayoutObj(VkDeviceObj *device, const std::vector<const VkDescriptorSetLayoutObj *> &descriptor_layouts = {},
                         const std::vector<VkPushConstantRange> &push_constant_ranges = {});
 
-    VkPipelineLayoutObj(VkPipelineLayoutObj &&src) = default;
-    VkPipelineLayoutObj &operator=(VkPipelineLayoutObj &&src) = default;
+    // Move constructor and move assignment operator for Visual Studio 2013
+    VkPipelineLayoutObj(VkPipelineLayoutObj &&src) : PipelineLayout(std::move(src)) {}
+    VkPipelineLayoutObj &operator=(VkPipelineLayoutObj &&src) {
+        PipelineLayout::operator=(std::move(src));
+        return *this;
+    }
 
     void Reset();
 };

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -19,7 +19,8 @@
  * Author: Tony Barbour <tony@LunarG.com>
  */
 
-#include "vktestbinding.h"
+#include "test_common.h"    // NOEXCEPT macro (must precede vktestbinding.h)
+#include "vktestbinding.h"  // Left for clarity, no harm, already included via test_common.h
 #include <algorithm>
 #include <assert.h>
 #include <iostream>

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -97,8 +97,8 @@ class Handle {
     Handle &operator=(const Handle &) = delete;
 
     // handles can be moved out
-    Handle(Handle &&src) noexcept : handle_{src.handle_} { src.handle_ = {}; }
-    Handle &operator=(Handle &&src) noexcept {
+    Handle(Handle &&src) NOEXCEPT : handle_{src.handle_} { src.handle_ = {}; }
+    Handle &operator=(Handle &&src) NOEXCEPT {
         handle_ = src.handle_;
         src.handle_ = {};
         return *this;
@@ -542,7 +542,7 @@ class Pipeline : public internal::NonDispHandle<VkPipeline> {
 
 class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
    public:
-    PipelineLayout() noexcept : NonDispHandle(){};
+    PipelineLayout() NOEXCEPT : NonDispHandle(){};
     ~PipelineLayout();
 
     PipelineLayout(PipelineLayout &&src) = default;
@@ -566,11 +566,11 @@ class Sampler : public internal::NonDispHandle<VkSampler> {
 
 class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout> {
    public:
-    DescriptorSetLayout() noexcept : NonDispHandle(){};
+    DescriptorSetLayout() NOEXCEPT : NonDispHandle(){};
     ~DescriptorSetLayout();
 
     DescriptorSetLayout(DescriptorSetLayout &&src) = default;
-    DescriptorSetLayout &operator=(DescriptorSetLayout &&src) noexcept {
+    DescriptorSetLayout &operator=(DescriptorSetLayout &&src) NOEXCEPT {
         this->~DescriptorSetLayout();
         this->NonDispHandle::operator=(std::move(src));
         return *this;

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -119,8 +119,16 @@ class NonDispHandle : public Handle<T> {
     explicit NonDispHandle() : Handle<T>(), dev_handle_(VK_NULL_HANDLE) {}
     explicit NonDispHandle(VkDevice dev, T handle) : Handle<T>(handle), dev_handle_(dev) {}
 
-    NonDispHandle(NonDispHandle &&src) = default;
-    NonDispHandle &operator=(NonDispHandle &&src) = default;
+    NonDispHandle(NonDispHandle &&src) : Handle<T>(std::move(src)) {
+        dev_handle_ = src.dev_handle_;
+        src.dev_handle_ = VK_NULL_HANDLE;
+    }
+    NonDispHandle &operator=(NonDispHandle &&src) {
+        Handle<T>::operator=(std::move(src));
+        dev_handle_ = src.dev_handle_;
+        src.dev_handle_ = VK_NULL_HANDLE;
+        return *this;
+    }
 
     const VkDevice &device() const { return dev_handle_; }
 
@@ -545,7 +553,9 @@ class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
     PipelineLayout() NOEXCEPT : NonDispHandle(){};
     ~PipelineLayout();
 
-    PipelineLayout(PipelineLayout &&src) = default;
+    // Move constructor for Visual Studio 2013
+    PipelineLayout(PipelineLayout &&src) : NonDispHandle(std::move(src)){};
+
     PipelineLayout &operator=(PipelineLayout &&src) {
         this->~PipelineLayout();
         this->NonDispHandle::operator=(std::move(src));
@@ -569,7 +579,9 @@ class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout
     DescriptorSetLayout() NOEXCEPT : NonDispHandle(){};
     ~DescriptorSetLayout();
 
-    DescriptorSetLayout(DescriptorSetLayout &&src) = default;
+    // Move constructor for Visual Studio 2013
+    DescriptorSetLayout(DescriptorSetLayout &&src) : NonDispHandle(std::move(src)){};
+
     DescriptorSetLayout &operator=(DescriptorSetLayout &&src) NOEXCEPT {
         this->~DescriptorSetLayout();
         this->NonDispHandle::operator=(std::move(src));

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -28,7 +28,6 @@
 #include "icd-spv.h"
 #include "test_common.h"
 #include "test_environment.h"
-#include "vktestbinding.h"
 
 #include <fstream>
 #include <iostream>

--- a/tests/vktestframeworkandroid.h
+++ b/tests/vktestframeworkandroid.h
@@ -21,7 +21,6 @@
 #define VKTESTFRAMEWORKANDROID_H
 
 #include "test_common.h"
-#include "vktestbinding.h"
 
 #if defined(NDEBUG)
 #define U_ASSERT_ONLY __attribute__((unused))


### PR DESCRIPTION
Restore compatibility with Visual Studio 2013:
- Put noexcept specifier behind a common macro
- Provide move constructors and assignment operators because we cannot rely on the compiler to generate them
- Update BUILD.md to list VS2013 as supported again

TODO:
- Update AppVeyor configuration to run VS2013 -- in progress