### PR TITLE
layers: Track display and display mode objects

### DIFF
--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -1243,6 +1243,62 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2KHR(VkPhysical
     }
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(VkPhysicalDevice physicalDevice, uint32_t *pPropertyCount,
+                                                                     VkDisplayPropertiesKHR *pProperties) {
+    bool skip = false;
+    std::unique_lock<std::mutex> lock(global_lock);
+    skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, VALIDATION_ERROR_2b827a01,
+                           VALIDATION_ERROR_UNDEFINED);
+    lock.unlock();
+
+    if (skip) {
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+    VkResult result = get_dispatch_table(ot_instance_table_map, physicalDevice)
+                          ->GetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties);
+
+    lock.lock();
+    if (result == VK_SUCCESS) {
+        if (pProperties) {
+            for (uint32_t i = 0; i < *pPropertyCount; ++i) {
+                CreateObject(physicalDevice, pProperties[i].display, kVulkanObjectTypeDisplayKHR, nullptr);
+            }
+        }
+    }
+    lock.unlock();
+
+    return result;
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
+                                                           uint32_t *pPropertyCount, VkDisplayModePropertiesKHR *pProperties) {
+    bool skip = false;
+    std::unique_lock<std::mutex> lock(global_lock);
+    skip |= ValidateObject(physicalDevice, physicalDevice, kVulkanObjectTypePhysicalDevice, false, VALIDATION_ERROR_29827a01,
+                           VALIDATION_ERROR_UNDEFINED);
+    skip |= ValidateObject(physicalDevice, display, kVulkanObjectTypeDisplayKHR, false, VALIDATION_ERROR_29806001,
+                           VALIDATION_ERROR_UNDEFINED);
+    lock.unlock();
+
+    if (skip) {
+        return VK_ERROR_VALIDATION_FAILED_EXT;
+    }
+    VkResult result = get_dispatch_table(ot_instance_table_map, physicalDevice)
+                          ->GetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties);
+
+    lock.lock();
+    if (result == VK_SUCCESS) {
+        if (pProperties) {
+            for (uint32_t i = 0; i < *pPropertyCount; ++i) {
+                CreateObject(physicalDevice, pProperties[i].displayMode, kVulkanObjectTypeDisplayModeKHR, nullptr);
+            }
+        }
+    }
+    lock.unlock();
+
+    return result;
+}
+
 VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
     bool skip = VK_FALSE;
     std::unique_lock<std::mutex> lock(global_lock);

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -184,6 +184,8 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
             'vkCmdBeginDebugUtilsLabelEXT',
             'vkCmdEndDebugUtilsLabelEXT',
             'vkCmdInsertDebugUtilsLabelEXT',
+            'vkGetDisplayModePropertiesKHR',
+            'vkGetPhysicalDeviceDisplayPropertiesKHR',
             ]
         # These VUIDS are not implicit, but are best handled in this layer. Codegen for vkDestroy calls will generate a key
         # which is translated here into a good VU.  Saves ~40 checks.
@@ -650,7 +652,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         return object_list
     #
     # Construct list of extension structs containing handles, or extension structs that share a <validextensionstructs>
-    # tag WITH an extension struct containing handles. 
+    # tag WITH an extension struct containing handles.
     def GenerateCommandWrapExtensionList(self):
         for struct in self.structMembers:
             if (len(struct.members) > 1) and struct.members[1].extstructs is not None:


### PR DESCRIPTION
Resolves #2597.

Add VkDisplayKHR and VkDisplayModeKHR tracking to
VK_LAYER_LUNARG_object_tracker for vkGetPhysicalDeviceDisplayPropertiesKHR() and vkGetDisplayModePropertiesKHR().