### PR TITLE
Fix multi-plane aspect bit check

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -3147,6 +3147,18 @@ bool ValidateImageAspectMask(layer_data *device_data, VkImage image, VkFormat fo
                             HandleToUint64(image), VALIDATION_ERROR_0a400c01,
                             "%s: Stencil-only image formats can have only the VK_IMAGE_ASPECT_STENCIL_BIT set.", func_name);
         }
+    } else if (FormatIsMultiplane(format)) {
+        VkImageAspectFlags valid_flags = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT;
+        if (3 == FormatPlaneCount(format)) {
+            valid_flags = valid_flags | VK_IMAGE_ASPECT_PLANE_2_BIT;
+        }
+        if ((aspect_mask & valid_flags) != aspect_mask) {
+            skip |= log_msg(report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,
+                            HandleToUint64(image), VALIDATION_ERROR_0a400c01,
+                            "%s: Multi-plane image formats may have only VK_IMAGE_ASPECT_COLOR_BIT or VK_IMAGE_ASPECT_PLANE_n_BITs "
+                            "set, where n = [0, 1, 2].",
+                            func_name);
+        }
     }
     return skip;
 }

--- a/layers/vk_format_utils.h
+++ b/layers/vk_format_utils.h
@@ -119,10 +119,12 @@ VK_LAYER_EXPORT VkFormatCompatibilityClass FormatCompatibilityClass(VkFormat for
 VK_LAYER_EXPORT VkDeviceSize SafeModulo(VkDeviceSize dividend, VkDeviceSize divisor);
 
 static inline bool FormatIsUndef(VkFormat format) { return (format == VK_FORMAT_UNDEFINED); }
-static inline bool FormatIsColor(VkFormat format) { return !(FormatIsUndef(format) || FormatIsDepthOrStencil(format)); }
 static inline bool FormatHasDepth(VkFormat format) { return (FormatIsDepthOnly(format) || FormatIsDepthAndStencil(format)); }
 static inline bool FormatHasStencil(VkFormat format) { return (FormatIsStencilOnly(format) || FormatIsDepthAndStencil(format)); }
 static inline bool FormatIsMultiplane(VkFormat format) { return ((FormatPlaneCount(format)) > 1u); }
+static inline bool FormatIsColor(VkFormat format) {
+    return !(FormatIsUndef(format) || FormatIsDepthOrStencil(format) || FormatIsMultiplane(format));
+}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The FormatIsColor() util fxn classified anything not depth or stencil as 'color', and applied the aspect bit checks correspondingly. This PR segregates multi-plane formats from the catch-all color classification and adds multi-plane specific aspect bit checks for them.

Resolves #2527.
