### PR TITLE
loader: Send device dispatch table address to ICDs

### DIFF
--- a/include/vulkan/vk_layer.h
+++ b/include/vulkan/vk_layer.h
@@ -82,7 +82,8 @@ typedef VkResult(VKAPI_PTR *PFN_PhysDevExt)(VkPhysicalDevice phys_device);
  */
 typedef enum VkLayerFunction_ {
     VK_LAYER_LINK_INFO = 0,
-    VK_LOADER_DATA_CALLBACK = 1
+    VK_LOADER_DATA_CALLBACK = 1,
+    VK_LOADER_DATA_VALUE = 2
 } VkLayerFunction;
 
 typedef struct VkLayerInstanceLink_ {
@@ -131,6 +132,7 @@ typedef struct {
     union {
         VkLayerDeviceLink *pLayerInfo;
         PFN_vkSetDeviceLoaderData pfnSetDeviceLoaderData;
+        void* deviceLoaderData;
     } u;
 } VkLayerDeviceCreateInfo;
 

--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5563,6 +5563,14 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateDevice(VkPhysicalDevice physical
         dev->extensions.ext_debug_utils_enabled = icd_term->this_instance->enabled_known_extensions.ext_debug_utils;
     }
 
+    // Pass the future dispatch pointer to the ICD.
+    VkLayerDeviceCreateInfo deviceLoaderDataCreateInfo;
+    deviceLoaderDataCreateInfo.sType = VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO;
+    deviceLoaderDataCreateInfo.pNext = localCreateInfo.pNext;
+    deviceLoaderDataCreateInfo.function = VK_LOADER_DATA_VALUE;
+    deviceLoaderDataCreateInfo.u.deviceLoaderData = &dev->loader_dispatch;
+    localCreateInfo.pNext = &deviceLoaderDataCreateInfo;
+
     res = fpCreateDevice(phys_dev_term->phys_dev, &localCreateInfo, pAllocator, &dev->icd_device);
     if (res != VK_SUCCESS) {
         loader_log(icd_term->this_instance, VK_DEBUG_REPORT_ERROR_BIT_EXT, 0,


### PR DESCRIPTION
Send ICDs the device dispatch table address using
VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO. This is to support
implementations that need the handle to be in scope during the execution
of CreateDevice.

See issue #2578 