### PR TITLE
Add LAYER_EXPORT specifiers to vk_layer_config

### DIFF
--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -69,11 +69,11 @@ std::string getEnvironment(const char *variable) {
 #endif
 }
 
-const char *getLayerOption(const char *_option) { return g_configFileObj.getOption(_option); }
+VK_LAYER_EXPORT const char *getLayerOption(const char *_option) { return g_configFileObj.getOption(_option); }
 
 // If option is NULL or stdout, return stdout, otherwise try to open option
 // as a filename. If successful, return file handle, otherwise stdout
-FILE *getLayerLogOutput(const char *_option, const char *layerName) {
+VK_LAYER_EXPORT FILE *getLayerLogOutput(const char *_option, const char *layerName) {
     FILE *log_output = NULL;
     if (!_option || !strcmp("stdout", _option))
         log_output = stdout;
@@ -92,8 +92,8 @@ FILE *getLayerLogOutput(const char *_option, const char *layerName) {
 }
 
 // Map option strings to flag enum values
-VkFlags GetLayerOptionFlags(std::string _option, std::unordered_map<std::string, VkFlags> const &enum_data,
-                            uint32_t option_default) {
+VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(std::string _option, std::unordered_map<std::string, VkFlags> const &enum_data,
+                                            uint32_t option_default) {
     VkDebugReportFlagsEXT flags = option_default;
     std::string option_list = g_configFileObj.getOption(_option.c_str());
 
@@ -128,7 +128,7 @@ VkFlags GetLayerOptionFlags(std::string _option, std::unordered_map<std::string,
     return flags;
 }
 
-void setLayerOption(const char *_option, const char *_val) { g_configFileObj.setOption(_option, _val); }
+VK_LAYER_EXPORT void setLayerOption(const char *_option, const char *_val) { g_configFileObj.setOption(_option, _val); }
 
 // Constructor for ConfigFile. Initialize layers to log error messages to stdout by default. If a vk_layer_settings file is present,
 // its settings will override the defaults.
@@ -244,7 +244,7 @@ void ConfigFile::parseFile(const char *filename) {
     }
 }
 
-void print_msg_flags(VkFlags msgFlags, char *msg_flags) {
+VK_LAYER_EXPORT void print_msg_flags(VkFlags msgFlags, char *msg_flags) {
     bool separator = false;
 
     msg_flags[0] = 0;

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -57,13 +57,13 @@ const std::unordered_map<std::string, VkFlags> report_flags_option_definitions =
     {std::string("error"), VK_DEBUG_REPORT_ERROR_BIT_EXT},
     {std::string("debug"), VK_DEBUG_REPORT_DEBUG_BIT_EXT}};
 
-const char *getLayerOption(const char *_option);
-FILE *getLayerLogOutput(const char *_option, const char *layerName);
-VkFlags GetLayerOptionFlags(std::string _option, std::unordered_map<std::string, VkFlags> const &enum_data,
-                            uint32_t option_default);
+VK_LAYER_EXPORT const char *getLayerOption(const char *_option);
+VK_LAYER_EXPORT FILE *getLayerLogOutput(const char *_option, const char *layerName);
+VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(std::string _option, std::unordered_map<std::string, VkFlags> const &enum_data,
+                                            uint32_t option_default);
 
-void setLayerOption(const char *_option, const char *_val);
-void print_msg_flags(VkFlags msgFlags, char *msg_flags);
+VK_LAYER_EXPORT void setLayerOption(const char *_option, const char *_val);
+VK_LAYER_EXPORT void print_msg_flags(VkFlags msgFlags, char *msg_flags);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Required for hassle-free linking to layer_utils lib.