### PR TITLE
Accept color aspect bit for multiplane image

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -433,7 +433,7 @@ void TransitionImageAspectLayout(layer_data *device_data, GLOBAL_CB_NODE *pCB, c
 
 bool VerifyAspectsPresent(VkImageAspectFlags aspect_mask, VkFormat format) {
     if ((aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) != 0) {
-        if (!FormatIsColor(format)) return false;
+        if (!(FormatIsColor(format) || FormatIsMultiplane(format))) return false;
     }
     if ((aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0) {
         if (!FormatHasDepth(format)) return false;


### PR DESCRIPTION
There is a case (memory barrier) where a multiplane image can have
the color aspect bit set, so the general aspect check should allow
it. In the common case where only VK_IMAGE_ASPECT_PLANE_n_BIT
bits are allowed, there are specific VUIDs in place to enforce.

This fixes an "unexpected error" result that recently appeared for
the CopyImageMultiplaneAspectBits test.

Change-Id: I766da2940955d8a7b72ec26e4dbefe9e60eb0b08