### PR TITLE
build: Fix application of /bigobj compile flag

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -174,12 +174,11 @@ include_directories(
 )
 
 if (WIN32)
-    set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -D_CRT_SECURE_NO_WARNINGS")
-    set (CMAKE_C_FLAGS_RELEASE   "${CMAKE_C_FLAGS_RELEASE} -D_CRT_SECURE_NO_WARNINGS")
-    set (CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -D_CRT_SECURE_NO_WARNINGS")
-    set (CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -D_CRT_SECURE_NO_WARNINGS")
-    set (CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -D_CRT_SECURE_NO_WARNINGS /bigobj")
-    set (CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} -D_CRT_SECURE_NO_WARNINGS /bigobj")
+    # Applies to all configurations
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
+    set_source_files_properties(core_validation.cpp threading.cpp
+        PROPERTIES COMPILE_FLAGS "/bigobj")
     # Turn off transitional "changed behavior" warning message for Visual Studio versions prior to 2015.
     # The changed behavior is that constructor initializers are now fixed to clear the struct members.
     add_compile_options("$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19>>:/wd4351>")


### PR DESCRIPTION
Fixes #2316
Affects only Windows builds.
Need to compile code that generates large object files
with the /bigobj option in order to avoid exceeding the
default number of sections in an object file.
This change applies the /bigobj compiler option to all
configurations, rather than just Debug.
It also applies it only to selected files, instead of
all the files in the project.
Although /bigobj is now applied to Release builds,
this does not increase build time.