### PR TITLE
Fix 2408: record 3D image-slice layouts as subresources

### DIFF
--- a/layers/buffer_validation.h
+++ b/layers/buffer_validation.h
@@ -85,8 +85,8 @@ bool FindLayouts(layer_data *device_data, VkImage image, std::vector<VkImageLayo
 bool FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imageLayoutMap, ImageSubresourcePair imgpair,
                 VkImageLayout &layout, const VkImageAspectFlags aspectMask);
 
-bool FindLayout(const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imageLayoutMap, ImageSubresourcePair imgpair,
-                VkImageLayout &layout);
+bool FindLayout(layer_data *device_data, const std::unordered_map<ImageSubresourcePair, IMAGE_LAYOUT_NODE> &imageLayoutMap,
+                ImageSubresourcePair imgpair, VkImageLayout &layout);
 
 void SetGlobalLayout(layer_data *device_data, ImageSubresourcePair imgpair, const VkImageLayout &layout);
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -2815,6 +2815,7 @@ static void PostCallRecordQueueSubmit(layer_data *dev_data, VkQueue queue, uint3
                 cbs.push_back(submit->pCommandBuffers[i]);
                 for (auto secondaryCmdBuffer : cb_node->linkedCommandBuffers) {
                     cbs.push_back(secondaryCmdBuffer->commandBuffer);
+                    UpdateCmdBufImageLayouts(dev_data, secondaryCmdBuffer);
                 }
                 UpdateCmdBufImageLayouts(dev_data, cb_node);
                 incrementResources(dev_data, cb_node);


### PR DESCRIPTION
Fixes a bug in image layout state handling that appeared with
khr_maintenance1. When a 3D image which was created with the
VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR flag is transitioned
between layouts, we now also record a transition for each depth
slice, treating it as an array layer subresource.

The actual fix is just two lines within TransitionImageLayouts().
Also included are some debug-enabling refactoring to distinguish
layout state updates vs additions, and support for new aspect
mask bits.

Fixes #2408 
Fixes #2210 
Fixes #1650 

Change-Id: Ibb5131a6dba8fcdeafe5e6d94af2decf751842ec