### PR TITLE
loader: Fix loader skipping layer files

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -3630,7 +3630,8 @@ void loader_layer_scan(const struct loader_instance *inst, struct loader_layer_l
             VkResult local_res = loader_add_layer_properties(inst, instance_layers, json, (implicit == 1), file_str);
             cJSON_Delete(json);
 
-            if (VK_SUCCESS != local_res) {
+            // If the error is anything other than out of memory we still want to try to load the other layers
+            if (VK_ERROR_OUT_OF_HOST_MEMORY == local_res) {
                 goto out;
             }
         }


### PR DESCRIPTION
Fix a bug where having a json file in the layer path that isn't a valid layer would cause the other valid layers to be skipped. This fixes #2403. 
