### PR TITLE
Move LVL temporary & worker MSVC cmake targets into solution explorer subfolder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ if (USE_CCACHE)
     endif(CCACHE_FOUND)
 endif()
 
+# Enable cmake folders
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set(LVL_TARGET_FOLDER lvl_cmake_targets)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(FALLBACK_CONFIG_DIRS "/etc/xdg" CACHE STRING
         "Search path to use when XDG_CONFIG_DIRS is unset or empty or the current process is SUID/SGID. Default is freedesktop compliant.")
@@ -337,6 +341,7 @@ add_custom_target(generate_helper_files DEPENDS
     vk_typemap_helper.h
     spirv_tools_commit_id.h
     )
+set_target_properties(generate_helper_files PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
 
 # Rules to build generated helper files
 run_vk_xml_generate(loader_extension_generator.py vk_layer_dispatch_table.h)

--- a/icd/CMakeLists.txt
+++ b/icd/CMakeLists.txt
@@ -37,6 +37,7 @@ if (WIN32)
                     COMMAND copy ${src_json} ${dst_json}
                     VERBATIM
                     )
+                set_target_properties(${config_file}-json PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
             endforeach(config_file)
         else()
             foreach (config_file ${ICD_JSON_FILES})
@@ -71,6 +72,7 @@ add_custom_target(generate_icd_files DEPENDS
     mock_icd.h
     mock_icd.cpp
     )
+set_target_properties(generate_icd_files PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
 
 if (WIN32)
     macro(add_vk_icd target)
@@ -79,6 +81,7 @@ if (WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DEF_FILE} VkICD_${target}.def
         VERBATIM
     )
+    set_target_properties(copy-${target}-def-file PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
     add_library(VkICD_${target} SHARED ${ARGN} VkICD_${target}.def)
     add_dependencies(VkICD_${target} generate_icd_files)
     #target_link_Libraries(VkICD_${target} VkICD_utils)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -48,6 +48,7 @@ if (WIN32)
                     COMMAND copy ${src_json} ${dst_json}
                     VERBATIM
                     )
+                set_target_properties(${config_file}-json PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
             endforeach(config_file)
         else()
             foreach (config_file ${LAYER_JSON_FILES})
@@ -67,6 +68,7 @@ if (WIN32)
             COMMAND copy ${src_val_msgs} ${dst_val_msgs}
             VERBATIM
             )
+        set_target_properties(vk_validation_error_messages PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
     endif()
 else()
     # extra setup for out-of-tree builds
@@ -119,6 +121,7 @@ if (WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DEF_FILE} VkLayer_${target}.def
         VERBATIM
     )
+    set_target_properties(copy-${target}-def-file PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
     add_library(VkLayer_${target} SHARED ${ARGN} VkLayer_${target}.def)
     add_dependencies(VkLayer_${target} generate_helper_files)
     target_link_Libraries(VkLayer_${target} VkLayer_utils)

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -104,6 +104,7 @@ if (WIN32)
         add_dependencies(asm_offset generate_helper_files loader_gen_files)
         add_custom_command(OUTPUT gen_defines.asm DEPENDS asm_offset COMMAND asm_offset MASM)
         add_custom_target(loader_asm_gen_files DEPENDS gen_defines.asm)
+        set_target_properties(loader_asm_gen_files PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
     else()
         message(WARNING "Could not find working MASM assebler\n${ASM_FAILURE_MSG}")
         set(OPT_LOADER_SRCS ${OPT_LOADER_SRCS} unknown_ext_chain.c)
@@ -137,6 +138,7 @@ add_custom_target(loader_gen_files DEPENDS
         vk_loader_extensions.h
         vk_loader_extensions.c
     )
+set_target_properties(loader_gen_files PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
 
 if (WIN32)
     # Use static MSVCRT libraries

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,7 @@ else()
             COMMAND ${CMAKE_COMMAND} -E copy_if_different ${VALIDATE_DOC} vkvalidatelayerdoc.ps1
             VERBATIM
             )
+        set_target_properties(binary-dir-symlinks PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
     endif()
 endif()
 

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -22,7 +22,8 @@ if (WIN32)
                 COMMAND copy ${src_json} ${dst_json}
                 VERBATIM
                 )
-                add_dependencies(${config_file}-json ${config_file})
+            add_dependencies(${config_file}-json ${config_file})
+            set_target_properties(${config_file}-json PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
         endforeach(config_file)
     endif()
 else()
@@ -44,6 +45,7 @@ if (WIN32)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${DEF_FILE} VkLayer_${target}.def
         VERBATIM
     )
+    set_target_properties(copy-${target}-def-file PROPERTIES FOLDER ${LVL_TARGET_FOLDER})
     add_library(VkLayer_${target} SHARED ${ARGN} VkLayer_${target}.def)
     add_dependencies(VkLayer_${target} generate_helper_files VkLayer_utils)
     endmacro()


### PR DESCRIPTION
This sets up cmake to locate the temporary or worker MSVC projects into a subfolder called lvl_cmake_targets. This simply unclutters tte Visual Studio Solution Explorer projects pane, and does not affect functionality.

For example, all of the solution explorer projects such as *-def-file, *-json, and the file generator targets will show up in the lvl_cmake_targets folder.