### PR TITLE
loader: Fix a 1.0/1.1 versioning bug

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5177,6 +5177,8 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
         // If any error happens after here, we need to remove the ICD from the list,
         // because we've already added it, but haven't validated it
 
+        // Make sure that we reset the pApplicationInfo so we don't get an old pointer
+        icd_create_info.pApplicationInfo = pCreateInfo->pApplicationInfo;
         icd_create_info.enabledExtensionCount = 0;
         struct loader_extension_list icd_exts;
 


### PR DESCRIPTION
Fix a bug where when mixing a 1.0 and a 1.1 driver, if the loader
stores the 1.0 driver first, the apiVersion field in vkCreateInstance
will be rewritten to 1.0 for both drivers. Now it will only be
changed for the 1.0 driver, as intended.

Change-Id: I9e7c5e0b0b7c0eb660082319dcddd9e8ef8adc61