### PR TITLE
Fix issue #2346

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,10 @@ endmacro()
 # Define macro used for generating header files containing commit IDs for external dependencies
 macro(run_external_revision_generate source_dir symbol_name output)
     add_custom_command(OUTPUT ${output}
-    COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/external_revision_generator.py ${source_dir} ${symbol_name} ${output}
+    # NOTE: If you modify this call to use --rev_file instead of --git_dir (to read the commit ID from a file instead of
+    # parsing from a Git repository), you probably also want to add the revision file to the list of DEPENDS on the
+    # subsequent line (to ensure that the script is re-run when the revision file is modified).
+    COMMAND ${PYTHON_CMD} ${SCRIPTS_DIR}/external_revision_generator.py --git_dir ${source_dir} -s ${symbol_name} -o ${output}
     DEPENDS ${SCRIPTS_DIR}/external_revision_generator.py ${source_dir}/.git/HEAD ${source_dir}/.git/index
     )
 endmacro()

--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -34,6 +34,6 @@ py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_layer_d
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_extension_helper.h
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml object_tracker.cpp
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_typemap_helper.h
-py -3 ../../../scripts/external_revision_generator.py ../../third_party/shaderc/third_party/spirv-tools SPIRV_TOOLS_COMMIT_ID spirv_tools_commit_id.h
+py -3 ../../../scripts/external_revision_generator.py --git_dir ../../third_party/shaderc/third_party/spirv-tools -s SPIRV_TOOLS_COMMIT_ID -o spirv_tools_commit_id.h
 cd ../..
 

--- a/build-android/android-generate.bat
+++ b/build-android/android-generate.bat
@@ -34,6 +34,33 @@ py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_layer_d
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_extension_helper.h
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml object_tracker.cpp
 py -3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_typemap_helper.h
-py -3 ../../../scripts/external_revision_generator.py --git_dir ../../third_party/shaderc/third_party/spirv-tools -s SPIRV_TOOLS_COMMIT_ID -o spirv_tools_commit_id.h
+
+set SPIRV_TOOLS_PATH=../../third_party/shaderc/third_party/spirv-tools
+set SPIRV_TOOLS_UUID=spirv_tools_uuid.txt
+
+if exist %SPIRV_TOOLS_PATH% (
+
+  echo Found spirv-tools, using git_dir for external_revision_generator.py
+  py -3 ../../../scripts/external_revision_generator.py ^
+    --git_dir %SPIRV_TOOLS_PATH% ^
+    -s SPIRV_TOOLS_COMMIT_ID ^
+    -o spirv_tools_commit_id.h
+
+) else (
+
+  echo No spirv-tools git_dir found, generating UUID for external_revision_generator.py
+
+  REM Ensure uuidgen is installed, this should error if not found
+  uuidgen.exe -v
+
+  uuidgen.exe > %SPIRV_TOOLS_UUID%
+  type %SPIRV_TOOLS_UUID%
+  py -3 ../../../scripts/external_revision_generator.py ^
+    --rev_file %SPIRV_TOOLS_UUID% ^
+    -s SPIRV_TOOLS_COMMIT_ID ^
+    -o spirv_tools_commit_id.h
+
+)
+
 cd ../..
 

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -37,6 +37,6 @@ mkdir -p generated/include generated/common
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_extension_helper.h )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml object_tracker.cpp )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_typemap_helper.h )
-( cd generated/include; python3 ../../../scripts/external_revision_generator.py ../../third_party/shaderc/third_party/spirv-tools SPIRV_TOOLS_COMMIT_ID spirv_tools_commit_id.h )
+( cd generated/include; python3 ../../../scripts/external_revision_generator.py --git_dir ../../third_party/shaderc/third_party/spirv-tools -s SPIRV_TOOLS_COMMIT_ID -o spirv_tools_commit_id.h )
 
 exit 0

--- a/build-android/android-generate.sh
+++ b/build-android/android-generate.sh
@@ -37,6 +37,39 @@ mkdir -p generated/include generated/common
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_extension_helper.h )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml object_tracker.cpp )
 ( cd generated/include; python3 ../../../scripts/lvl_genvk.py -registry ../../../scripts/vk.xml vk_typemap_helper.h )
-( cd generated/include; python3 ../../../scripts/external_revision_generator.py --git_dir ../../third_party/shaderc/third_party/spirv-tools -s SPIRV_TOOLS_COMMIT_ID -o spirv_tools_commit_id.h )
+
+SPIRV_TOOLS_PATH=../../third_party/shaderc/third_party/spirv-tools
+SPIRV_TOOLS_UUID=spirv_tools_uuid.txt
+
+set -e
+
+( cd generated/include;
+
+  if [[ -d $SPIRV_TOOLS_PATH ]]; then
+
+    echo Found spirv-tools, using git_dir for external_revision_generator.py
+
+    python3 ../../../scripts/external_revision_generator.py \
+      --git_dir $SPIRV_TOOLS_PATH \
+      -s SPIRV_TOOLS_COMMIT_ID \
+      -o spirv_tools_commit_id.h
+
+  else
+
+    echo No spirv-tools git_dir found, generating UUID for external_revision_generator.py
+
+    # Ensure uuidgen is installed, this should error if not found
+    uuidgen --v
+
+    uuidgen > $SPIRV_TOOLS_UUID;
+    cat $SPIRV_TOOLS_UUID;
+    python3 ../../../scripts/external_revision_generator.py \
+      --rev_file $SPIRV_TOOLS_UUID \
+      -s SPIRV_TOOLS_COMMIT_ID \
+      -o spirv_tools_commit_id.h
+
+  fi
+)
+
 
 exit 0

