### PR TITLE
Build fails on Linux/x32 due to 32-bit pointers but 64-bit registers.

### DIFF
--- a/layers/threading.h
+++ b/layers/threading.h
@@ -26,7 +26,7 @@
 #include "vk_layer_config.h"
 #include "vk_layer_logging.h"
 
-#if defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) || defined(__ia64) || defined(_M_IA64) || \
+#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || defined(_M_IA64) || \
     defined(__aarch64__) || defined(__powerpc64__)
 // If pointers are 64-bit, then there can be separate counters for each
 // NONDISPATCHABLE_HANDLE type.  Otherwise they are all typedef uint64_t.


### PR DESCRIPTION
On Linux/x32 systems, it's not enough to test for __x86_64__.
Pointers are 32-bit, as represented by __ILP32__, so it must be
tested as well.