### PR TITLE
tests: Workaround crash in PSOPolygonModeValid

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -27803,7 +27803,7 @@ TEST_F(VkPositiveLayerTest, PSOPolygonModeValid) {
     rs_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
     rs_ci.pNext = nullptr;
     rs_ci.lineWidth = 1.0f;
-    rs_ci.rasterizerDiscardEnable = true;
+    rs_ci.rasterizerDiscardEnable = false;
 
     VkShaderObj vs(&test_device, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT, this);
     VkShaderObj fs(&test_device, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT, this);


### PR DESCRIPTION
This test has been crashing in some versions of Linux nvidia drivers.
Crash occurs in vkCreateGraphicsPipelines.

works: 375.27.14
fails: 387.42.03

This test sets rasterizerDiscardEnable to true as part of creating
a graphics pipeline. Setting it to false allows the test to pass.
The test also passes if no fragment shader is provided for the pipeline.

Several other tests set rasterizerDiscardEnable to true, but they
do not crash since they are negative tests and the call to
vkCreateGraphicsPipelines probably doesn't make it to the driver.

There's one other positive test that sets rasterizerDiscardEnable
to true, but it doesn't supply a fragment shader.

Since whether a crash occurs or not depends on the driver version
and because turning on discard isn't part of the test's goals, it
seems best to just turn off discard.

I've submitted a bug report to the vendor.

Change-Id: If1b3ee2db88ee5701bb731b96dcaa45d6bdcb287