--- a/scripts/external_revision_generator.py
+++ b/scripts/external_revision_generator.py
@@ -18,14 +18,13 @@
 # limitations under the License.
 #
 # Author: Cort Stratton <cort@google.com>
+# Author: Jean-Francois Roy <jfroy@google.com>
 
-import os
+import argparse
+import hashlib
 import subprocess
-import sys
 
-def generate(git_binary):
-    commit_id = subprocess.check_output([git_binary, "rev-parse", "HEAD"], cwd=source_dir).decode('utf-8').strip()
-
+def generate(symbol_name, commit_id, output_header_file):
     # Write commit ID to output header file
     with open(output_header_file, "w") as header_file:
          # File Comment
@@ -64,18 +63,52 @@ def generate(git_binary):
         contents += '#define %s "%s"\n' % (symbol_name, commit_id)
         header_file.write(contents)
 
+def get_commit_id_from_git(git_binary, source_dir):
+    return subprocess.check_output([git_binary, "rev-parse", "HEAD"], cwd=source_dir).decode('utf-8').strip()
+
+def is_sha1(str):
+    try: str_as_int = int(str, 16)
+    except ValueError: return False
+    return len(str) == 40
+    
+def get_commit_id_from_file(rev_file):
+    with open(rev_file, 'r') as rev_stream:
+        rev_contents = rev_stream.read()
+        rev_contents_stripped = rev_contents.strip()
+        if is_sha1(rev_contents_stripped):
+            return rev_contents_stripped;
+        # otherwise, SHA1 the entire (unstripped) file contents
+        sha1 = hashlib.sha1();
+        sha1.update(rev_contents.encode('utf-8'))
+        return sha1.hexdigest()
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--symbol_name", metavar="SYMBOL_NAME", required=True, help="C symbol name")
+    parser.add_argument("-o", "--output_header_file", metavar="OUTPUT_HEADER_FILE", required=True, help="output header file path")
+    rev_method_group = parser.add_mutually_exclusive_group(required=True)
+    rev_method_group.add_argument("--git_dir", metavar="SOURCE_DIR", help="git working copy directory")
+    rev_method_group.add_argument("--rev_file", metavar="REVISION_FILE", help="source revision file path (must contain a SHA1 hash")
+    args = parser.parse_args()
+    
+    # We can either parse the latest Git commit ID out of the specified repository (preferred where possible),
+    # or computing the SHA1 hash of the contents of a file passed on the command line and (where necessary --
+    # e.g. when building the layers outside of a Git environment).
+    if args.git_dir is not None:
+        # Extract commit ID from the specified source directory
+        try:
+            commit_id = get_commit_id_from_git('git', args.git_dir)
+        except WindowsError:
+            # Call git.bat on Windows for compatiblity.
+            commit_id = get_commit_id_from_git('git.bat', args.git_dir)
+    elif args.rev_file is not None:
+        # Read the commit ID from a file.
+        commit_id = get_commit_id_from_file(args.rev_file)
+    
+    if not is_sha1(commit_id):
+        raise ValueError("commit ID for " + args.symbol_name + " must be a SHA1 hash.")
+    
+    generate(args.symbol_name, commit_id, args.output_header_file)
+
 if __name__ == '__main__':
-    if (len(sys.argv) != 4):
-        print("Usage: %s <SOURCE_DIR> <SYMBOL_NAME> <OUTPUT_HEADER_FILE>" % sys.argv[0])
-        sys.exit(os.EX_USAGE)
-    
-    source_dir = sys.argv[1]
-    symbol_name = sys.argv[2]
-    output_header_file = sys.argv[3]
-    
-    # Extract commit ID from the specified source directory
-    try:
-        generate('git')
-    except WindowsError:
-        # Call git.bat on Windows for compatiblity.
-        generate('git.bat')
+    main()


### PR DESCRIPTION
Chris/Cody: I haven't run these through the build farm yet (will try that tomorrow), but please take a look anyway to ensure you're okay with the general direction.

One potential improvement that occurs to me as I type this just now: the validation cache code ultimately wants a UUID for its cache ID. `external_revision_generator.py` currently takes either a SHA1 Git commit ID or the contents of an arbitrary revision file (converted to a SHA1 hash if necessary), and writes the hash to the header file (which is converted back to a UUID at runtime by the layers). Perhaps the script should just convert its input to a UUID immediately, and write _that_ to the header file (so validation cache runtime code can ingest it directly). What do you think -- useful simplification, or overthinking?