### PR TITLE
headers: fix compilation error on android with vk_icd.h

### DIFF
--- a/include/vulkan/vk_icd.h
+++ b/include/vulkan/vk_icd.h
@@ -138,7 +138,7 @@ typedef struct {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 typedef struct {
     VkIcdSurfaceBase base;
-    ANativeWindow *window;
+    struct ANativeWindow *window;
 } VkIcdSurfaceAndroid;
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 


### PR DESCRIPTION
Change allow us to refer to ANativeWindow from C code, fixes following
compilation error seen with clang 3.8.27580 (Android O prebuilts).

vk_icd.h:116:5: error: must use 'struct' tag to refer to type 'ANativeWindow'

Signed-off-by: Tapani Pälli <tapani.palli@intel.com>