### PR TITLE
Adds push constant range and "compatible for set N" logic to pipeline layout compatibility validation and recording

### DIFF
--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -551,10 +551,10 @@ using PushConstantRangesId = PushConstantRangesDict::Id;
 // Canonical dictionary for the pipeline layout's layout of descriptorsetlayouts
 using DescriptorSetLayoutDef = cvdescriptorset::DescriptorSetLayoutDef;
 using DescriptorSetLayoutId = std::shared_ptr<const DescriptorSetLayoutDef>;
-using DescriptorSetLayoutLayoutDef = std::vector<DescriptorSetLayoutId>;
-using DescriptorSetLayoutLayoutDict =
-    hash_util::Dictionary<DescriptorSetLayoutLayoutDef, hash_util::IsOrderedContainer<DescriptorSetLayoutLayoutDef>>;
-using DescriptorSetLayoutLayoutId = DescriptorSetLayoutLayoutDict::Id;
+using PipelineLayoutSetLayoutsDef = std::vector<DescriptorSetLayoutId>;
+using PipelineLayoutSetLayoutsDict =
+    hash_util::Dictionary<PipelineLayoutSetLayoutsDef, hash_util::IsOrderedContainer<PipelineLayoutSetLayoutsDef>>;
+using PipelineLayoutSetLayoutsId = PipelineLayoutSetLayoutsDict::Id;
 
 // Defines/stores a compatibility defintion for set N
 // The "layout layout" must store at least set+1 entries, but only the first set+1 are considered for hash and equality testing
@@ -563,10 +563,9 @@ using DescriptorSetLayoutLayoutId = DescriptorSetLayoutLayoutDict::Id;
 struct PipelineLayoutCompatDef {
     uint32_t set;
     PushConstantRangesId push_constant_ranges;
-    using LayoutLayout = DescriptorSetLayoutLayoutId;
-    LayoutLayout layout_id;
-    PipelineLayoutCompatDef(const uint32_t set_index, const PushConstantRangesId pcr_id, const LayoutLayout ll_id)
-        : set(set_index), push_constant_ranges(pcr_id), layout_id(ll_id) {}
+    PipelineLayoutSetLayoutsId set_layouts_id;
+    PipelineLayoutCompatDef(const uint32_t set_index, const PushConstantRangesId pcr_id, const PipelineLayoutSetLayoutsId sl_id)
+        : set(set_index), push_constant_ranges(pcr_id), set_layouts_id(sl_id) {}
     size_t hash() const;
     bool operator==(const PipelineLayoutCompatDef &other) const;
 };

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -686,17 +686,18 @@ class PIPELINE_STATE : public BASE_NODE {
 // Track last states that are bound per pipeline bind point (Gfx & Compute)
 struct LAST_BOUND_STATE {
     PIPELINE_STATE *pipeline_state;
-    PIPELINE_LAYOUT_NODE pipeline_layout;
+    VkPipelineLayout pipeline_layout;
     // Track each set that has been bound
     // Ordered bound set tracking where index is set# that given set is bound to
     std::vector<cvdescriptorset::DescriptorSet *> boundDescriptorSets;
     std::unique_ptr<cvdescriptorset::DescriptorSet> push_descriptor_set;
     // one dynamic offset per dynamic descriptor bound to this CB
     std::vector<std::vector<uint32_t>> dynamicOffsets;
+    std::vector<PipelineLayoutCompatId> compat_id_for_set;
 
     void reset() {
         pipeline_state = nullptr;
-        pipeline_layout.reset();
+        pipeline_layout = VK_NULL_HANDLE;
         boundDescriptorSets.clear();
         push_descriptor_set = nullptr;
         dynamicOffsets.clear();

--- a/layers/core_validation_types.h
+++ b/layers/core_validation_types.h
@@ -23,6 +23,7 @@
 #ifndef CORE_VALIDATION_TYPES_H_
 #define CORE_VALIDATION_TYPES_H_
 
+#include "hash_vk_types.h"
 #include "vk_safe_struct.h"
 #include "vulkan/vulkan.h"
 #include "vk_validation_error_messages.h"
@@ -542,18 +543,21 @@ struct hash<ImageSubresourcePair> {
 };
 }  // namespace std
 
+// The id defines a unique ID based on the contents of a PushConstantRanges set;
+using PushConstantRangesId = std::shared_ptr<PushConstantRanges>;
+
 // Store layouts and pushconstants for PipelineLayout
 struct PIPELINE_LAYOUT_NODE {
     VkPipelineLayout layout;
     std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>> set_layouts;
-    std::vector<VkPushConstantRange> push_constant_ranges;
+    PushConstantRangesId push_constant_ranges;
 
     PIPELINE_LAYOUT_NODE() : layout(VK_NULL_HANDLE), set_layouts{}, push_constant_ranges{} {}
 
     void reset() {
         layout = VK_NULL_HANDLE;
         set_layouts.clear();
-        push_constant_ranges.clear();
+        push_constant_ranges.reset();
     }
 };
 

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -23,6 +23,7 @@
 #define NOMINMAX
 
 #include "descriptor_sets.h"
+#include "hash_vk_types.h"
 #include "vk_enum_string_helper.h"
 #include "vk_safe_struct.h"
 #include "buffer_validation.h"
@@ -36,6 +37,31 @@ struct BindingNumCmp {
     }
 };
 
+using DescriptorSetLayoutDef = cvdescriptorset::DescriptorSetLayoutDef;
+using DescriptorSetLayoutId = cvdescriptorset::DescriptorSetLayoutId;
+
+namespace std {
+template <>
+struct hash<DescriptorSetLayoutDef> : public hash_util::HasHashMember<DescriptorSetLayoutDef> {};
+}  // namespace std
+
+// Note: std::equal_to is looking for operator == to be defined in the innermost namespace enclosing DescriptorSetLayoutDef
+//       (i.e. cvdescriptorset) or in the class, base, or containing classes, and does *not* look in :: for it.
+static std::unordered_map<DescriptorSetLayoutDef, DescriptorSetLayoutId, std::hash<DescriptorSetLayoutDef>,
+                          std::equal_to<DescriptorSetLayoutDef>>
+    descriptor_set_layout_dict;
+
+DescriptorSetLayoutId get_definition_id(const VkDescriptorSetLayoutCreateInfo *p_create_info) {
+    DescriptorSetLayoutId from_input = std::make_shared<DescriptorSetLayoutDef>(p_create_info);
+
+    // Insert takes care of the "unique" id part by rejecting the insert if a key matching the DSL def exists, but returning us
+    // the entry with the extant shared_pointer(id->def) instead.
+    auto insert_pair = descriptor_set_layout_dict.insert({*from_input, from_input});
+
+    // This *awful* syntax takes the Iterator from the <It, bool> pair returned by insert, and extracts the value from the
+    // <key, value> pair of the Iterator
+    return insert_pair.first->second;
+}
 // Construct DescriptorSetLayout instance from given create info
 // Proactively reserve and resize as possible, as the reallocation was visible in profiling
 cvdescriptorset::DescriptorSetLayoutDef::DescriptorSetLayoutDef(const VkDescriptorSetLayoutCreateInfo *p_create_info)
@@ -100,6 +126,14 @@ cvdescriptorset::DescriptorSetLayoutDef::DescriptorSetLayoutDef(const VkDescript
         dyn_array_idx += bc_pair.second;
     }
 }
