### PR TITLE
layers: Correct non-dispatchable type handling

### DIFF
--- a/layers/threading.h
+++ b/layers/threading.h
@@ -26,11 +26,20 @@
 #include "vk_layer_config.h"
 #include "vk_layer_logging.h"
 
-#if defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) || defined(__ia64) || defined(_M_IA64) || \
-    defined(__aarch64__) || defined(__powerpc64__)
+VK_DEFINE_NON_DISPATCHABLE_HANDLE(DISTINCT_NONDISPATCHABLE_PHONY_HANDLE)
+// The following line must match the vulkan_core.h condition guarding VK_DEFINE_NON_DISPATCHABLE_HANDLE
+#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
+    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
 // If pointers are 64-bit, then there can be separate counters for each
 // NONDISPATCHABLE_HANDLE type.  Otherwise they are all typedef uint64_t.
 #define DISTINCT_NONDISPATCHABLE_HANDLES
+// Make sure we catch any disagreement between us and the vulkan definition
+static_assert(std::is_pointer<DISTINCT_NONDISPATCHABLE_PHONY_HANDLE>::value,
+              "Mismatched non-dispatchable handle handle, expected pointer type.");
+#else
+// Make sure we catch any disagreement between us and the vulkan definition
+static_assert(std::is_same<uint64_t, DISTINCT_NONDISPATCHABLE_PHONY_HANDLE>::value,
+              "Mismatched non-dispatchable handle handle, expected uint64_t.");
 #endif
 
 // Draw State ERROR codes


### PR DESCRIPTION
Update threading layer non-dispatchable type handling to reflect updates
to the vulkan header for Linux/x32 memory model support.  Includes new
static asserts to detect future mismatches.

This in response to [Pull Request 2484](https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/pull/2484) -- as the original poster does not have a signed CLA.  The updated #define logic is copied *not* from 2484, but from vulkan_core.h, and then clang formatted.

As I don't have access to x32 systems pinging the author of 2484.

Tagging @cnorthrop to ensure no Android issues. (e.g. does Android support Arm/ILP32 or do some other VK_DEFINE_NON_DISPATCHABLE_HANDLE magic that we'd need to be aware of?) 