### PR TITLE
Add some simple cube lighting

### DIFF
--- a/demos/cube.frag
+++ b/demos/cube.frag
@@ -24,7 +24,15 @@
 layout (binding = 1) uniform sampler2D tex;
 
 layout (location = 0) in vec4 texcoord;
+layout (location = 1) in vec3 frag_pos;
 layout (location = 0) out vec4 uFragColor;
+
+const vec3 lightDir= vec3(0.424, 0.566, 0.707);
+
 void main() {
-   uFragColor = texture(tex, texcoord.xy);
+   vec3 dX = dFdx(frag_pos);
+   vec3 dY = dFdy(frag_pos);
+   vec3 normal = normalize(cross(dX,dY));
+   float light = max(0.0, dot(lightDir, normal));
+   uFragColor = light * texture(tex, texcoord.xy);
 }

--- a/demos/cube.vert
+++ b/demos/cube.vert
@@ -28,9 +28,11 @@ layout(std140, binding = 0) uniform buf {
 } ubuf;
 
 layout (location = 0) out vec4 texcoord;
+layout (location = 1) out vec3 frag_pos;
 
 void main() 
 {
    texcoord = ubuf.attr[gl_VertexIndex];
    gl_Position = ubuf.MVP * ubuf.position[gl_VertexIndex];
+   frag_pos = gl_Position.xyz;
 }


### PR DESCRIPTION
This has been bugging me forever. Added some minimal n-dot-L screen-space lighting to the cube/cubepp samples' shaders.  glsl shader code changes only.

Unlit
![unlit](https://user-images.githubusercontent.com/23488040/38205896-959e2bac-3665-11e8-9cb2-bc478eebddd5.JPG)

n-dot-L Lighting
![lit](https://user-images.githubusercontent.com/23488040/38205899-980c0f12-3665-11e8-862a-24243b223cc6.JPG)

