### PR TITLE
Tobin gh2587 2nd cb clear attach fix

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -2198,8 +2198,10 @@ bool PreCallValidateCmdClearAttachments(layer_data *device_data, VkCommandBuffer
                                         j);
                         }
                     } else {
+                        const auto local_rect =
+                            pRects[j].rect;  // local copy of rect captured by value below to preserve original contents
                         cb_node->cmd_execute_commands_functions.emplace_back([=](GLOBAL_CB_NODE *prim_cb, VkFramebuffer fb) {
-                            if (false == ContainsRect(prim_cb->activeRenderPassBeginInfo.renderArea, pRects[j].rect)) {
+                            if (false == ContainsRect(prim_cb->activeRenderPassBeginInfo.renderArea, local_rect)) {
                                 return log_msg(
                                     report_data, VK_DEBUG_REPORT_ERROR_BIT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,
                                     HandleToUint64(commandBuffer), VALIDATION_ERROR_18600020,

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -13584,14 +13584,16 @@ TEST_F(VkPositiveLayerTest, ConfirmNoVLErrorWhenVkCmdClearAttachmentsCalledInSec
     color_attachment.colorAttachment = 0;
     VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
     vkCmdClearAttachments(secondary.handle(), 1, &color_attachment, 1, &clear_rect);
-    m_errorMonitor->VerifyNotFound();
     secondary.end();
+    // Modify clear rect here to verify that it doesn't cause validation error
+    clear_rect = {{{0, 0}, {99999999, 99999999}}, 0, 0};
 
     m_commandBuffer->begin();
     vkCmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     vkCmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary.handle());
     vkCmdEndRenderPass(m_commandBuffer->handle());
     m_commandBuffer->end();
+    m_errorMonitor->VerifyNotFound();
 }
 
 TEST_F(VkLayerTest, CmdClearAttachmentTests) {


### PR DESCRIPTION
Fixes #2587 

Lambda needs to capture rect by value, not the ptr to VkClearRect, which may have its underlying rect changed.