### PR TITLE
Add automated travis check for commit message format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,14 @@ dist: trusty
 sudo: required
 language: cpp
 
+# This line necessary for allow_failures operation
+env:
+
 matrix:
   # Show final status immediately if a test fails.
   fast_finish: true
+  allow_failures:
+    - env: CHECK_COMMIT_FORMAT=ON
   include:
     # Android build.
     - os: linux
@@ -27,6 +32,8 @@ matrix:
       env: VULKAN_BUILD_TARGET=LINUX
     # Check for proper clang formatting in the pull request.
     - env: CHECK_FORMAT=ON
+    # Check for proper commit message formatting for commits in PR
+    - env: CHECK_COMMIT_FORMAT=ON
 
 cache: ccache
 
@@ -119,6 +126,13 @@ script:
         ./scripts/check_code_format.sh
       else
         echo "Skipping clang-format check since this is not a pull request."
+      fi
+    fi
+  - |
+    if [[ "$CHECK_COMMIT_FORMAT" == "ON" ]]; then
+      if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+        echo "Checking commit message formats:  See CONTRIBUTING.md"
+        ./scripts/check_commit_message_format.sh
       fi
     fi
   - set +e

--- a/scripts/check_commit_message_format.sh
+++ b/scripts/check_commit_message_format.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Copyright (c) 2018 Valve Corporation
+# Copyright (c) 2018 LunarG, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Checks commit messages against project standards in CONTRIBUTING.md document
+# Script to determine if commit messages in Pull Request are properly formatted.
+# Exits with non 0 exit code if reformatting is needed.
+
+# Disable subshells
+shopt -s lastpipe
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# TRAVIS_COMMIT_RANGE contains range of commits for this PR
+
+# Get user-supplied commit message text for applicable commits and insert
+# a unique separator string identifier. The git command returns ONLY the
+# subject line and body for each of the commits.
+COMMIT_TEXT=$(git log ${TRAVIS_COMMIT_RANGE} --pretty=format:"XXXNEWLINEXXX"%n%B)
+
+# Bail if there are none
+if [ -z "${COMMIT_TEXT}" ]; then
+  echo -e "${GREEN}No source code to check for formatting.${NC}"
+  exit 0
+elif ! echo $TRAVIS_COMMIT_RANGE | grep -q "\.\.\."; then
+  echo -e "${GREEN}No source code to check for formatting.${NC}"
+  exit 0
+fi
+
+# Process commit messages
+success=1
+current_line=0
+prevline=""
+
+# Process each line of the commit message output, resetting counter on separator
+printf %s "$COMMIT_TEXT" | while IFS='' read -r line; do
+  # echo "Count = $current_line <Line> = $line"
+  current_line=$((current_line+1))
+  if [ "$line" = "XXXNEWLINEXXX" ]; then
+    current_line=0
+  fi
+  chars=${#line}
+  if [ $current_line -eq 1 ]; then
+    # Subject line should be 50 chars or less (but give some slack here)
+    if [ $chars -gt 54 ]; then
+      echo "The following subject line exceeds 50 characters in length."
+      echo "     '$line'"
+      success=0
+    fi
+    i=$(($chars-1))
+    last_char=${line:$i:1}
+    # Output error if last char of subject line is not alpha-numeric
+    if [[ ! $last_char =~ [0-9a-zA-Z] ]]; then
+      echo "For the following commit, the last character of the subject line must not be non-alphanumeric."
+      echo "     '$line'"
+      success=0
+    fi
+    # Checking if subject line doesn't start with 'module: '
+    prefix=$(echo $line | cut -f1 -d " ")
+    if [ "${prefix: -1}" != ":" ]; then
+      echo "The following subject line must start with a single word specifying the functional area of the change, followed by a colon and space. I.e., 'layers: Subject line here'"
+      echo "     '$line'"
+      success=0
+    fi
+  elif [ $current_line -eq 2 ]; then
+    # Commit message must have a blank line between subject and body
+    if [ $chars -ne 0 ]; then
+      echo "The following subject line must be followed by a blank line."
+      echo "     '$prevline'"
+      success=0
+    fi
+  else
+    # Lines in a commit message body must be less than 72 characters in length (but give some slack)
+    if [ $chars -gt 76 ]; then
+      echo "The following commit message body line exceeds the 72 character limit."
+      echo "'$line\'"
+      success=0
+    fi
+  fi
+  prevline=$line
+done
+
+if [ $success -eq 1 ]; then
+  echo -e "${GREEN}All commit messages in pull request are properly formatted.${NC}"
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
This change should check commit message formats against CONTRIBUTING.md.  PRs containing commit messages that don't follow the spec will fail the new test, but Travis is set up to allow these tests to fail -- this check is only run on PRs.  

Failing them should NOT result in a failed PR, though results can be checked by examining the Travis details for a submitted PR. For example on this PR, click on 'Show all checks' next to "All Checks Have Passed" below, then select "continuous-integration/travis-ci/pr — The Travis CI build passed ->Details".  
