### PR TITLE
Add device/instance extension lists to extension helper header file

### DIFF
--- a/layers/unique_objects.cpp
+++ b/layers/unique_objects.cpp
@@ -46,6 +46,7 @@
 #include "vk_enum_string_helper.h"
 #include "vk_validation_error_messages.h"
 #include "vk_object_types.h"
+#include "vk_extension_helper.h"
 #include "vulkan/vk_layer.h"
 
 // This intentionally includes a cpp file
@@ -67,7 +68,7 @@ static void InstanceExtensionWhitelist(const VkInstanceCreateInfo *pCreateInfo, 
 
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         // Check for recognized instance extensions
-        if (!white_list(pCreateInfo->ppEnabledExtensionNames[i], kUniqueObjectsSupportedInstanceExtensions)) {
+        if (!white_list(pCreateInfo->ppEnabledExtensionNames[i], kInstanceExtensionNames)) {
             log_msg(instance_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
                     VALIDATION_ERROR_UNDEFINED, "UniqueObjects",
                     "Instance Extension %s is not supported by this layer.  Using this extension may adversely affect "
@@ -83,7 +84,7 @@ static void DeviceExtensionWhitelist(const VkDeviceCreateInfo *pCreateInfo, VkDe
 
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         // Check for recognized device extensions
-        if (!white_list(pCreateInfo->ppEnabledExtensionNames[i], kUniqueObjectsSupportedDeviceExtensions)) {
+        if (!white_list(pCreateInfo->ppEnabledExtensionNames[i], kDeviceExtensionNames)) {
             log_msg(device_data->report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, 0, __LINE__,
                     VALIDATION_ERROR_UNDEFINED, "UniqueObjects",
                     "Device Extension %s is not supported by this layer.  Using this extension may adversely affect "

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -660,6 +660,15 @@ class HelperFileOutputGenerator(OutputGenerator):
             struct += '    }\n'
             struct += '};\n'
             struct += '\n'
+            # Output reference lists of instance/device extension names
+            struct += 'static const char * const k%sExtensionNames = \n' % type
+            for ext_name, ifdef in extension_dict.items():
+                if ifdef is not None:
+                    struct += '#ifdef %s\n' % ifdef
+                struct += '    %s\n' % ext_name
+                if ifdef is not None:
+                    struct += '#endif\n'
+            struct += ';\n\n'
         extension_helper_header += struct
         extension_helper_header += '\n'
         extension_helper_header += '#endif // VK_EXTENSION_HELPER_H_\n'

--- a/scripts/unique_objects_generator.py
+++ b/scripts/unique_objects_generator.py
@@ -245,23 +245,6 @@ class UniqueObjectsOutputGenerator(OutputGenerator):
             else:
                 self.newline()
 
-        # Write out device extension white list
-        self.newline()
-        write('// Layer Device Extension Whitelist', file=self.outFile)
-        write('static const char *kUniqueObjectsSupportedDeviceExtensions =', file=self.outFile)
-        for line in self.device_extensions:
-            write('%s' % line, file=self.outFile)
-        write(';\n', file=self.outFile)
-
-        # Write out instance extension white list
-        self.newline()
-        write('// Layer Instance Extension Whitelist', file=self.outFile)
-        write('static const char *kUniqueObjectsSupportedInstanceExtensions =', file=self.outFile)
-        for line in self.instance_extensions:
-            write('%s' % line, file=self.outFile)
-        write(';\n', file=self.outFile)
-        self.newline()
-
         # Record intercepted procedures
         write('// Map of all APIs to be intercepted by this layer', file=self.outFile)
         write('static const std::unordered_map<std::string, void*> name_to_funcptr_map = {', file=self.outFile)


### PR DESCRIPTION
These were previously generated in unique objects and used for the extension white-list.  The same information will be needed in other layers, so moved this definition to a common header file and updated U-O to use the new definitions.