### PR TITLE
Fix glslang validator cmake hint path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ else()
 endif()
 
 find_program(GLSLANG_VALIDATOR NAMES glslangValidator
-             HINTS "${CMAKE_SOURCE_DIR}/external/glslang/${BUILDTGT_DIR}/install/bin"
+             HINTS "${EXTERNAL_SOURCE_ROOT}/glslang/${BUILDTGT_DIR}/install/bin"
                    "${GLSLANG_BINARY_ROOT}/StandAlone"
                    "${PROJECT_SOURCE_DIR}/external/${BINDATA_DIR}")
 


### PR DESCRIPTION
Some CI systems were insisting this was a good idea.