+
+size_t cvdescriptorset::DescriptorSetLayoutDef::hash() const {
+    hash_util::HashCombiner hc;
+    hc << flags_;
+    hc.Combine(bindings_);
+    return hc.Value();
+}
+//
 
 // Return valid index or "end" i.e. binding_count_;
 // The asserts in "Get" are reduced to the set where no valid answer(like null or 0) could be given
@@ -190,8 +224,12 @@ bool cvdescriptorset::DescriptorSetLayout::IsCompatible(DescriptorSetLayout cons
                                                         std::string *error_msg) const {
     // Trivial case
     if (layout_ == rh_ds_layout->GetDescriptorSetLayout()) return true;
-    return get_layout_def()->IsCompatible(layout_, rh_ds_layout->GetDescriptorSetLayout(), rh_ds_layout->get_layout_def(),
-                                          error_msg);
+    if (get_layout_def() == rh_ds_layout->get_layout_def()) return true;
+    bool detailed_compat_check =
+        get_layout_def()->IsCompatible(layout_, rh_ds_layout->GetDescriptorSetLayout(), rh_ds_layout->get_layout_def(), error_msg);
+    // The detailed check should never tell us mismatching DSL are compatible
+    assert(!detailed_compat_check);
+    return detailed_compat_check;
 }
 
 bool cvdescriptorset::DescriptorSetLayoutDef::IsCompatible(VkDescriptorSetLayout ds_layout, VkDescriptorSetLayout rh_ds_layout,
@@ -205,6 +243,7 @@ bool cvdescriptorset::DescriptorSetLayoutDef::IsCompatible(VkDescriptorSetLayout
         *error_msg = error_str.str();
         return false;  // trivial fail case
     }
+
     // Descriptor counts match so need to go through bindings one-by-one
     //  and verify that type and stageFlags match
     for (auto binding : bindings_) {
@@ -299,7 +338,7 @@ bool cvdescriptorset::DescriptorSetLayoutDef::VerifyUpdateConsistency(uint32_t c
 // handle invariant portion
 cvdescriptorset::DescriptorSetLayout::DescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo *p_create_info,
                                                           const VkDescriptorSetLayout layout)
-    : layout_(layout), layout_destroyed_(false), layout_id_(std::make_shared<DescriptorSetLayoutDef>(p_create_info)) {}
+    : layout_(layout), layout_destroyed_(false), layout_id_(get_definition_id(p_create_info)) {}
 
 // Validate descriptor set layout create info
 bool cvdescriptorset::DescriptorSetLayout::ValidateCreateInfo(const debug_report_data *report_data,

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -217,6 +217,8 @@ bool cvdescriptorset::DescriptorSetLayout::IsCompatible(DescriptorSetLayout cons
     return detailed_compat_check;
 }
 
+// Do a detailed compatibility check of this def (referenced by ds_layout), vs. the rhs (layout and def)
+// Should only be called if trivial accept has failed, and in that context should return false.
 bool cvdescriptorset::DescriptorSetLayoutDef::IsCompatible(VkDescriptorSetLayout ds_layout, VkDescriptorSetLayout rh_ds_layout,
                                                            DescriptorSetLayoutDef const *const rh_ds_layout_def,
                                                            std::string *error_msg) const {

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -28,6 +28,7 @@
 #include "buffer_validation.h"
 #include <sstream>
 #include <algorithm>
+#include <memory>
 
 struct BindingNumCmp {
     bool operator()(const VkDescriptorSetLayoutBinding *a, const VkDescriptorSetLayoutBinding *b) const {
@@ -37,14 +38,8 @@ struct BindingNumCmp {
 
 // Construct DescriptorSetLayout instance from given create info
 // Proactively reserve and resize as possible, as the reallocation was visible in profiling
-cvdescriptorset::DescriptorSetLayout::DescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo *p_create_info,
-                                                          const VkDescriptorSetLayout layout)
-    : layout_(layout),
-      layout_destroyed_(false),
-      flags_(p_create_info->flags),
-      binding_count_(0),
-      descriptor_count_(0),
-      dynamic_descriptor_count_(0) {
+cvdescriptorset::DescriptorSetLayoutDef::DescriptorSetLayoutDef(const VkDescriptorSetLayoutCreateInfo *p_create_info)
+    : flags_(p_create_info->flags), binding_count_(0), descriptor_count_(0), dynamic_descriptor_count_(0) {
     binding_type_stats_ = {0, 0, 0};
     std::set<const VkDescriptorSetLayoutBinding *, BindingNumCmp> sorted_bindings;
     const uint32_t input_bindings_count = p_create_info->bindingCount;
@@ -106,6 +101,206 @@ cvdescriptorset::DescriptorSetLayout::DescriptorSetLayout(const VkDescriptorSetL
     }
 }
 
+// Return valid index or "end" i.e. binding_count_;
+// The asserts in "Get" are reduced to the set where no valid answer(like null or 0) could be given
+// Common code for all binding lookups.
+uint32_t cvdescriptorset::DescriptorSetLayoutDef::GetIndexFromBinding(uint32_t binding) const {
+    const auto &bi_itr = binding_to_index_map_.find(binding);
+    if (bi_itr != binding_to_index_map_.cend()) return bi_itr->second;
+    return GetBindingCount();
+}
+VkDescriptorSetLayoutBinding const *cvdescriptorset::DescriptorSetLayoutDef::GetDescriptorSetLayoutBindingPtrFromIndex(
+    const uint32_t index) const {
+    if (index >= bindings_.size()) return nullptr;
+    return bindings_[index].ptr();
+}
+// Return descriptorCount for given index, 0 if index is unavailable
+uint32_t cvdescriptorset::DescriptorSetLayoutDef::GetDescriptorCountFromIndex(const uint32_t index) const {
+    if (index >= bindings_.size()) return 0;
+    return bindings_[index].descriptorCount;
+}
+// For the given index, return descriptorType
+VkDescriptorType cvdescriptorset::DescriptorSetLayoutDef::GetTypeFromIndex(const uint32_t index) const {
+    assert(index < bindings_.size());
+    if (index < bindings_.size()) return bindings_[index].descriptorType;
+    return VK_DESCRIPTOR_TYPE_MAX_ENUM;
+}
+// For the given index, return stageFlags
+VkShaderStageFlags cvdescriptorset::DescriptorSetLayoutDef::GetStageFlagsFromIndex(const uint32_t index) const {
+    assert(index < bindings_.size());
+    if (index < bindings_.size()) return bindings_[index].stageFlags;
+    return VkShaderStageFlags(0);
+}
+
+// For the given global index, return index
+uint32_t cvdescriptorset::DescriptorSetLayoutDef::GetIndexFromGlobalIndex(const uint32_t global_index) const {
+    auto start_it = global_start_to_index_map_.upper_bound(global_index);
+    uint32_t index = binding_count_;
+    assert(start_it != global_start_to_index_map_.cbegin());
+    if (start_it != global_start_to_index_map_.cbegin()) {
+        --start_it;
+        index = start_it->second;
+#ifndef NDEBUG
+        const auto &range = GetGlobalIndexRangeFromBinding(bindings_[index].binding);
+        assert(range.start <= global_index && global_index < range.end);
+#endif
+    }
+    return index;
+}
+
+// For the given binding, return the global index range
+// As start and end are often needed in pairs, get both with a single hash lookup.
+const cvdescriptorset::IndexRange &cvdescriptorset::DescriptorSetLayoutDef::GetGlobalIndexRangeFromBinding(
+    const uint32_t binding) const {
+    assert(binding_to_global_index_range_map_.count(binding));
+    // In error case max uint32_t so index is out of bounds to break ASAP
+    const static IndexRange kInvalidRange = {0xFFFFFFFF, 0xFFFFFFFF};
+    const auto &range_it = binding_to_global_index_range_map_.find(binding);
+    if (range_it != binding_to_global_index_range_map_.end()) {
+        return range_it->second;
+    }
+    return kInvalidRange;
+}
+
+// For given binding, return ptr to ImmutableSampler array
+VkSampler const *cvdescriptorset::DescriptorSetLayoutDef::GetImmutableSamplerPtrFromBinding(const uint32_t binding) const {
+    const auto &bi_itr = binding_to_index_map_.find(binding);
+    if (bi_itr != binding_to_index_map_.end()) {
+        return bindings_[bi_itr->second].pImmutableSamplers;
+    }
+    return nullptr;
+}
+// Move to next valid binding having a non-zero binding count
+uint32_t cvdescriptorset::DescriptorSetLayoutDef::GetNextValidBinding(const uint32_t binding) const {
+    auto it = non_empty_bindings_.upper_bound(binding);
+    assert(it != non_empty_bindings_.cend());
+    if (it != non_empty_bindings_.cend()) return *it;
+    return GetMaxBinding() + 1;
+}
+// For given index, return ptr to ImmutableSampler array
+VkSampler const *cvdescriptorset::DescriptorSetLayoutDef::GetImmutableSamplerPtrFromIndex(const uint32_t index) const {
+    if (index < bindings_.size()) {
+        return bindings_[index].pImmutableSamplers;
+    }
+    return nullptr;
+}
+// If our layout is compatible with rh_ds_layout, return true,
+//  else return false and fill in error_msg will description of what causes incompatibility
+bool cvdescriptorset::DescriptorSetLayout::IsCompatible(DescriptorSetLayout const *const rh_ds_layout,
+                                                        std::string *error_msg) const {
+    // Trivial case
+    if (layout_ == rh_ds_layout->GetDescriptorSetLayout()) return true;
+    return get_layout_def()->IsCompatible(layout_, rh_ds_layout->GetDescriptorSetLayout(), rh_ds_layout->get_layout_def(),
+                                          error_msg);
+}
+
+bool cvdescriptorset::DescriptorSetLayoutDef::IsCompatible(VkDescriptorSetLayout ds_layout, VkDescriptorSetLayout rh_ds_layout,
+                                                           DescriptorSetLayoutDef const *const rh_ds_layout_def,
+                                                           std::string *error_msg) const {
+    if (descriptor_count_ != rh_ds_layout_def->descriptor_count_) {
+        std::stringstream error_str;
+        error_str << "DescriptorSetLayout " << ds_layout << " has " << descriptor_count_ << " descriptors, but DescriptorSetLayout "
+                  << rh_ds_layout << ", which comes from pipelineLayout, has " << rh_ds_layout_def->descriptor_count_
+                  << " descriptors.";
+        *error_msg = error_str.str();
+        return false;  // trivial fail case
+    }
+    // Descriptor counts match so need to go through bindings one-by-one
+    //  and verify that type and stageFlags match
+    for (auto binding : bindings_) {
+        // TODO : Do we also need to check immutable samplers?
+        // VkDescriptorSetLayoutBinding *rh_binding;
+        if (binding.descriptorCount != rh_ds_layout_def->GetDescriptorCountFromBinding(binding.binding)) {
+            std::stringstream error_str;
+            error_str << "Binding " << binding.binding << " for DescriptorSetLayout " << ds_layout << " has a descriptorCount of "
+                      << binding.descriptorCount << " but binding " << binding.binding << " for DescriptorSetLayout "
+                      << rh_ds_layout << ", which comes from pipelineLayout, has a descriptorCount of "
+                      << rh_ds_layout_def->GetDescriptorCountFromBinding(binding.binding);
+            *error_msg = error_str.str();
+            return false;
+        } else if (binding.descriptorType != rh_ds_layout_def->GetTypeFromBinding(binding.binding)) {
+            std::stringstream error_str;
+            error_str << "Binding " << binding.binding << " for DescriptorSetLayout " << ds_layout << " is type '"
+                      << string_VkDescriptorType(binding.descriptorType) << "' but binding " << binding.binding
+                      << " for DescriptorSetLayout " << rh_ds_layout << ", which comes from pipelineLayout, is type '"
+                      << string_VkDescriptorType(rh_ds_layout_def->GetTypeFromBinding(binding.binding)) << "'";
+            *error_msg = error_str.str();
+            return false;
+        } else if (binding.stageFlags != rh_ds_layout_def->GetStageFlagsFromBinding(binding.binding)) {
+            std::stringstream error_str;
+            error_str << "Binding " << binding.binding << " for DescriptorSetLayout " << ds_layout << " has stageFlags "
+                      << binding.stageFlags << " but binding " << binding.binding << " for DescriptorSetLayout " << rh_ds_layout
+                      << ", which comes from pipelineLayout, has stageFlags "
+                      << rh_ds_layout_def->GetStageFlagsFromBinding(binding.binding);
+            *error_msg = error_str.str();
+            return false;
+        }
+    }
+    return true;
+}
+
+bool cvdescriptorset::DescriptorSetLayoutDef::IsNextBindingConsistent(const uint32_t binding) const {
+    if (!binding_to_index_map_.count(binding + 1)) return false;
+    auto const &bi_itr = binding_to_index_map_.find(binding);
+    if (bi_itr != binding_to_index_map_.end()) {
+        const auto &next_bi_itr = binding_to_index_map_.find(binding + 1);
+        if (next_bi_itr != binding_to_index_map_.end()) {
+            auto type = bindings_[bi_itr->second].descriptorType;
+            auto stage_flags = bindings_[bi_itr->second].stageFlags;
+            auto immut_samp = bindings_[bi_itr->second].pImmutableSamplers ? true : false;
+            if ((type != bindings_[next_bi_itr->second].descriptorType) ||
+                (stage_flags != bindings_[next_bi_itr->second].stageFlags) ||
+                (immut_samp != (bindings_[next_bi_itr->second].pImmutableSamplers ? true : false))) {
+                return false;
+            }
+            return true;
+        }
+    }
+    return false;
+}
+// Starting at offset descriptor of given binding, parse over update_count
+//  descriptor updates and verify that for any binding boundaries that are crossed, the next binding(s) are all consistent
+//  Consistency means that their type, stage flags, and whether or not they use immutable samplers matches
+//  If so, return true. If not, fill in error_msg and return false
+bool cvdescriptorset::DescriptorSetLayoutDef::VerifyUpdateConsistency(uint32_t current_binding, uint32_t offset,
+                                                                      uint32_t update_count, const char *type,
+                                                                      const VkDescriptorSet set, std::string *error_msg) const {
+    // Verify consecutive bindings match (if needed)
+    auto orig_binding = current_binding;
+    // Track count of descriptors in the current_bindings that are remaining to be updated
+    auto binding_remaining = GetDescriptorCountFromBinding(current_binding);
+    // First, it's legal to offset beyond your own binding so handle that case
+    //  Really this is just searching for the binding in which the update begins and adjusting offset accordingly
+    while (offset >= binding_remaining) {
+        // Advance to next binding, decrement offset by binding size
+        offset -= binding_remaining;
+        binding_remaining = GetDescriptorCountFromBinding(++current_binding);
+    }
+    binding_remaining -= offset;
+    while (update_count > binding_remaining) {  // While our updates overstep current binding
+        // Verify next consecutive binding matches type, stage flags & immutable sampler use
+        if (!IsNextBindingConsistent(current_binding++)) {
+            std::stringstream error_str;
+            error_str << "Attempting " << type << " descriptor set " << set << " binding #" << orig_binding << " with #"
+                      << update_count
+                      << " descriptors being updated but this update oversteps the bounds of this binding and the next binding is "
+                         "not consistent with current binding so this update is invalid.";
+            *error_msg = error_str.str();
+            return false;
+        }
+        // For sake of this check consider the bindings updated and grab count for next binding
+        update_count -= binding_remaining;
+        binding_remaining = GetDescriptorCountFromBinding(current_binding);
+    }
+    return true;
+}
+
+// The DescriptorSetLayout stores the per handle data for a descriptor set layout, and references the common defintion for the
+// handle invariant portion
+cvdescriptorset::DescriptorSetLayout::DescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo *p_create_info,
+                                                          const VkDescriptorSetLayout layout)
+    : layout_(layout), layout_destroyed_(false), layout_id_(std::make_shared<DescriptorSetLayoutDef>(p_create_info)) {}
+
 // Validate descriptor set layout create info
 bool cvdescriptorset::DescriptorSetLayout::ValidateCreateInfo(const debug_report_data *report_data,
                                                               const VkDescriptorSetLayoutCreateInfo *create_info,
@@ -156,194 +351,6 @@ bool cvdescriptorset::DescriptorSetLayout::ValidateCreateInfo(const debug_report
     }
 
     return skip;
-}
-
-// Return valid index or "end" i.e. binding_count_;
-// The asserts in "Get" are reduced to the set where no valid answer(like null or 0) could be given
-// Common code for all binding lookups.
-uint32_t cvdescriptorset::DescriptorSetLayout::GetIndexFromBinding(uint32_t binding) const {
-    const auto &bi_itr = binding_to_index_map_.find(binding);
-    if (bi_itr != binding_to_index_map_.cend()) return bi_itr->second;
-    return GetBindingCount();
-}
-VkDescriptorSetLayoutBinding const *cvdescriptorset::DescriptorSetLayout::GetDescriptorSetLayoutBindingPtrFromIndex(
-    const uint32_t index) const {
-    if (index >= bindings_.size()) return nullptr;
-    return bindings_[index].ptr();
-}
-// Return descriptorCount for given index, 0 if index is unavailable
-uint32_t cvdescriptorset::DescriptorSetLayout::GetDescriptorCountFromIndex(const uint32_t index) const {
-    if (index >= bindings_.size()) return 0;
-    return bindings_[index].descriptorCount;
-}
-// For the given index, return descriptorType
-VkDescriptorType cvdescriptorset::DescriptorSetLayout::GetTypeFromIndex(const uint32_t index) const {
-    assert(index < bindings_.size());
-    if (index < bindings_.size()) return bindings_[index].descriptorType;
-    return VK_DESCRIPTOR_TYPE_MAX_ENUM;
-}
-// For the given index, return stageFlags
-VkShaderStageFlags cvdescriptorset::DescriptorSetLayout::GetStageFlagsFromIndex(const uint32_t index) const {
-    assert(index < bindings_.size());
-    if (index < bindings_.size()) return bindings_[index].stageFlags;
-    return VkShaderStageFlags(0);
-}
-
-// For the given global index, return index
-uint32_t cvdescriptorset::DescriptorSetLayout::GetIndexFromGlobalIndex(const uint32_t global_index) const {
-    auto start_it = global_start_to_index_map_.upper_bound(global_index);
-    uint32_t index = binding_count_;
-    assert(start_it != global_start_to_index_map_.cbegin());
-    if (start_it != global_start_to_index_map_.cbegin()) {
-        --start_it;
-        index = start_it->second;
-#ifndef NDEBUG
-        const auto &range = GetGlobalIndexRangeFromBinding(bindings_[index].binding);
-        assert(range.start <= global_index && global_index < range.end);
-#endif
-    }
-    return index;
-}
-
-// For the given binding, return the global index range
-// As start and end are often needed in pairs, get both with a single hash lookup.
-const cvdescriptorset::IndexRange &cvdescriptorset::DescriptorSetLayout::GetGlobalIndexRangeFromBinding(
-    const uint32_t binding) const {
-    assert(binding_to_global_index_range_map_.count(binding));
-    // In error case max uint32_t so index is out of bounds to break ASAP
-    const static IndexRange kInvalidRange = {0xFFFFFFFF, 0xFFFFFFFF};
-    const auto &range_it = binding_to_global_index_range_map_.find(binding);
-    if (range_it != binding_to_global_index_range_map_.end()) {
-        return range_it->second;
-    }
-    return kInvalidRange;
-}
-
-// For given binding, return ptr to ImmutableSampler array
-VkSampler const *cvdescriptorset::DescriptorSetLayout::GetImmutableSamplerPtrFromBinding(const uint32_t binding) const {
-    const auto &bi_itr = binding_to_index_map_.find(binding);
-    if (bi_itr != binding_to_index_map_.end()) {
-        return bindings_[bi_itr->second].pImmutableSamplers;
-    }
-    return nullptr;
-}
-// Move to next valid binding having a non-zero binding count
-uint32_t cvdescriptorset::DescriptorSetLayout::GetNextValidBinding(const uint32_t binding) const {
-    auto it = non_empty_bindings_.upper_bound(binding);
-    assert(it != non_empty_bindings_.cend());
-    if (it != non_empty_bindings_.cend()) return *it;
-    return GetMaxBinding() + 1;
-}
-// For given index, return ptr to ImmutableSampler array
-VkSampler const *cvdescriptorset::DescriptorSetLayout::GetImmutableSamplerPtrFromIndex(const uint32_t index) const {
-    if (index < bindings_.size()) {
-        return bindings_[index].pImmutableSamplers;
-    }
-    return nullptr;
-}
-// If our layout is compatible with rh_ds_layout, return true,
-//  else return false and fill in error_msg will description of what causes incompatibility
-bool cvdescriptorset::DescriptorSetLayout::IsCompatible(DescriptorSetLayout const *const rh_ds_layout,
-                                                        std::string *error_msg) const {
-    // Trivial case
-    if (layout_ == rh_ds_layout->GetDescriptorSetLayout()) return true;
-    if (descriptor_count_ != rh_ds_layout->descriptor_count_) {
-        std::stringstream error_str;
-        error_str << "DescriptorSetLayout " << layout_ << " has " << descriptor_count_ << " descriptors, but DescriptorSetLayout "
-                  << rh_ds_layout->GetDescriptorSetLayout() << ", which comes from pipelineLayout, has "
-                  << rh_ds_layout->descriptor_count_ << " descriptors.";
-        *error_msg = error_str.str();
-        return false;  // trivial fail case
-    }
-    // Descriptor counts match so need to go through bindings one-by-one
-    //  and verify that type and stageFlags match
-    for (auto binding : bindings_) {
-        // TODO : Do we also need to check immutable samplers?
-        // VkDescriptorSetLayoutBinding *rh_binding;
-        if (binding.descriptorCount != rh_ds_layout->GetDescriptorCountFromBinding(binding.binding)) {
-            std::stringstream error_str;
-            error_str << "Binding " << binding.binding << " for DescriptorSetLayout " << layout_ << " has a descriptorCount of "
-                      << binding.descriptorCount << " but binding " << binding.binding << " for DescriptorSetLayout "
-                      << rh_ds_layout->GetDescriptorSetLayout() << ", which comes from pipelineLayout, has a descriptorCount of "
-                      << rh_ds_layout->GetDescriptorCountFromBinding(binding.binding);
-            *error_msg = error_str.str();
-            return false;
-        } else if (binding.descriptorType != rh_ds_layout->GetTypeFromBinding(binding.binding)) {
-            std::stringstream error_str;
-            error_str << "Binding " << binding.binding << " for DescriptorSetLayout " << layout_ << " is type '"
-                      << string_VkDescriptorType(binding.descriptorType) << "' but binding " << binding.binding
-                      << " for DescriptorSetLayout " << rh_ds_layout->GetDescriptorSetLayout()
-                      << ", which comes from pipelineLayout, is type '"
-                      << string_VkDescriptorType(rh_ds_layout->GetTypeFromBinding(binding.binding)) << "'";
-            *error_msg = error_str.str();
-            return false;
-        } else if (binding.stageFlags != rh_ds_layout->GetStageFlagsFromBinding(binding.binding)) {
-            std::stringstream error_str;
-            error_str << "Binding " << binding.binding << " for DescriptorSetLayout " << layout_ << " has stageFlags "
-                      << binding.stageFlags << " but binding " << binding.binding << " for DescriptorSetLayout "
-                      << rh_ds_layout->GetDescriptorSetLayout() << ", which comes from pipelineLayout, has stageFlags "
-                      << rh_ds_layout->GetStageFlagsFromBinding(binding.binding);
-            *error_msg = error_str.str();
-            return false;
-        }
-    }
-    return true;
-}
-
-bool cvdescriptorset::DescriptorSetLayout::IsNextBindingConsistent(const uint32_t binding) const {
-    if (!binding_to_index_map_.count(binding + 1)) return false;
-    auto const &bi_itr = binding_to_index_map_.find(binding);
-    if (bi_itr != binding_to_index_map_.end()) {
-        const auto &next_bi_itr = binding_to_index_map_.find(binding + 1);
-        if (next_bi_itr != binding_to_index_map_.end()) {
-            auto type = bindings_[bi_itr->second].descriptorType;
-            auto stage_flags = bindings_[bi_itr->second].stageFlags;
-            auto immut_samp = bindings_[bi_itr->second].pImmutableSamplers ? true : false;
-            if ((type != bindings_[next_bi_itr->second].descriptorType) ||
-                (stage_flags != bindings_[next_bi_itr->second].stageFlags) ||
-                (immut_samp != (bindings_[next_bi_itr->second].pImmutableSamplers ? true : false))) {
-                return false;
-            }
-            return true;
-        }
-    }
-    return false;
-}
-// Starting at offset descriptor of given binding, parse over update_count
-//  descriptor updates and verify that for any binding boundaries that are crossed, the next binding(s) are all consistent
-//  Consistency means that their type, stage flags, and whether or not they use immutable samplers matches
-//  If so, return true. If not, fill in error_msg and return false
-bool cvdescriptorset::DescriptorSetLayout::VerifyUpdateConsistency(uint32_t current_binding, uint32_t offset, uint32_t update_count,
-                                                                   const char *type, const VkDescriptorSet set,
-                                                                   std::string *error_msg) const {
-    // Verify consecutive bindings match (if needed)
-    auto orig_binding = current_binding;
-    // Track count of descriptors in the current_bindings that are remaining to be updated
-    auto binding_remaining = GetDescriptorCountFromBinding(current_binding);
-    // First, it's legal to offset beyond your own binding so handle that case
-    //  Really this is just searching for the binding in which the update begins and adjusting offset accordingly
-    while (offset >= binding_remaining) {
-        // Advance to next binding, decrement offset by binding size
-        offset -= binding_remaining;
-        binding_remaining = GetDescriptorCountFromBinding(++current_binding);
-    }
-    binding_remaining -= offset;
-    while (update_count > binding_remaining) {  // While our updates overstep current binding
-        // Verify next consecutive binding matches type, stage flags & immutable sampler use
-        if (!IsNextBindingConsistent(current_binding++)) {
-            std::stringstream error_str;
-            error_str << "Attempting " << type << " descriptor set " << set << " binding #" << orig_binding << " with #"
-                      << update_count
-                      << " descriptors being updated but this update oversteps the bounds of this binding and the next binding is "
-                         "not consistent with current binding so this update is invalid.";
-            *error_msg = error_str.str();
-            return false;
-        }
-        // For sake of this check consider the bindings updated and grab count for next binding
-        update_count -= binding_remaining;
-        binding_remaining = GetDescriptorCountFromBinding(current_binding);
-    }
-    return true;
 }
 
 cvdescriptorset::AllocateDescriptorSetsData::AllocateDescriptorSetsData(uint32_t count)

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -103,8 +103,8 @@ class DescriptorSetLayoutDef {
     const std::set<uint32_t> &GetSortedBindingSet() const { return non_empty_bindings_; }
     // Return true if given binding is present in this layout
     bool HasBinding(const uint32_t binding) const { return binding_to_index_map_.count(binding) > 0; };
-    // Return true if this layout is compatible with passed in layout from a pipelineLayout,
-    //   else return false and update error_msg with description of incompatibility
+    // Return true if this DSL Def (referenced by the 1st layout) is compatible with another DSL Def (ref'd from the 2nd layout)
+    // else return false and update error_msg with description of incompatibility
     bool IsCompatible(VkDescriptorSetLayout, VkDescriptorSetLayout, DescriptorSetLayoutDef const *const, std::string *) const;
     // Return true if binding 1 beyond given exists and has same type, stageFlags & immutable sampler use
     bool IsNextBindingConsistent(const uint32_t) const;
@@ -161,7 +161,8 @@ class DescriptorSetLayoutDef {
     const BindingTypeStats &GetBindingTypeStats() const { return binding_type_stats_; }
 
    private:
-    // Only the first two are needed for hash and equality checks, the other fields are derivative them uniquely
+    // Only the first two data members are used for hash and equality checks, the other members are derived from them, and are used
+    // to speed up the various lookups/queries/validations
     VkDescriptorSetLayoutCreateFlags flags_;
     std::vector<safe_VkDescriptorSetLayoutBinding> bindings_;
 

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -24,6 +24,7 @@
 #include "core_validation_error_enums.h"
 #include "vk_validation_error_messages.h"
 #include "core_validation_types.h"
+#include "hash_vk_types.h"
 #include "vk_layer_logging.h"
 #include "vk_layer_utils.h"
 #include "vk_safe_struct.h"
@@ -172,6 +173,10 @@ class DescriptorSetLayoutDef {
     uint32_t dynamic_descriptor_count_;
     BindingTypeStats binding_type_stats_;
 };
+
+static bool operator==(const DescriptorSetLayoutDef &lhs, const DescriptorSetLayoutDef &rhs) {
+    return (lhs.GetCreateFlags() == rhs.GetCreateFlags()) && (lhs.GetBindings() == rhs.GetBindings());
+}
 
 using DescriptorSetLayoutId = std::shared_ptr<DescriptorSetLayoutDef>;
 

--- a/layers/hash_util.h
+++ b/layers/hash_util.h
@@ -1,0 +1,114 @@
+/* Copyright (c) 2015-2016 The Khronos Group Inc.
+ * Copyright (c) 2015-2016 Valve Corporation
+ * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (C) 2015-2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: John Zulauf <jzulauf@lunarg.com>
+ */
+#ifndef HASH_UTIL_H_
+#define HASH_UTIL_H_
+
+#define NOMINMAX
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+// Hash and equality utilities for supporting hashing containers (e.g. unordered_set, unordered_map)
+namespace hash_util {
+
+// True iff both pointers are null or both are non-null
+template <typename T>
+bool similar_for_nullity(const T *const lhs, const T *const rhs) {
+    return ((lhs != nullptr) && (rhs != nullptr)) || ((lhs == nullptr) && (rhs == nullptr));
+}
+
+// Wrap std hash to avoid manual casts for the holes in std::hash (in C++11)
+template <typename Value>
+size_t HashWithUnderlying(Value value, typename std::enable_if<!std::is_enum<Value>::value, void *>::type = nullptr) {
+    return std::hash<Value>()(value);
+}
+
+template <typename Value>
+size_t HashWithUnderlying(Value value, typename std::enable_if<std::is_enum<Value>::value, void *>::type = nullptr) {
+    using Underlying = typename std::underlying_type<Value>::type;
+    return std::hash<Underlying>()(static_cast<const Underlying &>(value));
+}
+
+class HashCombiner {
+   public:
+    using Key = size_t;
+
+    template <typename Value>
+    struct WrappedHash {
+        size_t operator()(const Value &value) const { return HashWithUnderlying(value); }
+    };
+
+    HashCombiner(Key combined = 0) : combined_(combined) {}
+    // magic and combination algorithm based on boost::hash_combine
+    // http://www.boost.org/doc/libs/1_43_0/doc/html/hash/reference.html#boost.hash_combine
+    // Magic value is 2^size / ((1-sqrt(5)/2)
+    static const uint64_t kMagic = sizeof(Key) > 4 ? Key(0x9e3779b97f4a7c16UL) : Key(0x9e3779b9U);
+
+    // If you need to override the default hash
+    template <typename Value, typename Hasher = WrappedHash<Value>>
+    HashCombiner &Combine(const Value &value) {
+        combined_ ^= Hasher()(value) + kMagic + (combined_ << 6) + (combined_ >> 2);
+        return *this;
+    }
+
+    template <typename Iterator, typename Hasher = WrappedHash<typename std::iterator_traits<Iterator>::value_type>>
+    HashCombiner &Combine(Iterator first, Iterator end) {
+        using Value = typename std::iterator_traits<Iterator>::value_type;
+        auto current = first;
+        for (; current != end; ++current) {
+            Combine<Value, Hasher>(*current);
+        }
+        return *this;
+    }
+
+    template <typename Value, typename Hasher = WrappedHash<Value>>
+    HashCombiner &Combine(const std::vector<Value> &vector) {
+        return Combine(vector.cbegin(), vector.cend());
+    }
+
+    template <typename Value>
+    HashCombiner &operator<<(const Value &value) {
+        return Combine(value);
+    }
+
+    Key Value() const { return combined_; }
+    void Reset(Key combined = 0) { combined_ = combined; }
+
+   private:
+    Key combined_;
+};
+
+// A template to inherit std::hash overloads from when T::hash() is defined
+template <typename T>
+struct HasHashMember {
+    size_t operator()(const T &value) const { return value.hash(); }
+};
+
+// A template to inherit std::hash overloads from when is an *ordered* constainer
+template <typename T>
+struct IsOrderedContainer {
+    size_t operator()(const T &value) const { return HashCombiner().Combine(value.cbegin(), value.cend()).Value(); }
+};
+
+}  // namespace hash_util
+
+#endif  // HASH_UTILS_H_

--- a/layers/hash_vk_types.h
+++ b/layers/hash_vk_types.h
@@ -24,6 +24,7 @@
 
 #include <vulkan/vulkan.h>
 #include "vk_safe_struct.h"
+#include <vector>
 
 // Hash and equality and/or compare functions for selected Vk types (and useful collections thereof)
 
@@ -58,6 +59,28 @@ struct hash<safe_VkDescriptorSetLayoutBinding> {
         return hc.Value();
     }
 };
+}  // namespace std
+
+// VkPushConstantRange
+static bool operator==(const VkPushConstantRange &lhs, const VkPushConstantRange &rhs) {
+    return (lhs.stageFlags == rhs.stageFlags) && (lhs.offset == rhs.offset) && (lhs.size == rhs.size);
+}
+
+namespace std {
+template <>
+struct hash<VkPushConstantRange> {
+    size_t operator()(const VkPushConstantRange &value) const {
+        hash_util::HashCombiner hc;
+        return (hc << value.stageFlags << value.offset << value.size).Value();
+    }
+};
+}  // namespace std
+
+using PushConstantRanges = std::vector<VkPushConstantRange>;
+
+namespace std {
+template <>
+struct hash<PushConstantRanges> : public hash_util::IsOrderedContainer<PushConstantRanges> {};
 }  // namespace std
 
 #endif  // HASH_VK_TYPES_H_

--- a/layers/hash_vk_types.h
+++ b/layers/hash_vk_types.h
@@ -1,0 +1,63 @@
+/* Copyright (c) 2018 The Khronos Group Inc.
+ * Copyright (c) 2018 Valve Corporation
+ * Copyright (c) 2018 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: John Zulauf <jzulauf@lunarg.com>
+ */
+#ifndef HASH_VK_TYPES_H_
+#define HASH_VK_TYPES_H_
+
+// Includes everything needed for overloading std::hash
+#include "hash_util.h"
+
+#include <vulkan/vulkan.h>
+#include "vk_safe_struct.h"
+
+// Hash and equality and/or compare functions for selected Vk types (and useful collections thereof)
+
+// VkDescriptorSetLayoutBinding
+static bool operator==(const safe_VkDescriptorSetLayoutBinding &lhs, const safe_VkDescriptorSetLayoutBinding &rhs) {
+    if ((lhs.binding != rhs.binding) || (lhs.descriptorType != rhs.descriptorType) ||
+        (lhs.descriptorCount != rhs.descriptorCount) || (lhs.stageFlags != rhs.stageFlags) ||
+        !hash_util::similar_for_nullity(lhs.pImmutableSamplers, rhs.pImmutableSamplers)) {
+        return false;
+    }
+    if (lhs.pImmutableSamplers) {  // either one will do as they *are* similar for nullity (i.e. either both null or both non-null)
+        for (uint32_t samp = 0; samp < lhs.descriptorCount; samp++) {
+            if (lhs.pImmutableSamplers[samp] != rhs.pImmutableSamplers[samp]) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+namespace std {
+template <>
+struct hash<safe_VkDescriptorSetLayoutBinding> {
+    size_t operator()(const safe_VkDescriptorSetLayoutBinding &value) const {
+        hash_util::HashCombiner hc;
+        hc << value.binding << value.descriptorType << value.descriptorCount << value.stageFlags;
+        if (value.pImmutableSamplers) {
+            for (uint32_t samp = 0; samp < value.descriptorCount; samp++) {
+                hc << value.pImmutableSamplers[samp];
+            }
+        }
+        return hc.Value();
+    }
+};
+}  // namespace std
+
+#endif  // HASH_VK_TYPES_H_

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -1329,7 +1329,7 @@ static bool validate_pipeline_shader_stage(layer_data *dev_data, VkPipelineShade
     auto descriptor_uses = collect_interface_by_descriptor_slot(report_data, module, accessible_ids);
 
     skip |= validate_specialization_offsets(report_data, pStage);
-    skip |= validate_push_constant_usage(report_data, &pipeline->pipeline_layout.push_constant_ranges, module, accessible_ids,
+    skip |= validate_push_constant_usage(report_data, pipeline->pipeline_layout.push_constant_ranges.get(), module, accessible_ids,
                                          pStage->stage);
 
     // Validate descriptor use


### PR DESCRIPTION
Fixes #2214 .  Upgrades the pipeline layout compatibility and recording to (IIAC) match the compatibility text of of the spec.  Push constant and 1-N comparisons for compatibility are added for each set in the current layout.  Set update/disturb logic is now shared with push descriptors. 

As compatibility validation is deep nests (for each Set N { foreach set 1 through N } {for each set { for each binding in set }, where the inner three loops are comparing invariant quantities, the compatibility check has been reduced to a comparison of unique ID's which integrate each inner loop in  "canonical" definitions stored in dictionaries.  The dictionaries share a common container type and used the standard overload mechanism for std::equal_to and std::hash.

Specific layer state data (where appropriate) has been segregated into handle-specific and non-handle specific storage. Where possible, comparisons of unique ID's are used for "trivial accept" validation.