### PR TITLE
loader: Clean up mutexes on destruction

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -92,8 +92,6 @@ uint32_t g_loader_log_msgs = 0;
 loader_platform_thread_mutex loader_lock;
 loader_platform_thread_mutex loader_json_lock;
 
-LOADER_PLATFORM_THREAD_ONCE_DECLARATION(once_init);
-
 void *loader_instance_heap_alloc(const struct loader_instance *instance, size_t size, VkSystemAllocationScope alloc_scope) {
     void *pMemory = NULL;
 #if (DEBUG_DISABLE_APP_ALLOCATORS == 1)
@@ -1922,6 +1920,12 @@ struct loader_manifest_files {
     uint32_t count;
     char **filename_list;
 };
+
+void loader_release() {
+    // release mutexs
+    loader_platform_thread_delete_mutex(&loader_lock);
+    loader_platform_thread_delete_mutex(&loader_json_lock);
+}
 
 // Get next file or dirname given a string list or registry key path
 //
@@ -5885,7 +5889,6 @@ terminator_EnumerateInstanceExtensionProperties(const VkEnumerateInstanceExtensi
     // tls_instance = NULL;
     memset(&local_ext_list, 0, sizeof(local_ext_list));
     memset(&instance_layers, 0, sizeof(instance_layers));
-    // loader_platform_thread_once(&once_init, loader_initialize);
 
     // Get layer libraries if needed
     if (pLayerName && strlen(pLayerName) != 0) {
@@ -5967,8 +5970,6 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_EnumerateInstanceLayerProperties(const
     struct loader_layer_list instance_layer_list;
     tls_instance = NULL;
 
-    loader_platform_thread_once(&once_init, loader_initialize);
-
     uint32_t copy_size;
 
     // Get layer libraries
@@ -5997,3 +5998,26 @@ out:
     loader_delete_layer_properties(NULL, &instance_layer_list);
     return result;
 }
+
+#if defined(_WIN32)
+BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved) {
+    switch (reason) {
+        case DLL_PROCESS_ATTACH:
+            loader_initialize();
+            break;
+        case DLL_PROCESS_DETACH:
+            if (NULL == reserved) {
+                loader_release();
+            }
+            break;
+        default:
+            // Do nothing
+            break;
+    }
+    return TRUE;
+}
+#else
+__attribute__((constructor)) void loader_init_library() { loader_initialize(); }
+
+__attribute__((destructor)) void loader_free_library() { loader_release(); }
+#endif

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -379,7 +379,6 @@ static inline void loader_init_dispatch(void *obj, const void *data) {
 // Global variables used across files
 extern struct loader_struct loader;
 extern THREAD_LOCAL_DECL struct loader_instance *tls_instance;
-extern LOADER_PLATFORM_THREAD_ONCE_DEFINITION(once_init);
 extern loader_platform_thread_mutex loader_lock;
 extern loader_platform_thread_mutex loader_json_lock;
 

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -95,7 +95,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
                                                                                     uint32_t *pPropertyCount,
                                                                                     VkExtensionProperties *pProperties) {
     tls_instance = NULL;
-    loader_platform_thread_once(&once_init, loader_initialize);
 
     // We know we need to call at least the terminator
     VkResult res = VK_SUCCESS;
@@ -183,7 +182,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionPropert
 LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t *pPropertyCount,
                                                                                 VkLayerProperties *pProperties) {
     tls_instance = NULL;
-    loader_platform_thread_once(&once_init, loader_initialize);
 
     // We know we need to call at least the terminator
     VkResult res = VK_SUCCESS;
@@ -274,8 +272,6 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
     VkInstance created_instance = VK_NULL_HANDLE;
     bool loaderLocked = false;
     VkResult res = VK_ERROR_INITIALIZATION_FAILED;
-
-    loader_platform_thread_once(&once_init, loader_initialize);
 
     // Fail if the requested Vulkan apiVersion is > 1.0 since the loader only supports 1.0.
     // Having pCreateInfo == NULL, pCreateInfo->pApplication == NULL, or

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -116,8 +116,6 @@ static inline const char *loader_platform_get_proc_address_error(const char *nam
 // Threads:
 typedef pthread_t loader_platform_thread;
 #define THREAD_LOCAL_DECL __thread
-#define LOADER_PLATFORM_THREAD_ONCE_DECLARATION(var) pthread_once_t var = PTHREAD_ONCE_INIT;
-#define LOADER_PLATFORM_THREAD_ONCE_DEFINITION(var) pthread_once_t var;
 static inline void loader_platform_thread_once(pthread_once_t *ctl, void (*func)(void)) {
     assert(func != NULL);
     assert(ctl != NULL);


### PR DESCRIPTION
When unloading the vulkan loader dynamic library, a couple of mutexes were not getting cleaned up. This PR adds a mechanism to clean them up.

This PR addresses issue #2341.