### PR TITLE
Coupla CMake fixes

### DIFF
--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -101,7 +101,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../loader
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/vulkan
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_PROJECT_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}
     ${CMAKE_BINARY_DIR}
 )
 

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -141,7 +141,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../loader
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/vulkan
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_PROJECT_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}
     ${CMAKE_BINARY_DIR}
 )
 

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_PROJECT_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}
     ${CMAKE_BINARY_DIR}
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,14 +65,15 @@ set(COMMON_CPP
    )
 
 include_directories(
-    "${PROJECT_SOURCE_DIR}/tests"
-    "${PROJECT_SOURCE_DIR}/tests/gtest-1.7.0/include"
-    "${PROJECT_SOURCE_DIR}/icd/common"
-    "${PROJECT_SOURCE_DIR}/layers"
+    ${PROJECT_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}/tests/gtest-1.7.0/include
+    ${PROJECT_SOURCE_DIR}/icd/common
+    ${PROJECT_SOURCE_DIR}/layers
     ${GLSLANG_SPIRV_INCLUDE_DIR}
     ${LIBGLM_INCLUDE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}
     )
 
 if (NOT WIN32)

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -61,6 +61,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../../loader
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include/vulkan
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}
     ${CMAKE_BINARY_DIR}
 )
 


### PR DESCRIPTION
Removed some nonsense CMAKE variables, and added a required include variable to support building as a submodule.