### PR TITLE
loader: Fix swapchain bug

### DIFF
--- a/loader/loader.h
+++ b/loader/loader.h
@@ -278,6 +278,7 @@ struct loader_instance {
 
     VkAllocationCallbacks alloc_callbacks;
 
+    bool swapchain_enabled;
     bool wsi_surface_enabled;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     bool wsi_win32_surface_enabled;

--- a/loader/wsi.c
+++ b/loader/wsi.c
@@ -35,6 +35,7 @@
 #define ICD_VER_SUPPORTS_ICD_SURFACE_KHR 3
 
 void wsi_create_instance(struct loader_instance *ptr_instance, const VkInstanceCreateInfo *pCreateInfo) {
+    ptr_instance->swapchain_enabled = false;
     ptr_instance->wsi_surface_enabled = false;
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
@@ -59,6 +60,10 @@ void wsi_create_instance(struct loader_instance *ptr_instance, const VkInstanceC
     ptr_instance->wsi_display_enabled = false;
 
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
+        if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SWAPCHAIN_EXTENSION_NAME) == 0) {
+            ptr_instance->swapchain_enabled = true;
+            continue;
+        }
         if (strcmp(pCreateInfo->ppEnabledExtensionNames[i], VK_KHR_SURFACE_EXTENSION_NAME) == 0) {
             ptr_instance->wsi_surface_enabled = true;
             continue;
@@ -1418,23 +1423,23 @@ bool wsi_swapchain_instance_gpa(struct loader_instance *ptr_instance, const char
     // function will return the trampoline function for such device-extension
     // functions, regardless of whether the extension has been enabled.
     if (!strcmp("vkCreateSwapchainKHR", name)) {
-        *addr = (void *)vkCreateSwapchainKHR;
+        *addr = ptr_instance->swapchain_enabled ? (void *)vkCreateSwapchainKHR : NULL;
         return true;
     }
     if (!strcmp("vkDestroySwapchainKHR", name)) {
-        *addr = (void *)vkDestroySwapchainKHR;
+        *addr = ptr_instance->swapchain_enabled ? (void *)vkDestroySwapchainKHR : NULL;
         return true;
     }
     if (!strcmp("vkGetSwapchainImagesKHR", name)) {
-        *addr = (void *)vkGetSwapchainImagesKHR;
+        *addr = ptr_instance->swapchain_enabled ? (void *)vkGetSwapchainImagesKHR : NULL;
         return true;
     }
     if (!strcmp("vkAcquireNextImageKHR", name)) {
-        *addr = (void *)vkAcquireNextImageKHR;
+        *addr = ptr_instance->swapchain_enabled ? (void *)vkAcquireNextImageKHR : NULL;
         return true;
     }
     if (!strcmp("vkQueuePresentKHR", name)) {
-        *addr = (void *)vkQueuePresentKHR;
+        *addr = ptr_instance->swapchain_enabled ? (void *)vkQueuePresentKHR : NULL;
         return true;
     }
 


### PR DESCRIPTION
Fix a loader bug related to the proper behavior of
vkGetInstanceProcAddr on the VK_KHR_swapchain entry-points.

Thanks to Piers (@pdaniell-nv) for catching this.

Change-Id: Iaa2d2a1ab11e89b53052a5effa8fa8e92905bda8