### PR TITLE
Fix Superfluous and Erroneous inttypes.h Includes

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -22,7 +22,6 @@
 // Allow use of STL min and max functions in Windows
 #define NOMINMAX
 
-#include <inttypes.h>
 #include <sstream>
 #include <string>
 

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -51,7 +51,6 @@
 #include <string.h>
 #include <string>
 #include <valarray>
-#include <inttypes.h>
 
 #include "vk_loader_platform.h"
 #include "vk_dispatch_table_helper.h"

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -25,7 +25,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
The files that explicitly include <inttypes.h> are C++ files. The
convention for including C header files in C++ programs is to use a
special C++ header file that wraps the C header file. For example
<inttypes.h> would be included as <cinttypes>.

In vk_layer_logging.h:34 <cinttypes> is included.

In buffer_validation.cpp and parameter_validation_utils.cpp
"vk_layer_logging.h" is directly included.

In core_validation.cpp "vk_layer_logging.h" is indirectly included via
core_validation.h

This change removes the invalid and superfluous use of C header files from the
aforementioned C++ files.

Reviewed-by: dkoch
Reviewed-by: ddadap