### PR TITLE
tests: Clean up multiplane view format test

### DIFF
--- a/tests/device_profiles/geforce_940m.json
+++ b/tests/device_profiles/geforce_940m.json
@@ -394,6 +394,10 @@
             "specVersion": 1
         },
         {
+            "extensionName": "VK_KHR_get_physical_device_properties2",
+            "specVersion": 1
+        },
+        {
             "extensionName": "VK_KHR_image_format_list",
             "specVersion": 1
         },
@@ -1672,6 +1676,12 @@
             "linearTilingFeatures": 0,
             "optimalTilingFeatures": 0,
             "bufferFeatures": 0
+        },
+        {
+            "formatID": 1000156002,
+            "linearTilingFeatures": 0,
+            "optimalTilingFeatures": 1,
+            "bufferFeatures": 1
         }
     ]
 }

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -18831,38 +18831,13 @@ TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
         return;
     }
 
-    VkImage image;
-    ASSERT_VK_SUCCESS(vkCreateImage(device(), &ci, NULL, &image));
-
-    // Allocate & bind memory
-    VkPhysicalDeviceMemoryProperties phys_mem_props;
-    vkGetPhysicalDeviceMemoryProperties(gpu(), &phys_mem_props);
-    VkMemoryRequirements mem_reqs;
-    vkGetImageMemoryRequirements(device(), image, &mem_reqs);
-    VkDeviceMemory mem_obj = VK_NULL_HANDLE;
-    VkMemoryPropertyFlagBits mem_props = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-    for (uint32_t type = 0; type < phys_mem_props.memoryTypeCount; type++) {
-        if ((mem_reqs.memoryTypeBits & (1 << type)) &&
-            ((phys_mem_props.memoryTypes[type].propertyFlags & mem_props) == mem_props)) {
-            VkMemoryAllocateInfo alloc_info = {};
-            alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-            alloc_info.allocationSize = mem_reqs.size;
-            alloc_info.memoryTypeIndex = type;
-            ASSERT_VK_SUCCESS(vkAllocateMemory(device(), &alloc_info, NULL, &mem_obj));
-            break;
-        }
-    }
-
-    if (VK_NULL_HANDLE == mem_obj) {
-        printf("             Unable to allocate image memory. Skipping test.\n");
-        vkDestroyImage(device(), image, NULL);
-        return;
-    }
-    ASSERT_VK_SUCCESS(vkBindImageMemory(device(), image, mem_obj, 0));
+    VkImageObj image_obj(m_device);
+    image_obj.init(&ci);
+    ASSERT_TRUE(image_obj.initialized());
 
     VkImageViewCreateInfo ivci = {};
     ivci.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-    ivci.image = image;
+    ivci.image = image_obj.image();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_R8_SNORM;  // Compat is VK_FORMAT_R8_UNORM
     ivci.subresourceRange.layerCount = 1;
@@ -18893,10 +18868,6 @@ TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
     vkCreateImageView(m_device->device(), &ivci, NULL, &imageView);
     m_errorMonitor->VerifyNotFound();
     vkDestroyImageView(m_device->device(), imageView, NULL);  // VK_NULL_HANDLE allowed
-    imageView = VK_NULL_HANDLE;
-
-    vkFreeMemory(device(), mem_obj, NULL);
-    vkDestroyImage(m_device->device(), image, NULL);
 }
 
 TEST_F(VkLayerTest, CreateImageViewInvalidSubresourceRange) {


### PR DESCRIPTION
Simplified this test by using VkImageObj in place of direct vulkan
calls. Additionally added a fake multiplane image format to the geforce
940m device profile so that this repo would have a device profile that
doesn't skip this test.