### PR TITLE
Fix two test crashes on Windows with mock_icd enabled

### DIFF
--- a/scripts/mock_icd_generator.py
+++ b/scripts/mock_icd_generator.py
@@ -663,6 +663,10 @@ CUSTOM_C_INTERCEPTS = {
     }
     mapped_memory_map.erase(memory);
 ''',
+'vkGetImageSubresourceLayout': '''
+    // Need safe values. Callers are computing memory offsets from pLayout, with no return code to flag failure. 
+    *pLayout = VkSubresourceLayout(); // Default constructor zero values.
+''',
 }
 
 # MockICDGeneratorOptions - subclass of GeneratorOptions.


### PR DESCRIPTION
Calling tests use return values from GetImageSubresourceLayout to
compute offsets in texures.  Zero'd values are safe for this usage and
add minimal overhead to icd.

Change-Id: If52cf240925d2f7a41bb22d87519a918be5eb60a