### PR TITLE
Don't clobber immutable samplers in update

### DIFF
--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -1119,7 +1119,9 @@ bool cvdescriptorset::ValidateImageUpdate(VkImageView image_view, VkImageLayout 
 }
 
 void cvdescriptorset::SamplerDescriptor::WriteUpdate(const VkWriteDescriptorSet *update, const uint32_t index) {
-    sampler_ = update->pImageInfo[index].sampler;
+    if (!immutable_) {
+        sampler_ = update->pImageInfo[index].sampler;
+    }
     updated = true;
 }
 
@@ -1151,7 +1153,9 @@ cvdescriptorset::ImageSamplerDescriptor::ImageSamplerDescriptor(const VkSampler 
 void cvdescriptorset::ImageSamplerDescriptor::WriteUpdate(const VkWriteDescriptorSet *update, const uint32_t index) {
     updated = true;
     const auto &image_info = update->pImageInfo[index];
-    sampler_ = image_info.sampler;
+    if (!immutable_) {
+        sampler_ = image_info.sampler;
+    }
     image_view_ = image_info.imageView;
     image_layout_ = image_info.imageLayout;
 }


### PR DESCRIPTION
The copy cases were already doing the right thing; the basic updates
missed the check for the sampler being immutable.

Fixes #2569