### PR TITLE
layers: Fix command buffer allocation ABA bug (issue #2517)

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4519,9 +4519,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(VkDevice device, VkCommandPool com
     unique_lock_t lock(global_lock);
     bool skip = PreCallValidateDestroyCommandPool(dev_data, commandPool);
     if (!skip) {
-        if (commandPool != VK_NULL_HANDLE) {
-            PreCallRecordDestroyCommandPool(dev_data, commandPool);
-        }
+        PreCallRecordDestroyCommandPool(dev_data, commandPool);
         lock.unlock();
         dev_data->dispatch_table.DestroyCommandPool(device, commandPool, pAllocator);
     }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4355,16 +4355,18 @@ static bool PreCallValidateDestroyDescriptorPool(layer_data *dev_data, VkDescrip
     return skip;
 }
 
-static void PostCallRecordDestroyDescriptorPool(layer_data *dev_data, VkDescriptorPool descriptorPool,
-                                                DESCRIPTOR_POOL_STATE *desc_pool_state, VK_OBJECT obj_struct) {
-    // Any bound cmd buffers are now invalid
-    invalidateCommandBuffers(dev_data, desc_pool_state->cb_bindings, obj_struct);
-    // Free sets that were in this pool
-    for (auto ds : desc_pool_state->sets) {
-        freeDescriptorSet(dev_data, ds);
+static void PreCallRecordDestroyDescriptorPool(layer_data *dev_data, VkDescriptorPool descriptorPool,
+                                               DESCRIPTOR_POOL_STATE *desc_pool_state, VK_OBJECT obj_struct) {
+    if (desc_pool_state) {
+        // Any bound cmd buffers are now invalid
+        invalidateCommandBuffers(dev_data, desc_pool_state->cb_bindings, obj_struct);
+        // Free sets that were in this pool
+        for (auto ds : desc_pool_state->sets) {
+            freeDescriptorSet(dev_data, ds);
+        }
+        dev_data->descriptorPoolMap.erase(descriptorPool);
+        delete desc_pool_state;
     }
-    dev_data->descriptorPoolMap.erase(descriptorPool);
-    delete desc_pool_state;
 }
 
 VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
@@ -4375,14 +4377,12 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(VkDevice device, VkDescriptorPo
     unique_lock_t lock(global_lock);
     bool skip = PreCallValidateDestroyDescriptorPool(dev_data, descriptorPool, &desc_pool_state, &obj_struct);
     if (!skip) {
+        PreCallRecordDestroyDescriptorPool(dev_data, descriptorPool, desc_pool_state, obj_struct);
         lock.unlock();
         dev_data->dispatch_table.DestroyDescriptorPool(device, descriptorPool, pAllocator);
-        lock.lock();
-        if (descriptorPool != VK_NULL_HANDLE) {
-            PostCallRecordDestroyDescriptorPool(dev_data, descriptorPool, desc_pool_state, obj_struct);
-        }
     }
 }
+
 // Verify cmdBuffer in given cb_node is not in global in-flight set, and return skip result
 //  If this is a secondary command buffer, then make sure its primary is also in-flight
 //  If primary is not in-flight, then remove secondary from global in-flight set

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -4501,7 +4501,7 @@ static bool PreCallValidateDestroyCommandPool(layer_data *dev_data, VkCommandPoo
     return skip;
 }
 
-static void PostCallRecordDestroyCommandPool(layer_data *dev_data, VkCommandPool pool) {
+static void PreCallRecordDestroyCommandPool(layer_data *dev_data, VkCommandPool pool) {
     COMMAND_POOL_NODE *cp_state = GetCommandPoolNode(dev_data, pool);
     // Remove cmdpool from cmdpoolmap, after freeing layer data for the command buffers
     // "When a pool is destroyed, all command buffers allocated from the pool are freed."
@@ -4519,12 +4519,11 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(VkDevice device, VkCommandPool com
     unique_lock_t lock(global_lock);
     bool skip = PreCallValidateDestroyCommandPool(dev_data, commandPool);
     if (!skip) {
+        if (commandPool != VK_NULL_HANDLE) {
+            PreCallRecordDestroyCommandPool(dev_data, commandPool);
+        }
         lock.unlock();
         dev_data->dispatch_table.DestroyCommandPool(device, commandPool, pAllocator);
-        lock.lock();
-        if (commandPool != VK_NULL_HANDLE) {
-            PostCallRecordDestroyCommandPool(dev_data, commandPool);
-        }
     }
 }
 


### PR DESCRIPTION
In core validation layer's DestroyCommandPool API entry function, the
ext layer's API call is executed outside of the lock, and before the
command pool's command buffers are erased from the layer's command
buffer map. That means that between next layer's call and the time the
lock is regained, any other thread can allocate other command buffers.
In particular, it may reuse the memory freed the command, and then the
core validation layer will not insert a new entry in the command buffer
map. So after the lock in regained and the command pool's command
buffers are erased from the map, leaving those allocated with no state,
leading to either crashes or assertions later on. The fix is to move the
release of command buffers before releasing the lock the first, before
calling the next layer's function, such that they will be removed from
the map before any other thread might reuse those addresses.