### PR TITLE
Modify .gitattributes for unix line endings on shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,16 +1,16 @@
 # See https://git-scm.com/docs/gitattributes
 # See https://help.github.com/articles/dealing-with-line-endings/
 
-# default behavior, if core.autocrlf is unset.
+# Default behavior, if core.autocrlf is unset.
 * text=auto
 
-# files to be converted to native line endings on checkout.
+# Files to be converted to native line endings on checkout.
 *.cpp text
 *.h text
 
-# files to always have CRLF line endings on checkout.
+# Text files to always have CRLF (dos) line endings on checkout.
 *.bat text eol=crlf
 
-# files to always have CR line endings on checkout.
-*.sh text eol=cr
+# Text files to always have LF (unix) line endings on checkout.
+*.sh text eol=lf
 


### PR DESCRIPTION
Git settings caused shell scripts to get converted to carriage-return line endings -- changed this to a line feed line ending (which lets the scripts run in Cygwin shells on Windows).